### PR TITLE
Raise HN route rate limit from 30 to 100 req/min

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,8 +11,8 @@ function getHnRatelimit(): Ratelimit | null {
 
   hnRatelimit = new Ratelimit({
     redis: Redis.fromEnv(),
-    // 30 requests per 60 seconds per IP for HN routes
-    limiter: Ratelimit.slidingWindow(30, "60 s"),
+    // 100 requests per 60 seconds per IP for HN routes
+    limiter: Ratelimit.slidingWindow(100, "60 s"),
     prefix: "rl:hn",
     analytics: true,
   });


### PR DESCRIPTION
## Summary
- Bumps the HN middleware rate limit from 30 to 100 requests per 60 seconds per IP so normal browsing on /hn/[id] stops tripping 429s (page + SWR API call + prefetches was exceeding 30/min).

## Test plan
- [ ] Browse several /hn/[id] pages in quick succession and confirm no "Too many requests" errors
- [ ] Verify sustained abusive traffic still gets throttled