### PR TITLE
Add persisted likes sorting to sites and stack

### DIFF
--- a/src/atoms/likesSortOrder.ts
+++ b/src/atoms/likesSortOrder.ts
@@ -1,0 +1,13 @@
+import { atomWithStorage } from "jotai/utils";
+
+export type LikesSortOrder = "none" | "desc" | "asc";
+
+export const sitesLikesSortOrderAtom = atomWithStorage<LikesSortOrder>(
+  "sites-likes-sort-order",
+  "none",
+);
+
+export const stackLikesSortOrderAtom = atomWithStorage<LikesSortOrder>(
+  "stack-likes-sort-order",
+  "none",
+);

--- a/src/components/good-websites/GoodWebsitesPageClient.tsx
+++ b/src/components/good-websites/GoodWebsitesPageClient.tsx
@@ -4,12 +4,14 @@ import { useAtom } from "jotai";
 import Image from "next/image";
 import { useMemo, useState, useSyncExternalStore } from "react";
 
+import { sitesLikesSortOrderAtom } from "@/atoms/likesSortOrder";
 import { sitesViewModeAtom } from "@/atoms/sitesViewMode";
 import { GoodWebsiteGalleryItem } from "@/components/good-websites/GoodWebsiteGalleryItem";
 import { GoodWebsitesFilters } from "@/components/good-websites/GoodWebsitesFilters";
 import { ViewToggle } from "@/components/good-websites/ViewToggle";
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
+import { LikesSortHeader } from "@/components/likes/LikesSortHeader";
 import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { LoadingSpinner, PreviewCardProvider, PreviewCardTrigger } from "@/components/ui";
 import type { GoodWebsiteItem } from "@/lib/goodWebsites";
@@ -33,10 +35,23 @@ const getServerSnapshot = () => false;
 export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsitesPageClientProps) {
   const { goodWebsites, isInitialLoading, isValidating, isError } = useGoodWebsites(initialData);
   const [viewMode, setViewMode] = useAtom(sitesViewModeAtom);
+  const [likesSortOrder, setLikesSortOrder] = useAtom(sitesLikesSortOrderAtom);
   const isHydrated = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   // Collect all page IDs for batch likes fetching
   const pageIds = useMemo(() => goodWebsites.map((item) => item.id), [goodWebsites]);
+  const sortedGoodWebsites = useMemo(() => {
+    if (likesSortOrder === "none") {
+      return goodWebsites;
+    }
+
+    return [...goodWebsites].sort((a, b) => {
+      const likesA = initialLikes?.[a.id]?.count ?? 0;
+      const likesB = initialLikes?.[b.id]?.count ?? 0;
+
+      return likesSortOrder === "desc" ? likesB - likesA : likesA - likesB;
+    });
+  }, [goodWebsites, initialLikes, likesSortOrder]);
 
   const topBarContent = useMemo(
     () => (
@@ -92,7 +107,20 @@ export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsit
                       <div className="col-span-7 text-left">Name</div>
                       <div className="col-span-3 text-left">Site</div>
                       <div className="col-span-1" />
-                      <div className="col-span-1" />
+                      <div className="col-span-1 text-left">
+                        <LikesSortHeader
+                          sortOrder={likesSortOrder}
+                          onToggle={() =>
+                            setLikesSortOrder((currentOrder) =>
+                              currentOrder === "none"
+                                ? "desc"
+                                : currentOrder === "desc"
+                                  ? "asc"
+                                  : "none",
+                            )
+                          }
+                        />
+                      </div>
                     </div>
                   </div>
 
@@ -100,7 +128,7 @@ export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsit
                   <div
                     className={`divide-secondary divide-y ${isValidating && !isInitialLoading ? "opacity-75 transition-opacity duration-200" : ""}`}
                   >
-                    {goodWebsites.map((item) => (
+                    {sortedGoodWebsites.map((item) => (
                       <GoodWebsiteItemComponent key={item.id} item={item} />
                     ))}
                   </div>
@@ -110,7 +138,7 @@ export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsit
                 <div
                   className={`bg-tertiary grid grid-cols-1 gap-0.5 p-0.5 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 dark:bg-transparent ${isValidating && !isInitialLoading ? "opacity-75 transition-opacity duration-200" : ""}`}
                 >
-                  {goodWebsites.map((item) => (
+                  {sortedGoodWebsites.map((item) => (
                     <GoodWebsiteGalleryItem key={item.id} item={item} />
                   ))}
                 </div>

--- a/src/components/likes/LikesSortHeader.tsx
+++ b/src/components/likes/LikesSortHeader.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { LikesSortOrder } from "@/atoms/likesSortOrder";
+import { ArrowDown } from "@/components/icons/ArrowDown";
+import { ArrowUp } from "@/components/icons/ArrowUp";
+import { cn } from "@/lib/utils";
+
+interface LikesSortHeaderProps {
+  sortOrder: LikesSortOrder;
+  onToggle: () => void;
+  className?: string;
+}
+
+export function LikesSortHeader({ sortOrder, onToggle, className }: LikesSortHeaderProps) {
+  const nextSortOrder = sortOrder === "none" ? "desc" : sortOrder === "desc" ? "asc" : "none";
+  const currentLabel =
+    sortOrder === "desc"
+      ? "most liked first"
+      : sortOrder === "asc"
+        ? "least liked first"
+        : "default order";
+  const nextLabel =
+    nextSortOrder === "desc"
+      ? "most liked first"
+      : nextSortOrder === "asc"
+        ? "least liked first"
+        : "default order";
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={cn(
+        "text-tertiary hover:text-primary inline-flex items-center gap-1 transition-colors",
+        sortOrder !== "none" && "text-primary",
+        className,
+      )}
+      aria-pressed={sortOrder !== "none"}
+      aria-label={`Sort by likes. Currently ${currentLabel}. Click to sort ${nextLabel}.`}
+      title={`Sort by likes (${nextLabel})`}
+    >
+      <span>Likes</span>
+      {sortOrder === "asc" ? (
+        <ArrowUp size={14} strokeWidth={2} className="text-secondary shrink-0" />
+      ) : null}
+      {sortOrder === "desc" ? (
+        <ArrowDown size={14} strokeWidth={2} className="text-secondary shrink-0" />
+      ) : null}
+    </button>
+  );
+}

--- a/src/components/stack/StackPageClient.tsx
+++ b/src/components/stack/StackPageClient.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useAtom } from "jotai";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 
+import { stackLikesSortOrderAtom } from "@/atoms/likesSortOrder";
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
+import { LikesSortHeader } from "@/components/likes/LikesSortHeader";
 import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { StackFilters } from "@/components/stack/StackFilters";
 import { LoadingSpinner, PreviewCardProvider, PreviewCardTrigger } from "@/components/ui";
@@ -21,10 +24,16 @@ interface StackPageClientProps {
   initialLikes?: Record<string, LikeData>;
 }
 
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 export function StackPageClient({ initialData, initialLikes }: StackPageClientProps) {
   const { stacks, isInitialLoading, isValidating, isError } = useStacks(initialData);
+  const [likesSortOrder, setLikesSortOrder] = useAtom(stackLikesSortOrderAtom);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const isHydrated = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   const handlePlatformFilter = (platform: string, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -35,6 +44,18 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
 
   // Collect all page IDs for batch likes fetching
   const pageIds = useMemo(() => stacks.map((item) => item.id), [stacks]);
+  const sortedStacks = useMemo(() => {
+    if (likesSortOrder === "none") {
+      return stacks;
+    }
+
+    return [...stacks].sort((a, b) => {
+      const likesA = initialLikes?.[a.id]?.count ?? 0;
+      const likesB = initialLikes?.[b.id]?.count ?? 0;
+
+      return likesSortOrder === "desc" ? likesB - likesA : likesA - likesB;
+    });
+  }, [stacks, initialLikes, likesSortOrder]);
 
   const topBarContent = useMemo(
     () => (
@@ -46,8 +67,7 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
   );
   useTopBarActions(topBarContent);
 
-  // Only show full page loading on initial load (without fallback data)
-  if (isInitialLoading && stacks.length === 0) {
+  if (!isHydrated || (isInitialLoading && stacks.length === 0)) {
     return (
       <ListDetailWrapper>
         <div className="flex h-full flex-1 items-center justify-center">
@@ -85,7 +105,20 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
                   <div className="col-span-3 text-left">Name</div>
                   <div className="col-span-5 text-left">Description</div>
                   <div className="col-span-3 text-left">Platforms</div>
-                  <div className="col-span-1 text-left">Likes</div>
+                  <div className="col-span-1 text-left">
+                    <LikesSortHeader
+                      sortOrder={likesSortOrder}
+                      onToggle={() =>
+                        setLikesSortOrder((currentOrder) =>
+                          currentOrder === "none"
+                            ? "desc"
+                            : currentOrder === "desc"
+                              ? "asc"
+                              : "none",
+                        )
+                      }
+                    />
+                  </div>
                 </div>
               </div>
 
@@ -93,7 +126,7 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
               <div
                 className={`divide-secondary divide-y ${isValidating && !isInitialLoading ? "opacity-75 transition-opacity duration-200" : ""}`}
               >
-                {stacks.map((item) => (
+                {sortedStacks.map((item) => (
                   <StackItemComponent
                     key={item.id}
                     item={item}


### PR DESCRIPTION
Adds a persisted likes sort preference to the /sites and /stack table views using Jotai storage. The likes header now cycles through default order, most liked, and least liked, and /sites keeps that ordering when switching between list and grid layouts. This also adds a shared LikesSortHeader component and a hydration guard on /stack so saved preferences do not cause a reorder flash on refresh. Verified with `bun run lint` (passes; only the existing baseline-browser-mapping warning remains).