### PR TITLE
Protect HN API routes with BotID

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "brios-v2",
@@ -15,6 +14,7 @@
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.36.3",
         "@vercel/og": "^0.11.1",
+        "botid": "^1.5.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -709,6 +709,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.8.28", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-gYjt7OIqdM0PcttNYP2aVrr2G0bMALkBaoehD4BuRGjAOtipg0b6wHg1yNL+s5zSnLZZrGHOw4IrND8CD+3oIQ=="],
 
     "basic-ftp": ["basic-ftp@5.1.0", "", {}, "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw=="],
+
+    "botid": ["botid@1.5.11", "", { "peerDependencies": { "next": "*", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["next", "react"] }, "sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww=="],
 
     "bowser": ["bowser@2.12.1", "", {}, "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw=="],
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,7 @@
+import { initBotId } from "botid/client/core";
+
+import { HN_BOTID_PROTECTED_ROUTES } from "@/lib/botid";
+
+initBotId({
+  protect: [...HN_BOTID_PROTECTED_ROUTES],
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import { withBotId } from "botid/next/config";
 import type { NextConfig } from "next";
 import path from "path";
 
@@ -70,4 +71,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withBotId(nextConfig);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.3",
     "@vercel/og": "^0.11.1",
+    "botid": "^1.5.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/app/api/hn/[id]/route.ts
+++ b/src/app/api/hn/[id]/route.ts
@@ -1,12 +1,22 @@
+import { checkBotId } from "botid/server";
 import { NextResponse } from "next/server";
 
 import { cachedResponse, errorResponse } from "@/lib/api-utils";
+import { HN_BOTID_ADVANCED_OPTIONS } from "@/lib/botid";
 import { getPostById } from "@/lib/hn";
 
 export async function GET(
   _request: Request,
   props: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
+  const verification = await checkBotId({
+    advancedOptions: HN_BOTID_ADVANCED_OPTIONS,
+  });
+
+  if (verification.isBot) {
+    return errorResponse("Access denied", 403);
+  }
+
   const params = await props.params;
   const { id } = params;
 

--- a/src/app/api/hn/route.ts
+++ b/src/app/api/hn/route.ts
@@ -1,10 +1,20 @@
+import { checkBotId } from "botid/server";
 import { NextResponse } from "next/server";
 
 import { cachedResponse, errorResponse } from "@/lib/api-utils";
+import { HN_BOTID_ADVANCED_OPTIONS } from "@/lib/botid";
 import { getRankedHNPosts } from "@/lib/hn";
 
 export async function GET(): Promise<NextResponse> {
   try {
+    const verification = await checkBotId({
+      advancedOptions: HN_BOTID_ADVANCED_OPTIONS,
+    });
+
+    if (verification.isBot) {
+      return errorResponse("Access denied", 403);
+    }
+
     const posts = await getRankedHNPosts();
     // Cache for 1 hour - filtered high-signal posts from last 24 hours
     return cachedResponse(posts, 3600);

--- a/src/lib/botid.ts
+++ b/src/lib/botid.ts
@@ -1,0 +1,16 @@
+export const HN_BOTID_ADVANCED_OPTIONS = {
+  checkLevel: "basic",
+} as const;
+
+export const HN_BOTID_PROTECTED_ROUTES = [
+  {
+    path: "/api/hn",
+    method: "GET",
+    advancedOptions: HN_BOTID_ADVANCED_OPTIONS,
+  },
+  {
+    path: "/api/hn/*",
+    method: "GET",
+    advancedOptions: HN_BOTID_ADVANCED_OPTIONS,
+  },
+] as const;


### PR DESCRIPTION
This adds Vercel BotID to the Hacker News data surface without affecting the rest of the site. It initializes BotID client-side for the HN API routes, wraps Next.js config with the BotID rewrites, and blocks requests classified as bots in the HN list and detail API handlers. The shared HN BotID config keeps the protected route definitions aligned between client and server. Verification: bun run lint and bunx tsc --noEmit.