### PR TITLE
Upgrade to @authik/nextjs 0.0.9 to fix logout, update GraphCDN

### DIFF
--- a/graphcdn.yml
+++ b/graphcdn.yml
@@ -1,6 +1,6 @@
 schema: './src/graphql/typeDefs/index.ts'
 scopes:
-  AUTHENTICATED: 'cookie:appSession'
+  AUTHENTICATED: 'cookie:authik_session_token'
 rootTypeNames:
   query: Query
   mutation: Mutation

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@apollo/client": "^3.5.7",
     "@apollo/link-error": "^2.0.0-beta.3",
     "@apollo/link-schema": "^2.0.0-beta.3",
-    "@authik/nextjs": "0.0.8",
+    "@authik/nextjs": "0.0.9",
     "@graphql-tools/schema": "^8.3.1",
     "@headlessui/react": "^1.4.1",
     "@prisma/client": "^3.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,10 +91,10 @@
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-"@authik/nextjs@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@authik/nextjs/-/nextjs-0.0.8.tgz#d22965e4c323742682ba39c916bde42563a2a46a"
-  integrity sha512-rkUFq/Ip5aS3Dgfv1PqYNjckEY2h0K8EgpOiAnI6RjQnU5Z8Jvu3AdmP0NDlniU0MpRuRSSkCMfMz/fWLUr43g==
+"@authik/nextjs@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@authik/nextjs/-/nextjs-0.0.9.tgz#fc967b42d48ff4c659b4278f19478044e78d1ce5"
+  integrity sha512-Zm+ElcMpTdU4NtBn5ZNQ5LhWx7LzsJhKbWkzpu0ABca4pZZKFfQ/doDAVjHkaZavyPjYCuVcD8h+fwI8y/udmg==
   dependencies:
     axios "^0.25.0"
     cookie "^0.4.2"


### PR DESCRIPTION
`@authik/nextjs@0.0.8` had a bug where the client-side cookie would not be cleared on logout. This is fixed in 0.0.9.

Separately, we noticed an issue where GraphCDN was caching the result of the `viewer` query across users. We fix that by updating the cookie value that GraphCDN uses to detect if it is an authenticated query.