### PR TITLE
Remove broken analytics tracker script

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,11 +37,6 @@ export default function RootLayout({ children }: PropsWithChildren) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="theme-color" content="#fff" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="rgb(10, 10, 10)" media="(prefers-color-scheme: dark)" />
-        <script
-          defer
-          src="https://my-analytics-broken-fog-8153.fly.dev/tracker.js"
-          data-site-id="5de00909-54eb-48a0-bfa9-12e023184d22"
-        />
       </head>
       <body className={cn(inter.variable, ptSerif.variable)}>
         <Providers>


### PR DESCRIPTION
## Summary
Removed the analytics tracker script that was pointing to a non-functional endpoint.

## Changes
- Removed the analytics script tag from the root layout that was loading from `https://my-analytics-broken-fog-8153.fly.dev/tracker.js`
- This script was configured with site ID `5de00909-54eb-48a0-bfa9-12e023184d22`

## Details
The analytics service appears to be broken or no longer in use, so the script has been removed from the document head to eliminate unnecessary network requests and potential errors.

https://claude.ai/code/session_019rVUyNEK8nkKsJL64Dxvq1