### PR TITLE
Update HN API route pattern and remove redundant comment

### DIFF
--- a/src/app/api/hn/send/route.ts
+++ b/src/app/api/hn/send/route.ts
@@ -39,7 +39,6 @@ export async function GET(request: Request) {
 
     const date = formatDigestDate();
 
-    // Fetch subscribers from PlanetScale
     let subscribers = await getHNSubscribers();
 
     // In development, only send to the base email for testing

--- a/src/lib/botid.ts
+++ b/src/lib/botid.ts
@@ -9,7 +9,7 @@ export const HN_BOTID_PROTECTED_ROUTES = [
     advancedOptions: HN_BOTID_ADVANCED_OPTIONS,
   },
   {
-    path: "/api/hn/*",
+    path: "/api/hn/[id]",
     method: "GET",
     advancedOptions: HN_BOTID_ADVANCED_OPTIONS,
   },


### PR DESCRIPTION
## Summary
Minor cleanup to the HN API route configuration and code comments.

## Key Changes
- Updated the HN API protected route pattern from `/api/hn/*` to `/api/hn/[id]` to use explicit Next.js dynamic route syntax instead of wildcard matching
- Removed redundant comment "Fetch subscribers from PlanetScale" that was stating the obvious about the following code

## Implementation Details
The route pattern change makes the protected route definition more explicit and aligned with Next.js conventions for dynamic segments, improving clarity about what routes are being protected.

https://claude.ai/code/session_01YKmEszr9Kqqu9krikc46bn