### PR TITLE
Fix /hn 500s: fail open when Upstash HN Redis is suspended

### DIFF
--- a/src/lib/hn-ratelimit.test.ts
+++ b/src/lib/hn-ratelimit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { checkHnRateLimit, waitForRateLimitPending } from "@/lib/hn-ratelimit";
+
+describe("checkHnRateLimit", () => {
+  test("allows the request when no limiter is configured", async () => {
+    await expect(checkHnRateLimit("1.1.1.1", null)).resolves.toEqual({ allowed: true });
+  });
+
+  test("allows the request when the limiter succeeds", async () => {
+    const pending = Promise.resolve();
+    const decision = await checkHnRateLimit("1.1.1.1", {
+      limit: async () => ({
+        success: true,
+        pending,
+        limit: 100,
+        remaining: 99,
+        reset: 1,
+      }),
+    });
+
+    expect(decision).toEqual({ allowed: true, pending });
+  });
+
+  test("blocks the request when the limiter denies it", async () => {
+    const pending = Promise.resolve();
+    const decision = await checkHnRateLimit("1.1.1.1", {
+      limit: async () => ({
+        success: false,
+        pending,
+        limit: 100,
+        remaining: 0,
+        reset: 42,
+      }),
+    });
+
+    expect(decision).toEqual({
+      allowed: false,
+      pending,
+      limit: 100,
+      remaining: 0,
+      reset: 42,
+    });
+  });
+
+  test("fails open when the limiter throws", async () => {
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      await expect(
+        checkHnRateLimit("1.1.1.1", {
+          limit: async () => {
+            throw new Error("redis down");
+          },
+        }),
+      ).resolves.toEqual({ allowed: true });
+    } finally {
+      console.error = originalError;
+    }
+  });
+});
+
+describe("waitForRateLimitPending", () => {
+  test("does nothing without a pending promise or waitUntil", () => {
+    expect(() => waitForRateLimitPending(undefined, Promise.resolve())).not.toThrow();
+    expect(() => waitForRateLimitPending({}, Promise.resolve())).not.toThrow();
+    expect(() => waitForRateLimitPending({ waitUntil: () => {} }, undefined)).not.toThrow();
+  });
+
+  test("passes a rejection-safe pending promise to waitUntil", async () => {
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      const pending = Promise.reject(new Error("analytics failed"));
+      const waited: Promise<unknown>[] = [];
+
+      waitForRateLimitPending(
+        {
+          waitUntil: (promise) => {
+            waited.push(promise);
+          },
+        },
+        pending,
+      );
+
+      expect(waited).toHaveLength(1);
+      await expect(waited[0]).resolves.toBeUndefined();
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/src/lib/hn-ratelimit.test.ts
+++ b/src/lib/hn-ratelimit.test.ts
@@ -50,7 +50,9 @@ describe("checkHnRateLimit", () => {
       await expect(
         checkHnRateLimit("1.1.1.1", {
           limit: async () => {
-            throw new Error("redis down");
+            throw new Error(
+              "ERR This database has been suspended for exceeding the defined budget limit. Please increase budget or switch to a Fixed plan on Upstash Console",
+            );
           },
         }),
       ).resolves.toEqual({ allowed: true });

--- a/src/lib/hn-ratelimit.ts
+++ b/src/lib/hn-ratelimit.ts
@@ -74,6 +74,7 @@ export async function checkHnRateLimit(
       reset: result.reset,
     };
   } catch (error) {
+    // limit() throws when Redis is down or suspended (budget limit); fail open.
     console.error("[HN RateLimit] Error checking rate limit; failing open:", error);
     return { allowed: true };
   }

--- a/src/lib/hn-ratelimit.ts
+++ b/src/lib/hn-ratelimit.ts
@@ -1,0 +1,97 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+export type HnRateLimitLimiter = {
+  limit: (identifier: string) => Promise<{
+    success: boolean;
+    pending?: Promise<unknown>;
+    limit: number;
+    remaining: number;
+    reset: number;
+  }>;
+};
+
+export type HnRateLimitDecision =
+  | { allowed: true; pending?: Promise<unknown> }
+  | {
+      allowed: false;
+      pending?: Promise<unknown>;
+      limit: number;
+      remaining: number;
+      reset: number;
+    };
+
+export type WaitUntilEvent = {
+  waitUntil?: (promise: Promise<unknown>) => void;
+};
+
+// Lazy-initialize to avoid build-time env var errors
+let hnRatelimit: Ratelimit | null = null;
+
+export function getHnRatelimit(): HnRateLimitLimiter | null {
+  if (hnRatelimit) return hnRatelimit;
+  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
+    return null;
+  }
+
+  try {
+    hnRatelimit = new Ratelimit({
+      redis: Redis.fromEnv(),
+      // 100 requests per 60 seconds per IP for HN routes
+      limiter: Ratelimit.slidingWindow(100, "60 s"),
+      prefix: "rl:hn",
+      analytics: true,
+      // Fail open if Redis is slow so middleware cannot time out /hn
+      timeout: 1000,
+    });
+    return hnRatelimit;
+  } catch (error) {
+    console.error("[HN RateLimit] Failed to initialize limiter; failing open:", error);
+    return null;
+  }
+}
+
+/**
+ * Apply the HN rate limit. Redis/limiter failures fail open so /hn stays up.
+ */
+export async function checkHnRateLimit(
+  ip: string,
+  limiter: HnRateLimitLimiter | null = getHnRatelimit(),
+): Promise<HnRateLimitDecision> {
+  if (!limiter) return { allowed: true };
+
+  try {
+    const result = await limiter.limit(ip);
+    if (result.success) {
+      return { allowed: true, pending: result.pending };
+    }
+
+    return {
+      allowed: false,
+      pending: result.pending,
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+    };
+  } catch (error) {
+    console.error("[HN RateLimit] Error checking rate limit; failing open:", error);
+    return { allowed: true };
+  }
+}
+
+/**
+ * Keep analytics (`pending`) alive in Edge/serverless without letting a
+ * rejection crash the middleware invocation.
+ */
+export function waitForRateLimitPending(
+  event: WaitUntilEvent | undefined,
+  pending: Promise<unknown> | undefined,
+): void {
+  if (!pending || typeof event?.waitUntil !== "function") return;
+
+  event.waitUntil(
+    pending.catch((error: unknown) => {
+      console.error("[HN RateLimit] Analytics failed:", error);
+    }),
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,6 @@
-import { Ratelimit } from "@upstash/ratelimit";
-import { Redis } from "@upstash/redis";
-import { NextRequest, NextResponse } from "next/server";
+import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 
-// Lazy-initialize to avoid build-time env var errors
-let hnRatelimit: Ratelimit | null = null;
-
-function getHnRatelimit(): Ratelimit | null {
-  if (hnRatelimit) return hnRatelimit;
-  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) return null;
-
-  hnRatelimit = new Ratelimit({
-    redis: Redis.fromEnv(),
-    // 100 requests per 60 seconds per IP for HN routes
-    limiter: Ratelimit.slidingWindow(100, "60 s"),
-    prefix: "rl:hn",
-    analytics: true,
-  });
-  return hnRatelimit;
-}
+import { checkHnRateLimit, getHnRatelimit, waitForRateLimitPending } from "@/lib/hn-ratelimit";
 
 function getIP(request: NextRequest): string {
   return (
@@ -27,7 +10,7 @@ function getIP(request: NextRequest): string {
   );
 }
 
-export async function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
   const ip = getIP(request);
 
@@ -43,23 +26,22 @@ export async function middleware(request: NextRequest) {
       return NextResponse.json({ error: "Invalid HN post ID" }, { status: 400 });
     }
 
-    const limiter = getHnRatelimit();
-    if (limiter) {
-      const { success, limit, remaining, reset } = await limiter.limit(ip);
-      if (!success) {
-        return NextResponse.json(
-          { error: "Too many requests" },
-          {
-            status: 429,
-            headers: {
-              "X-RateLimit-Limit": limit.toString(),
-              "X-RateLimit-Remaining": remaining.toString(),
-              "X-RateLimit-Reset": reset.toString(),
-              "Retry-After": Math.ceil((reset - Date.now()) / 1000).toString(),
-            },
+    const decision = await checkHnRateLimit(ip, getHnRatelimit());
+    waitForRateLimitPending(event, decision.pending);
+
+    if (!decision.allowed) {
+      return NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: {
+            "X-RateLimit-Limit": decision.limit.toString(),
+            "X-RateLimit-Remaining": decision.remaining.toString(),
+            "X-RateLimit-Reset": decision.reset.toString(),
+            "Retry-After": Math.ceil((decision.reset - Date.now()) / 1000).toString(),
           },
-        );
-      }
+        },
+      );
     }
 
     return NextResponse.next();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause (confirmed from Vercel production logs)

Every `/hn` and `/api/hn` 500 is middleware (`source ε`) throwing:

```
UpstashError: ERR This database has been suspended for exceeding the defined budget limit.
Please increase budget or switch to a Fixed plan on Upstash Console
command: evalsha ... keys like rl:hn:<ip>:<window>
```

`Redis.fromEnv()` + `limiter.limit()` throws because the HN rate-limit Upstash DB is over budget / suspended. The missing-env short-circuit does not help — the env vars are present, Redis is just refusing commands.

That matches live HTTP behavior:

| Path | Result | Hits `limit()`? |
| --- | --- | --- |
| `/`, `/writing` | 200 | No |
| `/hn/garbage` | 400 | No (ID validation first) |
| `/hn`, `/hn/123`, `/api/hn` | 500 `MIDDLEWARE_INVOCATION_FAILED` | Yes |

This is not a Next.js 16.3 / `cacheComponents` middleware incompatibility. Invalid IDs never call Redis and return 400.

## Fix

If rate limiting throws (suspended DB, outage, etc.), log `[HN RateLimit] ... failing open` and `NextResponse.next()` so `/hn` stays up.

- Invalid `/hn/[id]` still 400s before Redis
- Healthy Redis still 429s at 100 req/60s/IP
- `event.waitUntil(pending.catch(...))` so analytics cannot crash the invocation
- 1s limiter timeout so a hung Redis call cannot burn the middleware budget

## How to verify

After deploy (Redis can stay suspended):

1. `curl -sI https://brianlovin.com/hn` → **200**, not `MIDDLEWARE_INVOCATION_FAILED`
2. `curl -sI https://brianlovin.com/hn/garbage` → **400**
3. Vercel logs should show `[HN RateLimit] Error checking rate limit; failing open:` plus the Upstash budget error, instead of an uncaught middleware crash
4. To restore rate limiting later: raise the Upstash budget or switch that DB to a Fixed plan, then confirm 429s still work

Local:

```bash
bun test src/lib/hn-ratelimit.test.ts
bun run lint
```

Ops follow-up (not in this PR): the `rl:hn` Upstash database needs a higher budget or a Fixed plan, or `/hn` will stay up but unrate-limited until Redis is healthy again.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9205e96-4860-4cda-8da7-9c1dbd117a93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9205e96-4860-4cda-8da7-9c1dbd117a93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

