### PR TITLE
Sync only changed likes to Notion via dirty-set tracking

### DIFF
--- a/.github/workflows/sync-likes.yml
+++ b/.github/workflows/sync-likes.yml
@@ -9,5 +9,17 @@ jobs:
   sync-likes:
     runs-on: ubuntu-latest
     steps:
-      - name: sync likes to notion
-        run: curl "https://brianlovin.com/api/likes/sync?token=${{ secrets.LIKES_SYNC_TOKEN }}"
+      - name: sync likes to notion (drain dirty set)
+        run: |
+          # Drain the dirty set across up to 5 sequential calls per tick.
+          # Each call processes up to 50 entries; this covers up to 250 dirty
+          # pages per hourly run without needing a second cron.
+          for i in 1 2 3 4 5; do
+            response=$(curl -sS "https://brianlovin.com/api/likes/sync?token=${{ secrets.LIKES_SYNC_TOKEN }}")
+            echo "Iteration $i: $response"
+            remaining=$(echo "$response" | jq -r '.remainingDirty // 0')
+            if [ "$remaining" = "0" ] || [ "$remaining" = "null" ]; then
+              break
+            fi
+            sleep 2
+          done

--- a/src/app/api/likes/sync/route.ts
+++ b/src/app/api/likes/sync/route.ts
@@ -1,8 +1,128 @@
 import { NextResponse } from "next/server";
 
 import { errorResponse } from "@/lib/api-utils";
-import { getAllLikeCounts } from "@/lib/likes-redis";
+import {
+  getAllLikeCounts,
+  getBatchLikeCounts,
+  getDirtyCount,
+  getDirtyPageIds,
+  markSynced,
+} from "@/lib/likes-redis";
 import { notion } from "@/lib/notion/client";
+
+/** Max entries processed per invocation. Notion updates are 3-wide concurrent,
+ * so 50 entries = ~17 sequential batches of 3 ≈ well under platform timeout. */
+const SYNC_BATCH_MAX = 50;
+
+/** Notion rate limit honors ~3 req/sec; keep existing concurrency. */
+const CONCURRENCY = 3;
+
+async function syncBatch(
+  entries: Array<[string, number]>,
+): Promise<{ synced: string[]; failed: string[] }> {
+  const synced: string[] = [];
+  const failed: string[] = [];
+
+  for (let i = 0; i < entries.length; i += CONCURRENCY) {
+    const batch = entries.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(([pageId, count]) =>
+        notion.pages
+          .update({
+            page_id: pageId,
+            properties: {
+              Likes: { number: count },
+            } as Parameters<typeof notion.pages.update>[0]["properties"],
+          })
+          .then(() => ({ pageId, success: true as const }))
+          .catch((error) => {
+            console.error(`[Likes Sync] Failed to sync page ${pageId}:`, error);
+            return { pageId, success: false as const };
+          }),
+      ),
+    );
+
+    for (const result of results) {
+      const value =
+        result.status === "fulfilled" ? result.value : { pageId: "unknown", success: false };
+      if (value.success) {
+        synced.push(value.pageId);
+      } else if (value.pageId !== "unknown") {
+        failed.push(value.pageId);
+      }
+    }
+  }
+
+  return { synced, failed };
+}
+
+/**
+ * Legacy scan-all path. Runs when FORCE_FULL_SYNC=true is set in the env.
+ * Used for the one-time seed after first deploying the dirty-tracking change,
+ * and as an emergency rollback path.
+ */
+async function runFullSync(): Promise<NextResponse> {
+  const likeCounts = await getAllLikeCounts();
+
+  if (likeCounts.size === 0) {
+    return NextResponse.json({ mode: "full", synced: 0, total: 0 });
+  }
+
+  const entries = Array.from(likeCounts.entries());
+  const { synced, failed } = await syncBatch(entries);
+
+  // Clear successfully-synced entries from the dirty set so the incremental
+  // path has a clean starting point.
+  if (synced.length > 0) {
+    await markSynced(synced);
+  }
+
+  return NextResponse.json({
+    mode: "full",
+    synced: synced.length,
+    failed: failed.length,
+    total: likeCounts.size,
+    errors: failed.length > 0 ? failed : undefined,
+  });
+}
+
+/**
+ * Incremental sync path. Reads up to SYNC_BATCH_MAX pageIds from the dirty
+ * set, syncs their counts to Notion, and marks successful updates clean.
+ * Caller can re-invoke if `remainingDirty > 0`.
+ */
+async function runIncrementalSync(): Promise<NextResponse> {
+  const dirtyIds = await getDirtyPageIds(SYNC_BATCH_MAX);
+
+  if (dirtyIds.length === 0) {
+    const remainingDirty = await getDirtyCount();
+    return NextResponse.json({
+      mode: "incremental",
+      synced: 0,
+      failed: 0,
+      remainingDirty,
+    });
+  }
+
+  const countsMap = await getBatchLikeCounts(dirtyIds);
+  const entries: Array<[string, number]> = dirtyIds.map((id) => [id, countsMap.get(id) ?? 0]);
+
+  const { synced, failed } = await syncBatch(entries);
+
+  if (synced.length > 0) {
+    await markSynced(synced);
+  }
+
+  const remainingDirty = await getDirtyCount();
+
+  return NextResponse.json({
+    mode: "incremental",
+    synced: synced.length,
+    failed: failed.length,
+    remainingDirty,
+    errors: failed.length > 0 ? failed : undefined,
+  });
+}
 
 export async function GET(request: Request) {
   try {
@@ -14,56 +134,11 @@ export async function GET(request: Request) {
       return errorResponse("Unauthorized", 401);
     }
 
-    // Get all like counts from Redis
-    const likeCounts = await getAllLikeCounts();
-
-    if (likeCounts.size === 0) {
-      return NextResponse.json({ message: "No likes to sync", synced: 0 });
+    if (process.env.FORCE_FULL_SYNC === "true") {
+      return runFullSync();
     }
 
-    const errors: string[] = [];
-    const entries = Array.from(likeCounts.entries());
-
-    // Process in concurrent batches of 3 to respect Notion's ~3 req/sec rate limit
-    const CONCURRENCY = 3;
-    let synced = 0;
-
-    for (let i = 0; i < entries.length; i += CONCURRENCY) {
-      const batch = entries.slice(i, i + CONCURRENCY);
-      const results = await Promise.allSettled(
-        batch.map(([pageId, count]) =>
-          notion.pages
-            .update({
-              page_id: pageId,
-              properties: {
-                Likes: { number: count },
-              } as Parameters<typeof notion.pages.update>[0]["properties"],
-            })
-            .then(() => ({ pageId, success: true as const }))
-            .catch((error) => {
-              console.error(`[Likes Sync] Failed to sync page ${pageId}:`, error);
-              return { pageId, success: false as const };
-            }),
-        ),
-      );
-
-      for (const result of results) {
-        const value =
-          result.status === "fulfilled" ? result.value : { pageId: "unknown", success: false };
-        if (value.success) {
-          synced++;
-        } else {
-          errors.push(value.pageId);
-        }
-      }
-    }
-
-    return NextResponse.json({
-      message: "Likes synced to Notion",
-      synced,
-      total: likeCounts.size,
-      errors: errors.length > 0 ? errors : undefined,
-    });
+    return runIncrementalSync();
   } catch (error) {
     console.error("[Likes Sync] Error syncing likes:", error);
     return errorResponse("Failed to sync likes");

--- a/src/lib/likes-redis.ts
+++ b/src/lib/likes-redis.ts
@@ -27,6 +27,13 @@ const USERS_PREFIX = "likes:users:";
 const USER_LIKES_PREFIX = "likes:user:";
 const RATE_LIMIT_PREFIX = "ratelimit:likes:";
 
+/**
+ * Set of pageIds whose counts have changed since the last successful sync to
+ * Notion. The sync job reads from this set to avoid scanning every key on
+ * every run.
+ */
+export const DIRTY_SET_KEY = "likes:dirty";
+
 // Constants
 const RATE_LIMIT_WINDOW = 60; // seconds
 const RATE_LIMIT_MAX = 60; // requests per window
@@ -101,6 +108,11 @@ export async function addLike(userId: string, pageId: string): Promise<number> {
 
     const results = await pipeline.exec();
 
+    // Mark this page as dirty so the next sync picks it up.
+    // Fire-and-forget: a Redis hiccup shouldn't break the like flow — worst
+    // case, the next mutation on this page re-marks it dirty.
+    client.sadd(DIRTY_SET_KEY, pageId).catch(() => {});
+
     // First result is the new total count
     return (results[0] as number) ?? 0;
   } catch (error) {
@@ -145,6 +157,9 @@ export async function removeLike(
     if (newUserLikes === 0) {
       await client.srem(`${USERS_PREFIX}${pageId}`, userId);
     }
+
+    // Mark this page as dirty so the next sync picks it up. Fire-and-forget.
+    client.sadd(DIRTY_SET_KEY, pageId).catch(() => {});
 
     return { count: newCount, userLikes: newUserLikes };
   } catch (error) {
@@ -309,5 +324,53 @@ export async function getBatchUserLikeData(
       result.set(id, { count: 0, userLikes: 0, hasLiked: false, canLike: true });
     });
     return result;
+  }
+}
+
+/**
+ * Read up to `limit` pageIds from the dirty set WITHOUT removing them. The
+ * caller is responsible for calling `markSynced` after the corresponding
+ * Notion updates succeed. Failed updates leave entries in the set for retry.
+ */
+export async function getDirtyPageIds(limit: number): Promise<string[]> {
+  const client = getLikesRedis();
+  if (!client || limit <= 0) return [];
+
+  try {
+    const ids = await client.srandmember<string[]>(DIRTY_SET_KEY, limit);
+    return ids ?? [];
+  } catch (error) {
+    console.error("[Likes] Error reading dirty set:", error);
+    return [];
+  }
+}
+
+/**
+ * Count how many pageIds remain in the dirty set. Used by callers to decide
+ * whether to re-invoke the sync endpoint.
+ */
+export async function getDirtyCount(): Promise<number> {
+  const client = getLikesRedis();
+  if (!client) return 0;
+
+  try {
+    return (await client.scard(DIRTY_SET_KEY)) ?? 0;
+  } catch (error) {
+    console.error("[Likes] Error reading dirty set size:", error);
+    return 0;
+  }
+}
+
+/**
+ * Remove pageIds from the dirty set after they've been successfully synced.
+ */
+export async function markSynced(pageIds: string[]): Promise<void> {
+  const client = getLikesRedis();
+  if (!client || pageIds.length === 0) return;
+
+  try {
+    await client.srem(DIRTY_SET_KEY, ...pageIds);
+  } catch (error) {
+    console.error("[Likes] Error removing from dirty set:", error);
   }
 }


### PR DESCRIPTION
## Why

- `/api/likes/sync` scans every like counter on every run
- Pushes counts to Notion sequentially, 3 at a time
- Hourly cron hits the platform max duration, 504s in the logs as the dataset grows

Switch to a dirty-set: Redis tracks which pageIds changed since last sync. Each call processes a bounded batch. Failures stay in the set for retry.

## What changed

`src/lib/likes-redis.ts`:
- `DIRTY_SET_KEY = "likes:dirty"` exported
- `addLike` and `removeLike` `SADD` the pageId after the counter mutation (fire-and-forget; a Redis hiccup doesn't break the like flow, next mutation re-marks)
- New helpers: `getDirtyPageIds(limit)` via `SRANDMEMBER` (read without remove), `getDirtyCount()` via `SCARD`, `markSynced(pageIds)` via `SREM`

`src/app/api/likes/sync/route.ts`:
- Incremental (default): up to `SYNC_BATCH_MAX = 50` dirty IDs per call, existing 3-wide concurrency preserved, `markSynced` on success
- Full (`FORCE_FULL_SYNC=true`): old scan-all path kept for emergency rollback + initial seed
- Token auth unchanged
- Response: `{ mode, synced, failed, remainingDirty, errors? }`

`.github/workflows/sync-likes.yml`:
- Loop sync up to 5x per cron tick, break when `remainingDirty` is 0
- Covers ~250 dirty pages/hour without needing a second cron

## Rollout

Before merging to main:
1. Set `FORCE_FULL_SYNC=true` in Vercel prod env
2. Run the action once — full scan clears the dirty set as a side-effect
3. Unset `FORCE_FULL_SYNC`

## Test plan

- [x] `bun run lint && bun run build`
- [ ] Preview: toggle likes via `POST /api/likes/<id>`, then sync returns `synced: N, remainingDirty: 0`
- [ ] Load: 200 likes across 200 pages → first call returns `remainingDirty: 150`, drains over subsequent calls
- [ ] 7d post-deploy: 504 count on this route drops to 0
