### PR TITLE
Add rate limiting and ISR caching to HN routes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@sparticuz/chromium": "^143.0.4",
         "@tanstack/react-virtual": "^3.13.18",
         "@types/dompurify": "^3.2.0",
+        "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.36.3",
         "@vercel/og": "^0.11.1",
         "class-variance-authority": "^0.7.1",
@@ -628,6 +629,10 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@upstash/core-analytics": ["@upstash/core-analytics@0.0.10", "", { "dependencies": { "@upstash/redis": "^1.28.3" } }, "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ=="],
+
+    "@upstash/ratelimit": ["@upstash/ratelimit@2.0.8", "", { "dependencies": { "@upstash/core-analytics": "^0.0.10" }, "peerDependencies": { "@upstash/redis": "^1.34.3" } }, "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w=="],
 
     "@upstash/redis": ["@upstash/redis@1.36.3", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-wxo1ei4OHDHm4UGMgrNVz9QUEela9N/Iwi4p1JlHNSowQiPi+eljlGnfbZVkV0V4PIrjGtGFJt5GjWM5k28enA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@sparticuz/chromium": "^143.0.4",
     "@tanstack/react-virtual": "^3.13.18",
     "@types/dompurify": "^3.2.0",
+    "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.3",
     "@vercel/og": "^0.11.1",
     "class-variance-authority": "^0.7.1",

--- a/src/app/hn/[id]/page.tsx
+++ b/src/app/hn/[id]/page.tsx
@@ -6,7 +6,7 @@ import { stripHtmlTags } from "@/lib/utils";
 
 import HNPostPageClient from "./HNPostPageClient";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600; // ISR: serve cached HTML, regenerate hourly
 
 export async function generateMetadata(props: {
   params: Promise<{ id: string }>;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,124 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { NextRequest, NextResponse } from "next/server";
+
+// Lazy-initialize to avoid build-time env var errors
+let hnRatelimit: Ratelimit | null = null;
+let globalRatelimit: Ratelimit | null = null;
+
+function getHnRatelimit(): Ratelimit | null {
+  if (hnRatelimit) return hnRatelimit;
+  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) return null;
+
+  hnRatelimit = new Ratelimit({
+    redis: Redis.fromEnv(),
+    // 30 requests per 60 seconds per IP for HN routes
+    limiter: Ratelimit.slidingWindow(30, "60 s"),
+    prefix: "rl:hn",
+    analytics: true,
+  });
+  return hnRatelimit;
+}
+
+function getGlobalRatelimit(): Ratelimit | null {
+  if (globalRatelimit) return globalRatelimit;
+  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) return null;
+
+  globalRatelimit = new Ratelimit({
+    redis: Redis.fromEnv(),
+    // 60 requests per 60 seconds per IP globally
+    limiter: Ratelimit.slidingWindow(60, "60 s"),
+    prefix: "rl:global",
+    analytics: true,
+  });
+  return globalRatelimit;
+}
+
+function getIP(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const ip = getIP(request);
+
+  // Skip rate limiting for unknown IPs (shouldn't happen in production)
+  if (ip === "unknown") return NextResponse.next();
+
+  // HN routes: validate ID parameter and apply strict rate limit
+  if (pathname.startsWith("/hn") || pathname.startsWith("/api/hn")) {
+    // Validate /hn/[id] — reject non-numeric IDs early
+    const idMatch = pathname.match(/^\/(?:api\/)?hn\/(\d+)$/);
+    if (
+      pathname !== "/hn" &&
+      pathname !== "/api/hn" &&
+      !pathname.startsWith("/api/hn/s") &&
+      !idMatch
+    ) {
+      // Allow /api/hn/subscribe, /api/hn/unsubscribe, /api/hn/send, /api/hn/test
+      // but reject anything like /hn/garbage or /hn/../etc
+      if (!pathname.match(/^\/api\/hn\/(subscribe|unsubscribe|send|test)$/)) {
+        return NextResponse.json({ error: "Invalid HN post ID" }, { status: 400 });
+      }
+    }
+
+    const limiter = getHnRatelimit();
+    if (limiter) {
+      const { success, limit, remaining, reset } = await limiter.limit(ip);
+      if (!success) {
+        return NextResponse.json(
+          { error: "Too many requests" },
+          {
+            status: 429,
+            headers: {
+              "X-RateLimit-Limit": limit.toString(),
+              "X-RateLimit-Remaining": remaining.toString(),
+              "X-RateLimit-Reset": reset.toString(),
+              "Retry-After": Math.ceil((reset - Date.now()) / 1000).toString(),
+            },
+          },
+        );
+      }
+    }
+
+    return NextResponse.next();
+  }
+
+  // Global rate limit for all other API routes
+  if (pathname.startsWith("/api/")) {
+    const limiter = getGlobalRatelimit();
+    if (limiter) {
+      const { success, limit, remaining, reset } = await limiter.limit(ip);
+      if (!success) {
+        return NextResponse.json(
+          { error: "Too many requests" },
+          {
+            status: 429,
+            headers: {
+              "X-RateLimit-Limit": limit.toString(),
+              "X-RateLimit-Remaining": remaining.toString(),
+              "X-RateLimit-Reset": reset.toString(),
+              "Retry-After": Math.ceil((reset - Date.now()) / 1000).toString(),
+            },
+          },
+        );
+      }
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    // HN pages and API routes
+    "/hn/:path*",
+    "/api/hn/:path*",
+    // All other API routes
+    "/api/:path*",
+  ],
+};


### PR DESCRIPTION
## Summary

A scraper hammered `/hn/[id]` with hundreds of thousands of requests, costing ~\$20 in Vercel function invocations. This adds two layers of defense:

- **ISR on `/hn/[id]`**: replaces `force-dynamic` with `revalidate = 3600` so Vercel serves cached HTML from the CDN instead of invoking a function for every request.
- **Rate limiting middleware**: per-IP sliding-window limits via `@upstash/ratelimit` (30/min on `/hn` + `/api/hn`, 60/min on other `/api` routes), using the existing Upstash Redis. Returns 429 with `Retry-After` and rate-limit headers.
- **ID validation**: rejects non-numeric `/hn/[id]` paths with 400 at the edge before they reach any function.

## Test plan

- [ ] `bun run build` passes locally
- [ ] Visit `/hn` and a post page — pages load normally
- [ ] Hit `/api/hn/[id]` >30 times in 60s from one IP — returns 429 with `Retry-After`
- [ ] Visit `/hn/notanumber` — returns 400
- [ ] Verify `/api/hn/subscribe`, `/unsubscribe`, `/send`, `/test` still work