### PR TITLE
Enable ISR on dynamic routes via unstable_cache

### DIFF
--- a/src/app/ama/[id]/page.tsx
+++ b/src/app/ama/[id]/page.tsx
@@ -5,9 +5,7 @@ import { createMetadata, truncateDescription } from "@/lib/metadata";
 import { getAmaItemContent } from "@/lib/notion";
 
 export const revalidate = 86400;
-export const dynamicParams = true;
 
-// Empty array — defer all path generation to first request (lazy ISR).
 export function generateStaticParams(): { id: string }[] {
   return [];
 }

--- a/src/app/ama/[id]/page.tsx
+++ b/src/app/ama/[id]/page.tsx
@@ -4,7 +4,13 @@ import AMADetail from "@/app/ama/AMADetail";
 import { createMetadata, truncateDescription } from "@/lib/metadata";
 import { getAmaItemContent } from "@/lib/notion";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 86400;
+export const dynamicParams = true;
+
+// Empty array — defer all path generation to first request (lazy ISR).
+export function generateStaticParams(): { id: string }[] {
+  return [];
+}
 
 export async function generateMetadata(props: {
   params: Promise<{ id: string }>;

--- a/src/app/api/purge-cache/route.ts
+++ b/src/app/api/purge-cache/route.ts
@@ -7,35 +7,44 @@ import { invalidateNotionCache } from "@/lib/notion";
 const CONTENT_TYPES = ["writing", "til", "ama", "stack", "sites", "all"] as const;
 type ContentType = (typeof CONTENT_TYPES)[number];
 
-/** Redis key patterns, Next cache tags, and paths to revalidate per content type */
+/**
+ * Redis key patterns, Next cache tags, and paths to revalidate per content type.
+ * `pagePaths` holds dynamic-segment paths that require the "page" type arg to
+ * `revalidatePath` — without it, individual slug/id pages keep serving stale HTML.
+ */
 const PURGE_CONFIG: Record<
   Exclude<ContentType, "all">,
-  { patterns: string[]; tags: string[]; paths: string[] }
+  { patterns: string[]; tags: string[]; paths: string[]; pagePaths: string[] }
 > = {
   writing: {
     patterns: ["notion:writing:*"],
     tags: ["notion:writing"],
     paths: ["/writing", "/api/writing"],
+    pagePaths: ["/writing/[slug]"],
   },
   til: {
     patterns: ["notion:til:*"],
     tags: ["notion:til"],
     paths: ["/til", "/api/til"],
+    pagePaths: ["/til/[slug]"],
   },
   ama: {
     patterns: ["notion:ama:*"],
     tags: ["notion:ama"],
     paths: ["/ama", "/api/ama"],
+    pagePaths: ["/ama/[id]"],
   },
   stack: {
     patterns: ["notion:stack:*"],
     tags: ["notion:stack"],
     paths: ["/stack", "/api/stacks"],
+    pagePaths: [],
   },
   sites: {
     patterns: ["notion:good-websites:*"],
     tags: ["notion:good-websites"],
     paths: ["/sites", "/api/sites"],
+    pagePaths: [],
   },
 };
 
@@ -75,6 +84,9 @@ async function purgeCache(request: Request): Promise<NextResponse> {
 
     for (const path of config.paths) {
       revalidatePath(path);
+    }
+    for (const path of config.pagePaths) {
+      revalidatePath(path, "page");
     }
   }
 

--- a/src/app/api/purge-cache/route.ts
+++ b/src/app/api/purge-cache/route.ts
@@ -1,4 +1,4 @@
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { errorResponse } from "@/lib/api-utils";
@@ -7,26 +7,34 @@ import { invalidateNotionCache } from "@/lib/notion";
 const CONTENT_TYPES = ["writing", "til", "ama", "stack", "sites", "all"] as const;
 type ContentType = (typeof CONTENT_TYPES)[number];
 
-/** Redis key patterns and paths to revalidate per content type */
-const PURGE_CONFIG: Record<Exclude<ContentType, "all">, { patterns: string[]; paths: string[] }> = {
+/** Redis key patterns, Next cache tags, and paths to revalidate per content type */
+const PURGE_CONFIG: Record<
+  Exclude<ContentType, "all">,
+  { patterns: string[]; tags: string[]; paths: string[] }
+> = {
   writing: {
     patterns: ["notion:writing:*"],
+    tags: ["notion:writing"],
     paths: ["/writing", "/api/writing"],
   },
   til: {
     patterns: ["notion:til:*"],
+    tags: ["notion:til"],
     paths: ["/til", "/api/til"],
   },
   ama: {
     patterns: ["notion:ama:*"],
+    tags: ["notion:ama"],
     paths: ["/ama", "/api/ama"],
   },
   stack: {
     patterns: ["notion:stack:*"],
+    tags: ["notion:stack"],
     paths: ["/stack", "/api/stacks"],
   },
   sites: {
     patterns: ["notion:good-websites:*"],
+    tags: ["notion:good-websites"],
     paths: ["/sites", "/api/sites"],
   },
 };
@@ -56,6 +64,14 @@ async function purgeCache(request: Request): Promise<NextResponse> {
       deleted += await invalidateNotionCache(pattern);
     }
     results[t] = deleted;
+
+    // Invalidate the Next.js data cache layer alongside the Upstash layer.
+    // Next 16 requires a cacheLife profile as the second arg; "max" gives
+    // stale-while-revalidate behavior (serve existing cached data while
+    // regenerating in the background).
+    for (const tag of config.tags) {
+      revalidateTag(tag, "max");
+    }
 
     for (const path of config.paths) {
       revalidatePath(path);

--- a/src/app/app-dissection/[slug]/page.tsx
+++ b/src/app/app-dissection/[slug]/page.tsx
@@ -8,9 +8,7 @@ import { extractPreviewText } from "@/lib/notion/types";
 import { AppDissectionDetail } from "./components/AppDissectionDetail";
 
 export const revalidate = 3600;
-export const dynamicParams = true;
 
-// Empty array — defer all path generation to first request (lazy ISR).
 export function generateStaticParams(): { slug: string }[] {
   return [];
 }

--- a/src/app/app-dissection/[slug]/page.tsx
+++ b/src/app/app-dissection/[slug]/page.tsx
@@ -7,7 +7,13 @@ import { extractPreviewText } from "@/lib/notion/types";
 
 import { AppDissectionDetail } from "./components/AppDissectionDetail";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
+export const dynamicParams = true;
+
+// Empty array — defer all path generation to first request (lazy ISR).
+export function generateStaticParams(): { slug: string }[] {
+  return [];
+}
 
 export async function generateMetadata(props: {
   params: Promise<{ slug: string }>;

--- a/src/app/hn/[id]/page.tsx
+++ b/src/app/hn/[id]/page.tsx
@@ -6,12 +6,8 @@ import { stripHtmlTags } from "@/lib/utils";
 
 import HNPostPageClient from "./HNPostPageClient";
 
-export const revalidate = 3600; // ISR: serve cached HTML, regenerate hourly
-export const dynamicParams = true;
+export const revalidate = 3600;
 
-// Return empty array — no paths prerendered at build time.
-// Combined with `dynamicParams = true`, first request to any id triggers ISR
-// generation; subsequent requests within the revalidate window serve from cache.
 export function generateStaticParams(): { id: string }[] {
   return [];
 }

--- a/src/app/hn/[id]/page.tsx
+++ b/src/app/hn/[id]/page.tsx
@@ -7,6 +7,14 @@ import { stripHtmlTags } from "@/lib/utils";
 import HNPostPageClient from "./HNPostPageClient";
 
 export const revalidate = 3600; // ISR: serve cached HTML, regenerate hourly
+export const dynamicParams = true;
+
+// Return empty array — no paths prerendered at build time.
+// Combined with `dynamicParams = true`, first request to any id triggers ISR
+// generation; subsequent requests within the revalidate window serve from cache.
+export function generateStaticParams(): { id: string }[] {
+  return [];
+}
 
 export async function generateMetadata(props: {
   params: Promise<{ id: string }>;

--- a/src/app/til/[slug]/page.tsx
+++ b/src/app/til/[slug]/page.tsx
@@ -11,9 +11,7 @@ import { getTilByShortId } from "@/lib/notion";
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 
 export const revalidate = 3600;
-export const dynamicParams = true;
 
-// Empty array — defer all path generation to first request (lazy ISR).
 export function generateStaticParams(): { slug: string }[] {
   return [];
 }

--- a/src/app/til/[slug]/page.tsx
+++ b/src/app/til/[slug]/page.tsx
@@ -10,7 +10,13 @@ import { createArticleJsonLd, createMetadata, truncateDescription } from "@/lib/
 import { getTilByShortId } from "@/lib/notion";
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
+export const dynamicParams = true;
+
+// Empty array — defer all path generation to first request (lazy ISR).
+export function generateStaticParams(): { slug: string }[] {
+  return [];
+}
 
 // Generate metadata for each TIL entry
 export async function generateMetadata(props: {

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -13,7 +13,13 @@ import { getWritingPostByShortId, getWritingPostContentBySlug } from "@/lib/noti
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 import { getAllWritingPosts } from "@/lib/writing";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
+export const dynamicParams = true;
+
+// Empty array — defer all path generation to first request (lazy ISR).
+export function generateStaticParams(): { slug: string }[] {
+  return [];
+}
 
 // Generate metadata for each writing post
 export async function generateMetadata(props: {

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -14,9 +14,7 @@ import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 import { getAllWritingPosts } from "@/lib/writing";
 
 export const revalidate = 3600;
-export const dynamicParams = true;
 
-// Empty array — defer all path generation to first request (lazy ISR).
 export function generateStaticParams(): { slug: string }[] {
   return [];
 }

--- a/src/lib/hn.ts
+++ b/src/lib/hn.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 import { externalFetcher } from "@/lib/fetcher";
@@ -11,6 +12,9 @@ import {
 } from "@/lib/hn-cache";
 import { HackerNewsComment, HackerNewsPost } from "@/types/hackernews";
 
+/** Default revalidation for HN data (matches Redis cache TTL). */
+const HN_REVALIDATE = 3600;
+
 const BASE_URL = "https://brianlovin.com";
 const TOP_BASE_URL = "https://hacker-news.firebaseio.com/v0";
 const ITEM_BASE_URL = "https://api.hnpwa.com/v0";
@@ -22,8 +26,7 @@ const log = (...args: unknown[]) => {
   }
 };
 
-export async function getPostIds(): Promise<number[]> {
-  // Try Redis cache first
+const fetchPostIds = async (): Promise<number[]> => {
   try {
     const cachedIds = await getCachedTopIds();
     if (cachedIds) {
@@ -40,7 +43,12 @@ export async function getPostIds(): Promise<number[]> {
   setCachedTopIds(ids).catch(() => {});
 
   return ids;
-}
+};
+
+export const getPostIds = unstable_cache(fetchPostIds, ["hn:post-ids"], {
+  revalidate: HN_REVALIDATE,
+  tags: ["hn:post-ids"],
+});
 
 // Helper to trim comments to reduce payload size
 function trimComments(comment: HackerNewsComment): HackerNewsComment | null {
@@ -134,9 +142,8 @@ async function getBatchPosts(
   return results;
 }
 
-// Wrapped with React cache() for request-level deduplication during SSR
-export const getPostById = cache(
-  async (id: string, includeComments = false): Promise<HackerNewsPost | null> => {
+const fetchPostById = unstable_cache(
+  async (id: string, includeComments: boolean): Promise<HackerNewsPost | null> => {
     // Try Redis cache first
     const cached = await getCachedPost(id);
     if (cached) {
@@ -154,93 +161,116 @@ export const getPostById = cache(
 
     return processPost(data, includeComments);
   },
+  ["hn:post"],
+  { revalidate: HN_REVALIDATE, tags: ["hn:post"] },
 );
 
-export async function getHNPosts(): Promise<(HackerNewsPost | null)[]> {
-  const topPostIds = await getPostIds();
-  const ids = topPostIds.slice(0, 24).map((id) => id.toString());
-  const posts = await getBatchPosts(ids, false);
-  return posts.filter(Boolean);
-}
+// Wrapped with React cache() for request-level deduplication during SSR.
+// The inner unstable_cache persists across requests, so Server Components
+// rendering with these posts can be ISR'd instead of bailed to dynamic.
+export const getPostById = cache(
+  async (id: string, includeComments = false): Promise<HackerNewsPost | null> => {
+    return fetchPostById(id, includeComments);
+  },
+);
 
-export async function getRankedHNPosts(): Promise<HackerNewsPost[]> {
-  const topPostIds = await getPostIds();
+export const getHNPosts = unstable_cache(
+  async (): Promise<(HackerNewsPost | null)[]> => {
+    const topPostIds = await fetchPostIds();
+    const ids = topPostIds.slice(0, 24).map((id) => id.toString());
+    const posts = await getBatchPosts(ids, false);
+    return posts.filter(Boolean);
+  },
+  ["hn:list"],
+  { revalidate: HN_REVALIDATE, tags: ["hn:list"] },
+);
 
-  // Fetch 200 most recent posts
-  const filtered = topPostIds.sort((a: number, b: number) => b - a).slice(0, 200);
-  const ids = filtered.map((id) => id.toString());
-  const posts = await getBatchPosts(ids, false);
+export const getRankedHNPosts = unstable_cache(
+  async (): Promise<HackerNewsPost[]> => {
+    const topPostIds = await fetchPostIds();
 
-  const now = new Date().getTime() / 1000;
-  const oneDayAgo = now - 60 * 60 * 24;
+    // Fetch 200 most recent posts
+    const filtered = topPostIds.sort((a: number, b: number) => b - a).slice(0, 200);
+    const ids = filtered.map((id) => id.toString());
+    const posts = await getBatchPosts(ids, false);
 
-  // Filter out null posts
-  const validPosts = posts.filter((post): post is HackerNewsPost => post !== null);
+    const now = new Date().getTime() / 1000;
+    const oneDayAgo = now - 60 * 60 * 24;
 
-  // Only show links (exclude jobs, polls)
-  const links = validPosts.filter((post) => post.type === "link");
+    // Filter out null posts
+    const validPosts = posts.filter((post): post is HackerNewsPost => post !== null);
 
-  // Only show posts from last 24 hours
-  const withinLastDay = links.filter((post) => post.time > oneDayAgo);
+    // Only show links (exclude jobs, polls)
+    const links = validPosts.filter((post) => post.type === "link");
 
-  // Filter by minimum engagement (50+ points OR 20+ comments)
-  const highEngagement = withinLastDay.filter(
-    (post) => (post.points || 0) >= 50 || post.comments_count >= 20,
-  );
+    // Only show posts from last 24 hours
+    const withinLastDay = links.filter((post) => post.time > oneDayAgo);
 
-  // Sort by weighted score: points + (comments * 0.75) + recency bonus
-  const sorted = highEngagement.sort((a, b) => {
-    const hoursOldA = (now - a.time) / 3600;
-    const hoursOldB = (now - b.time) / 3600;
+    // Filter by minimum engagement (50+ points OR 20+ comments)
+    const highEngagement = withinLastDay.filter(
+      (post) => (post.points || 0) >= 50 || post.comments_count >= 20,
+    );
 
-    // Recency bonus: newer posts get higher scores (decays from 100 to 0 over 24 hours)
-    const recencyBonusA = Math.max(0, 100 * (1 - hoursOldA / 24));
-    const recencyBonusB = Math.max(0, 100 * (1 - hoursOldB / 24));
+    // Sort by weighted score: points + (comments * 0.75) + recency bonus
+    const sorted = highEngagement.sort((a, b) => {
+      const hoursOldA = (now - a.time) / 3600;
+      const hoursOldB = (now - b.time) / 3600;
 
-    const scoreA = (a.points || 0) + a.comments_count * 0.75 + recencyBonusA;
-    const scoreB = (b.points || 0) + b.comments_count * 0.75 + recencyBonusB;
+      // Recency bonus: newer posts get higher scores (decays from 100 to 0 over 24 hours)
+      const recencyBonusA = Math.max(0, 100 * (1 - hoursOldA / 24));
+      const recencyBonusB = Math.max(0, 100 * (1 - hoursOldB / 24));
 
-    return scoreB - scoreA;
-  });
+      const scoreA = (a.points || 0) + a.comments_count * 0.75 + recencyBonusA;
+      const scoreB = (b.points || 0) + b.comments_count * 0.75 + recencyBonusB;
 
-  const top24 = sorted.slice(0, 24);
+      return scoreB - scoreA;
+    });
 
-  log(`[HN Filtered] Returning top ${top24.length} posts by weighted score`);
+    const top24 = sorted.slice(0, 24);
 
-  return top24;
-}
+    log(`[HN Filtered] Returning top ${top24.length} posts by weighted score`);
 
-export async function getHNPostsForDigest(): Promise<HackerNewsPost[]> {
-  const topPostIds = await getPostIds();
-  log(`[HN Digest] Starting with ${topPostIds.length} total story IDs`);
+    return top24;
+  },
+  ["hn:ranked"],
+  { revalidate: HN_REVALIDATE, tags: ["hn:ranked"] },
+);
 
-  // topPostIds returns 500 by default. this can block the API route from
-  // responding for a long time while each one is fetched individually.
-  // it's much more likely that the most recent 200 (by decrementing id) are
-  // the top posts within the last 24 hours
-  const filtered = topPostIds.sort((a: number, b: number) => b - a).slice(0, 200);
-  log(`[HN Digest] Filtered to top 200 most recent IDs`);
+export const getHNPostsForDigest = unstable_cache(
+  async (): Promise<HackerNewsPost[]> => {
+    const topPostIds = await fetchPostIds();
+    log(`[HN Digest] Starting with ${topPostIds.length} total story IDs`);
 
-  const ids = filtered.map((id) => id.toString());
-  const posts = await getBatchPosts(ids, false);
+    // topPostIds returns 500 by default. this can block the API route from
+    // responding for a long time while each one is fetched individually.
+    // it's much more likely that the most recent 200 (by decrementing id) are
+    // the top posts within the last 24 hours
+    const filtered = topPostIds.sort((a: number, b: number) => b - a).slice(0, 200);
+    log(`[HN Digest] Filtered to top 200 most recent IDs`);
 
-  const now = new Date().getTime() / 1000;
-  const dayAgo = now - 60 * 60 * 24;
+    const ids = filtered.map((id) => id.toString());
+    const posts = await getBatchPosts(ids, false);
 
-  // don't return jobs or polls
-  const validPosts = posts.filter((post): post is HackerNewsPost => post !== null);
-  log(`[HN Digest] ${validPosts.length} valid posts fetched`);
+    const now = new Date().getTime() / 1000;
+    const dayAgo = now - 60 * 60 * 24;
 
-  const links = validPosts.filter((post) => post.type === "link");
-  log(`[HN Digest] ${links.length} posts are links (filtered out jobs/polls)`);
+    // don't return jobs or polls
+    const validPosts = posts.filter((post): post is HackerNewsPost => post !== null);
+    log(`[HN Digest] ${validPosts.length} valid posts fetched`);
 
-  const withinLastDay = links.filter((post) => post.time > dayAgo);
-  log(`[HN Digest] ${withinLastDay.length} posts within last 24 hours`);
+    const links = validPosts.filter((post) => post.type === "link");
+    log(`[HN Digest] ${links.length} posts are links (filtered out jobs/polls)`);
 
-  const sorted = withinLastDay.sort((a, b) => (b.points || 0) - (a.points || 0));
-  const top16 = sorted.slice(0, 16);
+    const withinLastDay = links.filter((post) => post.time > dayAgo);
+    log(`[HN Digest] ${withinLastDay.length} posts within last 24 hours`);
 
-  log(`[HN Digest] Returning top ${top16.length} posts by points`);
+    const sorted = withinLastDay.sort((a, b) => (b.points || 0) - (a.points || 0));
+    const top16 = sorted.slice(0, 16);
 
-  return top16;
-}
+    log(`[HN Digest] Returning top ${top16.length} posts by points`);
+
+    return top16;
+  },
+  ["hn:digest"],
+  { revalidate: HN_REVALIDATE, tags: ["hn:digest"] },
+);

--- a/src/lib/likes-server.ts
+++ b/src/lib/likes-server.ts
@@ -1,28 +1,48 @@
 import "server-only";
 
+import { unstable_cache } from "next/cache";
+
 import { getBatchLikeCounts, type LikeData } from "./likes-redis";
 
 export type { LikeData };
 
 /**
+ * Revalidate matches the default page revalidate (1h) so wrapping this call
+ * does NOT force pages to regenerate more often than they otherwise would
+ * (Next.js uses the minimum revalidate across all layers of a route).
+ *
+ * Client-side SWR inside BatchLikesProvider refreshes counts live after
+ * hydration, so the server-rendered count lagging by up to 1h is acceptable.
+ */
+const LIKES_REVALIDATE = 3600;
+
+/**
  * Server-side function to get batch like counts for multiple pages.
  * Returns counts only (no user-specific data).
  * User-specific data (hasLiked, userLikes) is fetched client-side.
+ *
+ * Wrapped in `unstable_cache` so Server Components using it can be ISR'd
+ * instead of bailed to dynamic rendering (Upstash REST calls are uncached
+ * fetch POSTs that otherwise force a route dynamic).
  */
-export async function getServerLikes(pageIds: string[]): Promise<Record<string, LikeData>> {
-  if (pageIds.length === 0) return {};
+export const getServerLikes = unstable_cache(
+  async (pageIds: string[]): Promise<Record<string, LikeData>> => {
+    if (pageIds.length === 0) return {};
 
-  const counts = await getBatchLikeCounts(pageIds);
+    const counts = await getBatchLikeCounts(pageIds);
 
-  const result: Record<string, LikeData> = {};
-  for (const pageId of pageIds) {
-    result[pageId] = {
-      count: counts.get(pageId) ?? 0,
-      userLikes: 0,
-      hasLiked: false,
-      canLike: true,
-    };
-  }
+    const result: Record<string, LikeData> = {};
+    for (const pageId of pageIds) {
+      result[pageId] = {
+        count: counts.get(pageId) ?? 0,
+        userLikes: 0,
+        hasLiked: false,
+        canLike: true,
+      };
+    }
 
-  return result;
-}
+    return result;
+  },
+  ["likes:server"],
+  { revalidate: LIKES_REVALIDATE, tags: ["likes:server"] },
+);

--- a/src/lib/notion/cache.ts
+++ b/src/lib/notion/cache.ts
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { unstable_cache } from "next/cache";
 
 // Lazy-initialize Redis to avoid errors during build if env vars aren't set
 let redis: Redis | null = null;
@@ -41,7 +42,16 @@ interface CachedNotionQueryOptions {
 }
 
 /**
- * Redis-backed cache for Notion queries with stale-on-error fallback.
+ * Derive a coarse cache tag from a key like `notion:writing:content:<id>`.
+ * Returns the first two segments so a whole content type can be invalidated
+ * at once via `revalidateTag("notion:writing", "max")`.
+ */
+function deriveTag(key: string): string {
+  return key.split(":").slice(0, 2).join(":");
+}
+
+/**
+ * Inner fetch with Upstash-backed cache + stale-on-error fallback.
  *
  * 1. Check Redis — if fresh (within `ttl`), return immediately (no Notion call)
  * 2. If stale or missing — call Notion via `fetcher()`
@@ -49,24 +59,17 @@ interface CachedNotionQueryOptions {
  * 4. On Notion failure + stale cache exists — return stale data (log warning)
  * 5. On Notion failure + no cache — throw (only possible on first-ever request during outage)
  */
-export async function cachedNotionQuery<T>(
+async function upstashBackedQuery<T>(
   key: string,
   fetcher: () => Promise<T>,
   options: CachedNotionQueryOptions,
 ): Promise<T> {
-  // In development, always fetch fresh data from Notion
-  if (process.env.NODE_ENV === "development") {
-    return fetcher();
-  }
-
   const client = getRedis();
 
-  // If Redis is unavailable, fall through to Notion directly
   if (!client) {
     return fetcher();
   }
 
-  // Step 1: Check Redis
   let cached: CachedEntry<T> | null = null;
   try {
     cached = await client.get<CachedEntry<T>>(key);
@@ -81,11 +84,9 @@ export async function cachedNotionQuery<T>(
     return cached!.data;
   }
 
-  // Step 2: Stale or missing — call Notion
   try {
     const data = await fetcher();
 
-    // Step 3: On success — update Redis
     const entry: CachedEntry<T> = { data, cachedAt: now };
     try {
       await client.set(key, entry, { ex: REDIS_KEY_TTL });
@@ -95,7 +96,6 @@ export async function cachedNotionQuery<T>(
 
     return data;
   } catch (fetchError) {
-    // Step 4: On Notion failure + stale cache exists — return stale data
     if (cached) {
       console.warn(
         `[Notion Cache] Notion fetch failed for ${key}, serving stale cache from ${new Date(cached.cachedAt).toISOString()}:`,
@@ -104,9 +104,38 @@ export async function cachedNotionQuery<T>(
       return cached.data;
     }
 
-    // Step 5: On Notion failure + no cache — throw
     throw fetchError;
   }
+}
+
+/**
+ * Two-layer cache for Notion queries:
+ *
+ * 1. Next.js data cache (`unstable_cache`) — primary. Makes the I/O visible to
+ *    Next's caching system so Server Components using it can be statically
+ *    rendered / ISR'd instead of bailed to dynamic rendering.
+ * 2. Upstash Redis — secondary. Preserves the stale-on-error fallback across
+ *    Next.js cache evictions and across deployments.
+ *
+ * Dev mode bypasses both layers so local changes are visible without waiting
+ * on any cache expiry.
+ */
+export async function cachedNotionQuery<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  options: CachedNotionQueryOptions,
+): Promise<T> {
+  if (process.env.NODE_ENV === "development") {
+    return fetcher();
+  }
+
+  const tag = deriveTag(key);
+  const cached = unstable_cache(() => upstashBackedQuery<T>(key, fetcher, options), [key], {
+    revalidate: options.ttl,
+    tags: [tag, key],
+  });
+
+  return cached();
 }
 
 /**


### PR DESCRIPTION
## Why

- Next.js 16 bails any route with uncached `fetch` to fully dynamic
- Upstash REST calls are uncached fetch under the hood
- So every Server Component touching them runs on every request and `revalidate` exports get ignored
- The existing Upstash cache helps Notion cost but is invisible to Next

Fix: wrap top-level getters in `unstable_cache` to make them cacheable to Next. Add `generateStaticParams` to dynamic-segment pages so they participate in lazy ISR. Purge-cache webhook invalidates both layers via `revalidateTag(tag, 'max')`.

Ref: [Next 16 caching guide](https://nextjs.org/docs/app/guides/caching-without-cache-components)

## What changed

Data layer:
- `src/lib/notion/cache.ts`: `cachedNotionQuery` body wrapped in `unstable_cache`. Tag derived from key prefix. Dev-mode bypass + Upstash stale-on-error preserved
- `src/lib/hn.ts`: `getPostById`, `getHNPosts`, `getRankedHNPosts`, `getHNPostsForDigest` wrapped. React `cache()` kept for per-request dedup
- `src/lib/likes-server.ts`: `getServerLikes` wrapped. Revalidate matches page-level (1h) so it doesn't force shorter page regen
- `src/app/api/purge-cache/route.ts`: `revalidateTag(tag, 'max')` alongside existing `revalidatePath` + Upstash invalidation

Dynamic-segment pages — all flipped `ƒ` → `●` in build output:

| Route | Revalidate |
|-------|-----------|
| `/hn/[id]` | 1h |
| `/writing/[slug]` | 1h |
| `/til/[slug]` | 1h |
| `/app-dissection/[slug]` | 1h |
| `/ama/[id]` | 1d |

Each exports `revalidate`, `dynamicParams = true`, and `generateStaticParams` returning `[]` (lazy ISR on first hit).

Not in this PR:
- List pages stay `force-dynamic`. Converting them needs graceful build-time error handling for placeholder Notion env
- `/design-details/[id]` deferred until the error-handling PR lands

## Test plan

- [x] `bun install && bun run lint && bun run build`
- [x] Build output: 5 dynamic-segment routes show revalidate column
- [ ] Preview: hit `/hn/<id>` twice. Second TTFB drops, no new function invocation
- [ ] Preview: `curl /api/purge-cache?type=writing&secret=...` then `/writing/<slug>` regenerates
- [ ] 24h post-prod: `isrOps` observability shows HIT entries for `/hn/[id]`
