### PR TITLE
Unify Notion collection types behind property readers

### DIFF
--- a/schemas/AppDissectionSchema.json
+++ b/schemas/AppDissectionSchema.json
@@ -1,0 +1,61 @@
+{
+  "props": {
+    "Slug": {
+      "id": "HGK%60",
+      "name": "Slug",
+      "description": null,
+      "type": "rich_text",
+      "rich_text": {}
+    },
+    "Status": {
+      "id": "XxgG",
+      "name": "Status",
+      "description": null,
+      "type": "select",
+      "select": {
+        "options": [
+          {
+            "id": "1c9ce588-8356-4e8d-a713-18eaa1fbc7fb",
+            "name": "Draft",
+            "color": "gray",
+            "description": null
+          },
+          {
+            "id": "89be07f8-8ecf-43cc-aea6-96d1d7135d4b",
+            "name": "Published",
+            "color": "green",
+            "description": null
+          }
+        ]
+      }
+    },
+    "Published": {
+      "id": "oDL%3B",
+      "name": "Published",
+      "description": null,
+      "type": "date",
+      "date": {}
+    },
+    "Tint": {
+      "id": "sigS",
+      "name": "Tint",
+      "description": null,
+      "type": "rich_text",
+      "rich_text": {}
+    },
+    "Icon": {
+      "id": "~%5CXH",
+      "name": "Icon",
+      "description": null,
+      "type": "url",
+      "url": {}
+    },
+    "Name": {
+      "id": "title",
+      "name": "Name",
+      "description": null,
+      "type": "title",
+      "title": {}
+    }
+  }
+}

--- a/schemas/notionSchemas.ts
+++ b/schemas/notionSchemas.ts
@@ -134,3 +134,14 @@ export const TILSchema = z.object({
 });
 
 export type TIL = z.infer<typeof TILSchema>;
+
+export const AppDissectionSchema = z.object({
+  Slug: z.string().optional(),
+  Status: z.enum(["Draft", "Published"]).optional(),
+  Published: z.string().optional(),
+  Tint: z.string().optional(),
+  Icon: z.string().optional(),
+  Name: z.string().optional(),
+});
+
+export type AppDissection = z.infer<typeof AppDissectionSchema>;

--- a/scripts/generateNotionSchemas.ts
+++ b/scripts/generateNotionSchemas.ts
@@ -118,6 +118,7 @@ async function generateSchemas() {
     { varName: "GoodWebsites", id: process.env.NOTION_GOOD_WEBSITES_DATABASE_ID },
     { varName: "Speaking", id: process.env.NOTION_SPEAKING_DATABASE_ID },
     { varName: "TIL", id: process.env.NOTION_TIL_DATABASE_ID },
+    { varName: "AppDissection", id: process.env.NOTION_APP_DISSECTION_DATABASE_ID },
   ];
 
   const configuredDatabases = databases.filter((db) => db.id);

--- a/src/hooks/useDesignDetailsEpisodes.ts
+++ b/src/hooks/useDesignDetailsEpisodes.ts
@@ -1,17 +1,10 @@
 "use client";
 
+import type { DesignDetailsEpisode } from "@/lib/design-details";
+
 import { InfiniteScrollPage, useInfiniteScroll } from "./useInfiniteScroll";
 
-export type DesignDetailsEpisode = {
-  id: string;
-  title: string;
-  slug: string;
-  description?: string;
-  episodeNumber?: number;
-  publishedDate?: string;
-  imageUrl?: string;
-  audioUrl?: string;
-};
+export type { DesignDetailsEpisode };
 
 export type DesignDetailsEpisodePage = InfiniteScrollPage<DesignDetailsEpisode>;
 

--- a/src/hooks/useListeningHistory.ts
+++ b/src/hooks/useListeningHistory.ts
@@ -3,18 +3,11 @@
 import useSWR from "swr";
 
 import { fetcher } from "@/lib/fetcher";
+import type { MusicItem } from "@/lib/listening-history";
 
 import { InfiniteScrollPage, useInfiniteScroll } from "./useInfiniteScroll";
 
-export type MusicItem = {
-  id: string;
-  name: string;
-  artist: string;
-  album: string;
-  url?: string;
-  playedAt: string;
-  image?: string;
-};
+export type { MusicItem };
 
 export type ListeningHistoryPage = InfiniteScrollPage<MusicItem>;
 

--- a/src/lib/design-details.ts
+++ b/src/lib/design-details.ts
@@ -1,15 +1,9 @@
-import { getDesignDetailsEpisodeDatabaseItems } from "@/lib/notion";
+import {
+  getDesignDetailsEpisodeDatabaseItems,
+  type NotionDesignDetailsEpisodeItem,
+} from "@/lib/notion";
 
-export type DesignDetailsEpisode = {
-  id: string;
-  title: string;
-  slug: string;
-  description?: string;
-  episodeNumber?: number;
-  publishedDate?: string;
-  imageUrl?: string;
-  audioUrl?: string;
-};
+export type DesignDetailsEpisode = NotionDesignDetailsEpisodeItem;
 
 export async function getDesignDetailsEpisodes(): Promise<DesignDetailsEpisode[]> {
   const all: DesignDetailsEpisode[] = [];

--- a/src/lib/goodWebsites.ts
+++ b/src/lib/goodWebsites.ts
@@ -1,20 +1,12 @@
-import { getGoodWebsitesDatabaseItems, getGoodWebsitesDatabaseItemsForRss } from "@/lib/notion";
+import {
+  getGoodWebsitesDatabaseItems,
+  getGoodWebsitesDatabaseItemsForRss,
+  type GoodWebsiteItem as NotionGoodWebsiteItem,
+  type GoodWebsiteItemWithDate as NotionGoodWebsiteItemWithDate,
+} from "@/lib/notion";
 
-export type GoodWebsiteItem = {
-  id: string;
-  name: string;
-  url?: string;
-  x?: string;
-  icon?: string;
-  tags?: string[];
-  previewImage?: string;
-  previewImageDark?: string;
-  previewStatus?: "Queued" | "Processing" | "Done" | "Error";
-};
-
-export type GoodWebsiteItemWithDate = GoodWebsiteItem & {
-  createdTime: string;
-};
+export type GoodWebsiteItem = NotionGoodWebsiteItem;
+export type GoodWebsiteItemWithDate = NotionGoodWebsiteItemWithDate;
 
 // Seeded random number generator for consistent randomization within time windows
 function seededRandom(seed: number): () => number {
@@ -44,7 +36,7 @@ export function getGoodWebsitesSeed(now: number = Date.now()): number {
 
 export async function getGoodWebsites(seed: number): Promise<GoodWebsiteItem[]> {
   const items = await getGoodWebsitesDatabaseItems();
-  return shuffleWithSeed(items as GoodWebsiteItem[], seed);
+  return shuffleWithSeed(items, seed);
 }
 
 export async function getGoodWebsitesForRss(): Promise<GoodWebsiteItemWithDate[]> {

--- a/src/lib/listening-history.ts
+++ b/src/lib/listening-history.ts
@@ -1,16 +1,8 @@
-import { getListeningHistoryDatabaseItems } from "@/lib/notion";
+import { getListeningHistoryDatabaseItems, type NotionListeningHistoryItem } from "@/lib/notion";
 
-export type MusicItem = {
-  id: string;
-  name: string;
-  artist: string;
-  album: string;
-  url?: string;
-  playedAt: string;
-  image?: string;
-};
+export type MusicItem = NotionListeningHistoryItem;
 
 export async function getMusic(): Promise<MusicItem[]> {
   const { items } = await getListeningHistoryDatabaseItems();
-  return items as MusicItem[];
+  return items;
 }

--- a/src/lib/notion/index.ts
+++ b/src/lib/notion/index.ts
@@ -3,48 +3,36 @@ export { notion } from "./client";
 
 // Types
 export type {
-  AMA,
   // SDK types
   BlockObjectResponse,
-  // Zod schemas and types
   DatabaseObjectResponse,
-  DesignDetailsEpisodes,
   GoodWebsiteItem,
   GoodWebsiteItemWithDate,
-  Music,
   NotionAmaItem,
   NotionAmaItemWithContent,
+  NotionAppDissectionItem,
+  NotionAppDissectionItemWithContent,
   NotionDesignDetailsEpisodeItem,
   NotionItem,
   NotionListeningHistoryItem,
+  NotionSpeakingItem,
   NotionStackItem,
   NotionTilItem,
   NotionTilItemWithContent,
+  NotionWritingItem,
   PageObjectResponse,
   PageResponse,
   PartialDatabaseObjectResponse,
   PartialPageObjectResponse,
+  PreviewStatus,
   ProcessedBlock,
-  // Custom types
   RichTextContent,
   RichTextItemResponse,
-  Stack,
-  TIL,
-  Writing,
 } from "./types";
-
-// Zod schemas
-export {
-  AMASchema,
-  DesignDetailsEpisodesSchema,
-  MusicSchema,
-  StackSchema,
-  TILSchema,
-  WritingSchema,
-} from "./types";
+export { PREVIEW_STATUSES } from "./types";
 
 // Type guards and utilities
-export { extractPlainText, hasProperties, isBlockObjectResponse } from "./types";
+export { extractPlainText, hasProperties, isBlockObjectResponse, isFullPage } from "./types";
 
 // Block processing
 export { getAllBlocks, processBlockFromResponse } from "./blocks";
@@ -54,6 +42,9 @@ export {
   getAmaDatabaseItems,
   // AMA
   getAmaItemContent,
+  // App Dissection
+  getAppDissectionDatabaseItems,
+  getAppDissectionItemBySlug,
   // Design Details
   getDesignDetailsEpisodeDatabaseItems,
   // Generic

--- a/src/lib/notion/mutations.ts
+++ b/src/lib/notion/mutations.ts
@@ -1,4 +1,5 @@
 import { notion } from "./client";
+import { writeMultiSelect, writeRichText, writeSelect, writeTitle, writeUrl } from "./properties";
 
 // ===== Stack Mutations =====
 
@@ -16,45 +17,31 @@ export async function createStackItem(data: {
 
     // Build properties object based on the schema
     const properties: Record<string, unknown> = {
-      Name: {
-        title: [{ text: { content: data.name } }],
-      },
+      Name: writeTitle(data.name),
     };
 
     if (data.slug) {
-      properties.Slug = {
-        rich_text: [{ text: { content: data.slug } }],
-      };
+      properties.Slug = writeRichText(data.slug);
     }
 
     if (data.description) {
-      properties.Description = {
-        rich_text: [{ text: { content: data.description } }],
-      };
+      properties.Description = writeRichText(data.description);
     }
 
     if (data.image) {
-      properties.Image = {
-        url: data.image,
-      };
+      properties.Image = writeUrl(data.image);
     }
 
     if (data.url) {
-      properties.URL = {
-        url: data.url,
-      };
+      properties.URL = writeUrl(data.url);
     }
 
     if (data.platforms && data.platforms.length > 0) {
-      properties.Platforms = {
-        multi_select: data.platforms.map((platform) => ({ name: platform })),
-      };
+      properties.Platforms = writeMultiSelect(data.platforms);
     }
 
     if (data.status) {
-      properties.Status = {
-        select: { name: data.status },
-      };
+      properties.Status = writeSelect(data.status);
     }
 
     // Build the page creation object
@@ -97,59 +84,31 @@ export async function updateStackItem(
     const properties: Record<string, unknown> = {};
 
     if (data.name) {
-      properties.Name = {
-        title: [{ text: { content: data.name } }],
-      };
+      properties.Name = writeTitle(data.name);
     }
 
     if (data.slug) {
-      properties.Slug = {
-        rich_text: [{ text: { content: data.slug } }],
-      };
+      properties.Slug = writeRichText(data.slug);
     }
 
     if (data.description !== undefined) {
-      properties.Description = {
-        rich_text: data.description ? [{ text: { content: data.description } }] : [],
-      };
+      properties.Description = writeRichText(data.description);
     }
 
     if (data.image !== undefined) {
-      if (data.image) {
-        properties.Image = {
-          url: data.image,
-        };
-      } else {
-        properties.Image = null;
-      }
+      properties.Image = data.image ? writeUrl(data.image) : null;
     }
 
     if (data.url !== undefined) {
-      if (data.url) {
-        properties.URL = {
-          url: data.url,
-        };
-      } else {
-        properties.URL = null;
-      }
+      properties.URL = data.url ? writeUrl(data.url) : null;
     }
 
     if (data.platforms !== undefined) {
-      if (data.platforms.length > 0) {
-        properties.Platforms = {
-          multi_select: data.platforms.map((platform) => ({ name: platform })),
-        };
-      } else {
-        properties.Platforms = {
-          multi_select: [],
-        };
-      }
+      properties.Platforms = writeMultiSelect(data.platforms);
     }
 
     if (data.status) {
-      properties.Status = {
-        select: { name: data.status },
-      };
+      properties.Status = writeSelect(data.status);
     }
 
     // Set page icon if image is provided
@@ -181,14 +140,12 @@ export async function updateStackItem(
 export async function createAmaQuestion(title: string, description?: string) {
   const databaseId = process.env.NOTION_AMA_DATABASE_ID || "";
   const properties: Record<string, unknown> = {
-    Name: { title: [{ text: { content: title } }] },
-    Status: { select: { name: "Unanswered" } },
+    Name: writeTitle(title),
+    Status: writeSelect("Unanswered"),
   };
 
   if (description) {
-    properties.Description = {
-      rich_text: [{ text: { content: description } }],
-    };
+    properties.Description = writeRichText(description);
   }
 
   return notion.pages.create({
@@ -204,9 +161,7 @@ export async function updateWritingShortId(pageId: string, shortId: string) {
     const response = await notion.pages.update({
       page_id: pageId,
       properties: {
-        "Short ID": {
-          rich_text: [{ text: { content: shortId } }],
-        },
+        "Short ID": writeRichText(shortId),
       } as any,
     });
 

--- a/src/lib/notion/properties.test.ts
+++ b/src/lib/notion/properties.test.ts
@@ -1,0 +1,202 @@
+import type {
+  PageObjectResponse,
+  RichTextItemResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+import { describe, expect, test } from "bun:test";
+
+import {
+  createdTime,
+  dateStart,
+  filesUrl,
+  iconUrl,
+  multiSelect,
+  number,
+  previewStatus,
+  richText,
+  select,
+  title,
+  url,
+  writeMultiSelect,
+  writeRichText,
+  writeSelect,
+  writeTitle,
+  writeUrl,
+} from "./properties";
+
+function richTextItem(content: string): RichTextItemResponse {
+  return {
+    type: "text",
+    text: { content, link: null },
+    annotations: {
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: "default",
+    },
+    plain_text: content,
+    href: null,
+  };
+}
+
+function properties(entries: PageObjectResponse["properties"]): PageObjectResponse["properties"] {
+  return entries;
+}
+
+describe("title", () => {
+  test("reads Name and Title keys independently", () => {
+    const props = properties({
+      Name: { id: "title", type: "title", title: [richTextItem("Stack item")] },
+      Title: { id: "alt", type: "title", title: [richTextItem("TIL item")] },
+    });
+
+    expect(title(props, "Name")).toBe("Stack item");
+    expect(title(props, "Title")).toBe("TIL item");
+  });
+
+  test("joins every title segment", () => {
+    const props = properties({
+      Title: {
+        id: "title",
+        type: "title",
+        title: [richTextItem("Hello"), richTextItem(" world")],
+      },
+    });
+
+    expect(title(props, "Title")).toBe("Hello world");
+  });
+
+  test("returns undefined for a missing or empty title", () => {
+    expect(title(properties({}), "Name")).toBeUndefined();
+    expect(
+      title(
+        properties({ Name: { id: "title", type: "title", title: [richTextItem("")] } }),
+        "Name",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("richText / select / url / dateStart", () => {
+  test("reads each wire shape once", () => {
+    const props = properties({
+      Slug: { id: "s", type: "rich_text", rich_text: [richTextItem("hello")] },
+      Status: {
+        id: "st",
+        type: "select",
+        select: { id: "1", name: "Active", color: "green" },
+      },
+      URL: { id: "u", type: "url", url: "https://example.com" },
+      Published: {
+        id: "d",
+        type: "date",
+        date: { start: "2024-01-15", end: null, time_zone: null },
+      },
+    });
+
+    expect(richText(props, "Slug")).toBe("hello");
+    expect(select(props, "Status")).toBe("Active");
+    expect(url(props, "URL")).toBe("https://example.com");
+    expect(dateStart(props, "Published")).toBe("2024-01-15");
+  });
+
+  test("returns undefined when the property type does not match", () => {
+    const props = properties({
+      Name: { id: "title", type: "title", title: [richTextItem("Nope")] },
+    });
+
+    expect(richText(props, "Name")).toBeUndefined();
+    expect(select(props, "Name")).toBeUndefined();
+    expect(url(props, "Name")).toBeUndefined();
+    expect(dateStart(props, "Name")).toBeUndefined();
+  });
+});
+
+describe("multiSelect / createdTime / number / filesUrl", () => {
+  test("reads remaining property shapes", () => {
+    const props = properties({
+      Platforms: {
+        id: "p",
+        type: "multi_select",
+        multi_select: [
+          { id: "1", name: "macOS", color: "brown" },
+          { id: "2", name: "iOS", color: "red" },
+        ],
+      },
+      "Created time": { id: "c", type: "created_time", created_time: "2024-02-01T00:00:00.000Z" },
+      "Episode Number": { id: "n", type: "number", number: 42 },
+      Files: {
+        id: "f",
+        type: "files",
+        files: [
+          {
+            type: "external",
+            name: "cover",
+            external: { url: "https://cdn.example.com/cover.png" },
+          },
+        ],
+      },
+    });
+
+    expect(multiSelect(props, "Platforms")).toEqual(["macOS", "iOS"]);
+    expect(createdTime(props, "Created time")).toBe("2024-02-01T00:00:00.000Z");
+    expect(number(props, "Episode Number")).toBe(42);
+    expect(filesUrl(props, "Files")).toBe("https://cdn.example.com/cover.png");
+  });
+
+  test("multiSelect returns an empty array when missing", () => {
+    expect(multiSelect(properties({}), "Tags")).toEqual([]);
+  });
+});
+
+describe("iconUrl", () => {
+  test("reads file, external, and optional emoji icons", () => {
+    expect(
+      iconUrl({ icon: { type: "external", external: { url: "https://icon.test/a.png" } } }),
+    ).toBe("https://icon.test/a.png");
+    expect(
+      iconUrl({
+        icon: { type: "file", file: { url: "https://notion.so/file.png", expiry_time: "later" } },
+      }),
+    ).toBe("https://notion.so/file.png");
+    expect(iconUrl({ icon: { type: "emoji", emoji: "🎧" } })).toBeUndefined();
+    expect(iconUrl({ icon: { type: "emoji", emoji: "🎧" } }, { includeEmoji: true })).toBe("🎧");
+    expect(iconUrl({ icon: null })).toBeUndefined();
+  });
+});
+
+describe("previewStatus", () => {
+  test("includes Pending and rejects unknown values", () => {
+    const pending = properties({
+      "Preview Status": {
+        id: "ps",
+        type: "select",
+        select: { id: "1", name: "Pending", color: "pink" },
+      },
+    });
+    const unknown = properties({
+      "Preview Status": {
+        id: "ps",
+        type: "select",
+        select: { id: "1", name: "Mystery", color: "gray" },
+      },
+    });
+
+    expect(previewStatus(pending)).toBe("Pending");
+    expect(previewStatus(unknown)).toBeUndefined();
+  });
+});
+
+describe("writers", () => {
+  test("emit Notion write payloads", () => {
+    expect(writeTitle("Hello")).toEqual({ title: [{ text: { content: "Hello" } }] });
+    expect(writeRichText("Slug")).toEqual({ rich_text: [{ text: { content: "Slug" } }] });
+    expect(writeRichText("")).toEqual({ rich_text: [] });
+    expect(writeUrl("https://example.com")).toEqual({ url: "https://example.com" });
+    expect(writeSelect("Active")).toEqual({ select: { name: "Active" } });
+    expect(writeMultiSelect(["macOS", "iOS"])).toEqual({
+      multi_select: [{ name: "macOS" }, { name: "iOS" }],
+    });
+  });
+});

--- a/src/lib/notion/properties.ts
+++ b/src/lib/notion/properties.ts
@@ -1,0 +1,124 @@
+import type {
+  PageObjectResponse,
+  RichTextItemResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+
+import { extractPlainText, PREVIEW_STATUSES, type PreviewStatus } from "./types";
+
+type PageProperties = PageObjectResponse["properties"];
+type PageProperty = PageProperties[string];
+
+function property(properties: PageProperties, name: string): PageProperty | undefined {
+  return properties[name];
+}
+
+function textFromRichText(items: RichTextItemResponse[]): string | undefined {
+  const value = extractPlainText(items);
+  return value || undefined;
+}
+
+/** Title property. Callers pass the real key (`Name` or TIL's `Title`). */
+export function title(properties: PageProperties, name: string): string | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "title") return undefined;
+  return textFromRichText(value.title);
+}
+
+export function richText(properties: PageProperties, name: string): string | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "rich_text") return undefined;
+  return textFromRichText(value.rich_text);
+}
+
+export function select(properties: PageProperties, name: string): string | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "select") return undefined;
+  return value.select?.name || undefined;
+}
+
+export function url(properties: PageProperties, name: string): string | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "url") return undefined;
+  return value.url || undefined;
+}
+
+export function dateStart(properties: PageProperties, name: string): string | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "date") return undefined;
+  return value.date?.start || undefined;
+}
+
+export function multiSelect(properties: PageProperties, name: string): string[] {
+  const value = property(properties, name);
+  if (value?.type !== "multi_select") return [];
+  return value.multi_select.map((option) => option.name);
+}
+
+export function createdTime(properties: PageProperties, name: string): string | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "created_time") return undefined;
+  return value.created_time || undefined;
+}
+
+export function number(properties: PageProperties, name: string): number | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "number") return undefined;
+  return value.number ?? undefined;
+}
+
+export function filesUrl(properties: PageProperties, name: string): string | undefined {
+  const value = property(properties, name);
+  if (value?.type !== "files") return undefined;
+
+  const file = value.files[0];
+  if (!file) return undefined;
+  if (file.type === "file") return file.file.url;
+  if (file.type === "external") return file.external.url;
+  return undefined;
+}
+
+export function iconUrl(
+  page: Pick<PageObjectResponse, "icon">,
+  options: { includeEmoji?: boolean } = {},
+): string | undefined {
+  const icon = page.icon;
+  if (!icon) return undefined;
+  if (icon.type === "file") return icon.file.url;
+  if (icon.type === "external") return icon.external.url;
+  if (icon.type === "custom_emoji") return icon.custom_emoji.url;
+  if (options.includeEmoji && icon.type === "emoji") return icon.emoji;
+  return undefined;
+}
+
+function isPreviewStatus(value: string): value is PreviewStatus {
+  return (PREVIEW_STATUSES as readonly string[]).includes(value);
+}
+
+export function previewStatus(
+  properties: PageProperties,
+  name: string = "Preview Status",
+): PreviewStatus | undefined {
+  const value = select(properties, name);
+  if (!value || !isPreviewStatus(value)) return undefined;
+  return value;
+}
+
+export function writeTitle(content: string) {
+  return { title: [{ text: { content } }] };
+}
+
+export function writeRichText(content: string) {
+  return { rich_text: content ? [{ text: { content } }] : [] };
+}
+
+export function writeUrl(value: string | null) {
+  return { url: value };
+}
+
+export function writeSelect(name: string) {
+  return { select: { name } };
+}
+
+export function writeMultiSelect(names: string[]) {
+  return { multi_select: names.map((optionName) => ({ name: optionName })) };
+}

--- a/src/lib/notion/queries.ts
+++ b/src/lib/notion/queries.ts
@@ -1,16 +1,25 @@
-import type {
-  DatabaseObjectResponse,
-  PageObjectResponse,
-} from "@notionhq/client/build/src/api-endpoints";
+import type { DatabaseObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 
 import { getAllBlocks } from "./blocks";
 import { CACHE_TTLS, cachedNotionQuery } from "./cache";
 import { notion } from "./client";
 import {
+  createdTime,
+  dateStart,
+  iconUrl,
+  multiSelect,
+  number,
+  previewStatus,
+  richText,
+  select,
+  title,
+  url,
+} from "./properties";
+import {
   type AppDissectionDetail,
   type GoodWebsiteItem,
   type GoodWebsiteItemWithDate,
-  hasProperties,
+  isFullPage,
   isValidVideoMetadata,
   type NotionAmaItem,
   type NotionAmaItemWithContent,
@@ -23,6 +32,8 @@ import {
   type NotionStackItem,
   type NotionTilItem,
   type NotionTilItemWithContent,
+  type NotionWritingItem,
+  type PageResponse,
   type ProcessedBlock,
 } from "./types";
 
@@ -45,6 +56,230 @@ async function getDataSourceId(databaseId: string): Promise<string> {
   );
 }
 
+function mapGenericItem(page: PageResponse): NotionItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    title: title(properties, "Name") ?? "Untitled",
+    category: select(properties, "Category") ?? "Uncategorized",
+    status: select(properties, "Status") ?? "Draft",
+    createdTime: page.created_time,
+    published: dateStart(properties, "Published") || page.created_time,
+    source: url(properties, "Source")?.replace("https://", ""),
+    slug: richText(properties, "Slug") ?? "",
+  };
+}
+
+function mapStackItem(page: PageResponse): NotionStackItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    name: title(properties, "Name") ?? "Untitled",
+    slug: richText(properties, "Slug") ?? "",
+    description: richText(properties, "Description"),
+    image: url(properties, "Image"),
+    icon: iconUrl(page, { includeEmoji: true }),
+    url: url(properties, "URL"),
+    platforms: multiSelect(properties, "Platforms"),
+    status: select(properties, "Status"),
+    createdTime: createdTime(properties, "Created time") || page.created_time,
+    previewImage: url(properties, "Preview Image"),
+    previewImageDark: url(properties, "Preview Image Dark"),
+    previewStatus: previewStatus(properties),
+  };
+}
+
+function mapGoodWebsiteItem(page: PageResponse): GoodWebsiteItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    name: title(properties, "Name") ?? "Untitled",
+    url: url(properties, "URL"),
+    x: url(properties, "X"),
+    icon: iconUrl(page),
+    tags: multiSelect(properties, "Tags"),
+    previewImage: url(properties, "Preview Image"),
+    previewImageDark: url(properties, "Preview Image Dark"),
+    previewStatus: previewStatus(properties),
+  };
+}
+
+function mapGoodWebsiteItemWithDate(page: PageResponse): GoodWebsiteItemWithDate | null {
+  const item = mapGoodWebsiteItem(page);
+  if (!item || !isFullPage(page)) return null;
+
+  return {
+    ...item,
+    createdTime: createdTime(page.properties, "Created time") || page.created_time,
+  };
+}
+
+function mapWritingItem(page: PageResponse): NotionWritingItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    title: title(properties, "Name") ?? "Untitled",
+    slug: richText(properties, "Slug") ?? "",
+    published: dateStart(properties, "Published") || page.created_time,
+    createdTime: page.created_time,
+    shortId: richText(properties, "Short ID"),
+    excerpt: richText(properties, "Excerpt"),
+    featureImage: url(properties, "FeatureImage"),
+    source: url(properties, "URL")?.replace("https://", ""),
+  };
+}
+
+function mapAmaItem(page: PageResponse): NotionAmaItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    title: title(properties, "Name") ?? "Untitled",
+    description: richText(properties, "Description") ?? "",
+    status: select(properties, "Status") ?? "Unanswered",
+    answeredAt: dateStart(properties, "Answered At") || page.created_time,
+    createdAt: dateStart(properties, "Created At") || page.created_time,
+  };
+}
+
+function mapListeningHistoryItem(page: PageResponse): NotionListeningHistoryItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    name: title(properties, "Name") ?? "Untitled",
+    artist: richText(properties, "Artist") ?? "",
+    album: richText(properties, "Album") ?? "",
+    url: url(properties, "Spotify URL"),
+    playedAt: dateStart(properties, "Played At") || page.created_time,
+    image: iconUrl(page),
+  };
+}
+
+function mapDesignDetailsEpisode(page: PageResponse): NotionDesignDetailsEpisodeItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    title: title(properties, "Name") ?? "Untitled",
+    slug: richText(properties, "Slug") ?? "",
+    description: richText(properties, "Description"),
+    episodeNumber: number(properties, "Episode Number"),
+    publishedDate: dateStart(properties, "Published Date"),
+    imageUrl: url(properties, "Image URL"),
+    audioUrl: url(properties, "Audio URL (S3)"),
+  };
+}
+
+function mapSpeakingItem(page: PageResponse): NotionSpeakingItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    title: title(properties, "Name") ?? "Untitled",
+    date: dateStart(properties, "Date") || page.created_time,
+    href: url(properties, "URL"),
+  };
+}
+
+function mapTilItem(page: PageResponse): NotionTilItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    title: title(properties, "Title") ?? "Untitled",
+    published: dateStart(properties, "Published") || page.created_time,
+    shortId: richText(properties, "Short ID"),
+  };
+}
+
+function mapAppDissectionItem(page: PageResponse): NotionAppDissectionItem | null {
+  if (!isFullPage(page)) return null;
+  const properties = page.properties;
+
+  return {
+    id: page.id,
+    name: title(properties, "Name") ?? "Untitled",
+    slug: richText(properties, "Slug") ?? "",
+    description: "",
+    published: dateStart(properties, "Published") || page.created_time,
+    icon: url(properties, "Icon") || iconUrl(page) || "",
+    status: select(properties, "Status") ?? "Draft",
+  };
+}
+
+function parseAppDissectionDetails(blocks: ProcessedBlock[]): {
+  introBlocks: ProcessedBlock[];
+  details: AppDissectionDetail[];
+} {
+  const introBlocks: ProcessedBlock[] = [];
+  const details: AppDissectionDetail[] = [];
+
+  let currentDetail: AppDissectionDetail | null = null;
+  let inIntro = true;
+
+  for (const block of blocks) {
+    if (block.type === "divider") {
+      inIntro = false;
+      continue;
+    }
+
+    if (inIntro) {
+      introBlocks.push(block);
+      continue;
+    }
+
+    if (block.type === "heading_2") {
+      if (currentDetail) {
+        details.push(currentDetail);
+      }
+      currentDetail = {
+        title: block.content.map((c) => c.text.content).join(""),
+        descriptionBlocks: [],
+      };
+      continue;
+    }
+
+    if (block.type === "code" && block.language === "json" && currentDetail) {
+      const jsonContent = block.content.map((c) => c.text.content).join("");
+      try {
+        const parsed = JSON.parse(jsonContent);
+        if (isValidVideoMetadata(parsed)) {
+          currentDetail.video = parsed;
+        } else {
+          currentDetail.descriptionBlocks.push(block);
+        }
+      } catch {
+        currentDetail.descriptionBlocks.push(block);
+      }
+      continue;
+    }
+
+    if (currentDetail) {
+      currentDetail.descriptionBlocks.push(block);
+    }
+  }
+
+  if (currentDetail) {
+    details.push(currentDetail);
+  }
+
+  return { introBlocks, details };
+}
+
 // ===== Generic Content Retrieval =====
 
 export async function getFullContent(
@@ -54,29 +289,8 @@ export async function getFullContent(
     `notion:content:${pageId}`,
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
-
-      if (!hasProperties(page)) return null;
-
-      const pageWithProps = page as PageObjectResponse;
-      const properties = pageWithProps.properties as {
-        Name?: { title: { plain_text: string }[] };
-        Category?: { select: { name: string } | null };
-        Status?: { select: { name: string } | null };
-        Published?: { date: { start: string } | null };
-        Source?: { url: string };
-        Slug?: { rich_text: { plain_text: string }[] };
-      };
-
-      const metadata: NotionItem = {
-        id: pageWithProps.id,
-        title: properties.Name?.title[0]?.plain_text || "Untitled",
-        category: properties.Category?.select?.name || "Uncategorized",
-        status: properties.Status?.select?.name || "Draft",
-        createdTime: pageWithProps.created_time,
-        published: properties.Published?.date?.start || pageWithProps.created_time,
-        source: properties.Source?.url?.replace("https://", ""),
-        slug: properties.Slug?.rich_text[0]?.plain_text || "",
-      };
+      const metadata = mapGenericItem(page);
+      if (!metadata) return null;
 
       const blocks = await getAllBlocks(pageId);
 
@@ -104,60 +318,9 @@ export async function getStackDatabaseItems(): Promise<NotionStackItem[]> {
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-
-          // Extract icon from page object
-          const icon =
-            pageWithProps.icon?.type === "file"
-              ? pageWithProps.icon.file.url
-              : pageWithProps.icon?.type === "external"
-                ? pageWithProps.icon.external.url
-                : pageWithProps.icon?.type === "emoji"
-                  ? pageWithProps.icon.emoji
-                  : undefined;
-
-          const properties = pageWithProps.properties as {
-            Name?: { title: { plain_text: string }[] };
-            Slug?: { rich_text: { plain_text: string }[] };
-            Description?: { rich_text: { plain_text: string }[] };
-            Image?: { url: string };
-            URL?: { url: string };
-            Platforms?: { multi_select: { name: string }[] };
-            Status?: { select: { name: string } | null };
-            "Created time"?: { created_time: string };
-            "Preview Image"?: { url: string };
-            "Preview Image Dark"?: { url: string };
-            "Preview Status"?: { select: { name: string } | null };
-          };
-
-          return {
-            id: pageWithProps.id,
-            name: properties.Name?.title[0]?.plain_text || "Untitled",
-            slug: properties.Slug?.rich_text[0]?.plain_text || "",
-            description: properties.Description?.rich_text[0]?.plain_text || undefined,
-            image: properties.Image?.url || undefined,
-            icon,
-            url: properties.URL?.url || undefined,
-            platforms: properties.Platforms?.multi_select.map((p) => p.name) || [],
-            status: properties.Status?.select?.name || undefined,
-            createdTime: properties["Created time"]?.created_time || pageWithProps.created_time,
-            previewImage: properties["Preview Image"]?.url || undefined,
-            previewImageDark: properties["Preview Image Dark"]?.url || undefined,
-            previewStatus: properties["Preview Status"]?.select?.name as
-              | "Queued"
-              | "Processing"
-              | "Done"
-              | "Error"
-              | undefined,
-          } as NotionStackItem;
-        })
+      return response.results
+        .map(mapStackItem)
         .filter((item): item is NotionStackItem => item !== null);
-
-      return items;
     },
     { ttl: CACHE_TTLS.LIST },
   );
@@ -181,50 +344,9 @@ export async function getGoodWebsitesDatabaseItems(): Promise<GoodWebsiteItem[]>
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-
-          // Extract icon from page object
-          const icon =
-            pageWithProps.icon?.type === "file"
-              ? pageWithProps.icon.file.url
-              : pageWithProps.icon?.type === "external"
-                ? pageWithProps.icon.external.url
-                : undefined;
-
-          const properties = pageWithProps.properties as {
-            Name?: { title: { plain_text: string }[] };
-            URL?: { url: string };
-            X?: { url: string };
-            Tags?: { multi_select: { name: string }[] };
-            "Preview Image"?: { url: string };
-            "Preview Image Dark"?: { url: string };
-            "Preview Status"?: { select: { name: string } | null };
-          };
-
-          return {
-            id: pageWithProps.id,
-            name: properties.Name?.title[0]?.plain_text || "Untitled",
-            url: properties.URL?.url || undefined,
-            x: properties.X?.url || undefined,
-            icon,
-            tags: properties.Tags?.multi_select.map((t) => t.name) || [],
-            previewImage: properties["Preview Image"]?.url || undefined,
-            previewImageDark: properties["Preview Image Dark"]?.url || undefined,
-            previewStatus: properties["Preview Status"]?.select?.name as
-              | "Queued"
-              | "Processing"
-              | "Done"
-              | "Error"
-              | undefined,
-          } as GoodWebsiteItem;
-        })
+      return response.results
+        .map(mapGoodWebsiteItem)
         .filter((item): item is GoodWebsiteItem => item !== null);
-
-      return items;
     },
     { ttl: CACHE_TTLS.LIST },
   );
@@ -246,51 +368,9 @@ export async function getGoodWebsitesDatabaseItemsForRss(): Promise<GoodWebsiteI
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-
-          const icon =
-            pageWithProps.icon?.type === "file"
-              ? pageWithProps.icon.file.url
-              : pageWithProps.icon?.type === "external"
-                ? pageWithProps.icon.external.url
-                : undefined;
-
-          const properties = pageWithProps.properties as {
-            Name?: { title: { plain_text: string }[] };
-            URL?: { url: string };
-            X?: { url: string };
-            Tags?: { multi_select: { name: string }[] };
-            "Preview Image"?: { url: string };
-            "Preview Image Dark"?: { url: string };
-            "Preview Status"?: { select: { name: string } | null };
-            "Created time"?: { created_time: string };
-          };
-
-          return {
-            id: pageWithProps.id,
-            name: properties.Name?.title[0]?.plain_text || "Untitled",
-            url: properties.URL?.url || undefined,
-            x: properties.X?.url || undefined,
-            icon,
-            tags: properties.Tags?.multi_select.map((t) => t.name) || [],
-            previewImage: properties["Preview Image"]?.url || undefined,
-            previewImageDark: properties["Preview Image Dark"]?.url || undefined,
-            previewStatus: properties["Preview Status"]?.select?.name as
-              | "Queued"
-              | "Processing"
-              | "Done"
-              | "Error"
-              | undefined,
-            createdTime: properties["Created time"]?.created_time || pageWithProps.created_time,
-          } as GoodWebsiteItemWithDate;
-        })
+      return response.results
+        .map(mapGoodWebsiteItemWithDate)
         .filter((item): item is GoodWebsiteItemWithDate => item !== null);
-
-      return items;
     },
     { ttl: CACHE_TTLS.LIST },
   );
@@ -301,7 +381,7 @@ export async function getGoodWebsitesDatabaseItemsForRss(): Promise<GoodWebsiteI
 export async function getWritingDatabaseItems(
   cursor?: string,
   pageSize: number = 20,
-): Promise<{ items: NotionItem[]; nextCursor: string | null }> {
+): Promise<{ items: NotionWritingItem[]; nextCursor: string | null }> {
   return cachedNotionQuery(
     `notion:writing:list:${cursor || "start"}:${pageSize}`,
     async () => {
@@ -325,37 +405,10 @@ export async function getWritingDatabaseItems(
         ],
       });
 
-      const items = response.results.map((page) => {
-        if (!hasProperties(page)) return null;
-
-        const pageWithProps = page as PageObjectResponse;
-        const properties = pageWithProps.properties as {
-          Name?: { title: { plain_text: string }[] };
-          Published?: { date: { start: string } | null };
-          URL?: { url: string };
-          Slug?: { rich_text: { plain_text: string }[] };
-          "Short ID"?: { rich_text: { plain_text: string }[] };
-          Excerpt?: { rich_text: { plain_text: string }[] };
-          FeatureImage?: { url: string };
-        };
-
-        return {
-          id: pageWithProps.id,
-          title: properties.Name?.title[0]?.plain_text || "Untitled",
-          category: "Writing",
-          status: "Published",
-          createdTime: pageWithProps.created_time,
-          published: properties.Published?.date?.start || pageWithProps.created_time,
-          source: properties.URL?.url?.replace("https://", ""),
-          slug: properties.Slug?.rich_text[0]?.plain_text || "",
-          shortId: properties["Short ID"]?.rich_text[0]?.plain_text || undefined,
-          excerpt: properties.Excerpt?.rich_text[0]?.plain_text || "",
-          featureImage: properties.FeatureImage?.url || undefined,
-        } as NotionItem;
-      });
-
       return {
-        items: items.filter((item): item is NotionItem => item !== null),
+        items: response.results
+          .map(mapWritingItem)
+          .filter((item): item is NotionWritingItem => item !== null),
         nextCursor: response.has_more ? (response.next_cursor as string) : null,
       };
     },
@@ -365,38 +418,13 @@ export async function getWritingDatabaseItems(
 
 export async function getWritingPostContent(
   pageId: string,
-): Promise<{ blocks: ProcessedBlock[]; metadata: NotionItem } | null> {
+): Promise<{ blocks: ProcessedBlock[]; metadata: NotionWritingItem } | null> {
   return cachedNotionQuery(
     `notion:writing:content:${pageId}`,
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
-
-      if (!hasProperties(page)) return null;
-
-      const pageWithProps = page as PageObjectResponse;
-      const properties = pageWithProps.properties as {
-        Name?: { title: { plain_text: string }[] };
-        Published?: { date: { start: string } | null };
-        URL?: { url: string };
-        Slug?: { rich_text: { plain_text: string }[] };
-        "Short ID"?: { rich_text: { plain_text: string }[] };
-        Excerpt?: { rich_text: { plain_text: string }[] };
-        FeatureImage?: { url: string };
-      };
-
-      const metadata: NotionItem = {
-        id: pageWithProps.id,
-        title: properties.Name?.title[0]?.plain_text || "Untitled",
-        category: "Writing",
-        status: "Published",
-        createdTime: pageWithProps.created_time,
-        published: properties.Published?.date?.start || pageWithProps.created_time,
-        source: properties.URL?.url?.replace("https://", ""),
-        slug: properties.Slug?.rich_text[0]?.plain_text || "",
-        shortId: properties["Short ID"]?.rich_text[0]?.plain_text || undefined,
-        excerpt: properties.Excerpt?.rich_text[0]?.plain_text || "",
-        featureImage: properties.FeatureImage?.url || undefined,
-      };
+      const metadata = mapWritingItem(page);
+      if (!metadata) return null;
 
       const blocks = await getAllBlocks(pageId);
 
@@ -408,7 +436,7 @@ export async function getWritingPostContent(
 
 export async function getWritingPostContentBySlug(
   slug: string,
-): Promise<{ blocks: ProcessedBlock[]; metadata: NotionItem } | null> {
+): Promise<{ blocks: ProcessedBlock[]; metadata: NotionWritingItem } | null> {
   return cachedNotionQuery(
     `notion:writing:content:slug:${slug}`,
     async () => {
@@ -429,7 +457,7 @@ export async function getWritingPostContentBySlug(
       }
 
       const page = response.results[0];
-      if (!hasProperties(page)) return null;
+      if (!isFullPage(page)) return null;
 
       return getWritingPostContent(page.id);
     },
@@ -439,7 +467,7 @@ export async function getWritingPostContentBySlug(
 
 export async function getWritingPostByShortId(
   shortId: string,
-): Promise<{ blocks: ProcessedBlock[]; metadata: NotionItem } | null> {
+): Promise<{ blocks: ProcessedBlock[]; metadata: NotionWritingItem } | null> {
   return cachedNotionQuery(
     `notion:writing:content:shortid:${shortId}`,
     async () => {
@@ -460,7 +488,7 @@ export async function getWritingPostByShortId(
       }
 
       const page = response.results[0];
-      if (!hasProperties(page)) return null;
+      if (!isFullPage(page)) return null;
 
       return getWritingPostContent(page.id);
     },
@@ -475,31 +503,19 @@ export async function getAmaItemContent(pageId: string): Promise<NotionAmaItemWi
     `notion:ama:content:${pageId}`,
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
+      const item = mapAmaItem(page);
+      if (!item) return null;
 
-      if (!hasProperties(page)) return null;
-
-      const pageWithProps = page as PageObjectResponse;
-      const properties = pageWithProps.properties as {
-        Name?: { title: { plain_text: string }[] };
-        Description?: { rich_text: { plain_text: string }[] };
-        Status?: { select: { name: string } | null };
-        "Answered At"?: { date: { start: string } | null };
-        "Created At"?: { date: { start: string } | null };
-      };
-
-      const item: NotionAmaItem = {
-        id: pageWithProps.id,
-        title: properties.Name?.title[0]?.plain_text || "Untitled",
-        description: properties.Description?.rich_text[0]?.plain_text || null,
-        status: properties.Status?.select?.name || "Unanswered",
-        answeredAt: properties["Answered At"]?.date?.start || pageWithProps.created_time,
-        createdAt: properties["Created At"]?.date?.start || pageWithProps.created_time,
-      };
+      // List mapper uses "" for a missing description; content keeps null.
+      const description = isFullPage(page)
+        ? (richText(page.properties, "Description") ?? null)
+        : null;
 
       const blocks = await getAllBlocks(pageId);
 
       return {
         ...item,
+        description,
         blocks,
       };
     },
@@ -534,34 +550,10 @@ export async function getAmaDatabaseItems(
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-          const properties = pageWithProps.properties as {
-            Name?: { title: { plain_text: string }[] };
-            Description?: { rich_text: { plain_text: string }[] };
-            Status?: { select: { name: string } | null };
-            "Answered At"?: { date: { start: string } | null };
-            "Created At"?: { date: { start: string } | null };
-          };
-
-          const basicItem: NotionAmaItem = {
-            id: pageWithProps.id,
-            title: properties.Name?.title[0]?.plain_text || "Untitled",
-            description: properties.Description?.rich_text[0]?.plain_text || "",
-            status: properties.Status?.select?.name || "Unanswered",
-            answeredAt: properties["Answered At"]?.date?.start || pageWithProps.created_time,
-            createdAt: properties["Created At"]?.date?.start || pageWithProps.created_time,
-          };
-
-          return basicItem;
-        })
-        .filter((item): item is NotionAmaItem => item !== null);
-
       return {
-        items,
+        items: response.results
+          .map(mapAmaItem)
+          .filter((item): item is NotionAmaItem => item !== null),
         nextCursor: response.has_more ? (response.next_cursor as string) : null,
       };
     },
@@ -592,40 +584,10 @@ export async function getListeningHistoryDatabaseItems(
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithIcon = page as PageObjectResponse;
-          const icon =
-            pageWithIcon.icon?.type === "file"
-              ? pageWithIcon.icon.file.url
-              : pageWithIcon.icon?.type === "external"
-                ? pageWithIcon.icon.external.url
-                : undefined;
-
-          const properties = pageWithIcon.properties as {
-            Name?: { title: { plain_text: string }[] };
-            Artist?: { rich_text: { plain_text: string }[] };
-            Album?: { rich_text: { plain_text: string }[] };
-            "Spotify URL"?: { url: string };
-            "Played At"?: { date: { start: string } | null };
-          };
-
-          return {
-            id: pageWithIcon.id,
-            name: properties.Name?.title[0]?.plain_text || "Untitled",
-            artist: properties.Artist?.rich_text[0]?.plain_text || "",
-            album: properties.Album?.rich_text[0]?.plain_text || "",
-            url: properties["Spotify URL"]?.url || undefined,
-            playedAt: properties["Played At"]?.date?.start || pageWithIcon.created_time,
-            image: icon,
-          } as NotionListeningHistoryItem;
-        })
-        .filter((item): item is NotionListeningHistoryItem => item !== null);
-
       return {
-        items,
+        items: response.results
+          .map(mapListeningHistoryItem)
+          .filter((item): item is NotionListeningHistoryItem => item !== null),
         nextCursor: response.has_more ? (response.next_cursor as string) : null,
       };
     },
@@ -656,36 +618,10 @@ export async function getDesignDetailsEpisodeDatabaseItems(
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-          const properties = pageWithProps.properties as {
-            Name?: { title: { plain_text: string }[] };
-            Slug?: { rich_text: { plain_text: string }[] };
-            Description?: { rich_text: { plain_text: string }[] };
-            "Episode Number"?: { number: number };
-            "Published Date"?: { date: { start: string } | null };
-            "Image URL"?: { url: string };
-            "Audio URL (S3)"?: { url: string };
-          };
-
-          return {
-            id: pageWithProps.id,
-            title: properties.Name?.title[0]?.plain_text || "Untitled",
-            slug: properties.Slug?.rich_text[0]?.plain_text || "",
-            description: properties.Description?.rich_text[0]?.plain_text || undefined,
-            episodeNumber: properties["Episode Number"]?.number || undefined,
-            publishedDate: properties["Published Date"]?.date?.start || undefined,
-            imageUrl: properties["Image URL"]?.url || undefined,
-            audioUrl: properties["Audio URL (S3)"]?.url || undefined,
-          } as NotionDesignDetailsEpisodeItem;
-        })
-        .filter((item): item is NotionDesignDetailsEpisodeItem => item !== null);
-
       return {
-        items,
+        items: response.results
+          .map(mapDesignDetailsEpisode)
+          .filter((item): item is NotionDesignDetailsEpisodeItem => item !== null),
         nextCursor: response.has_more ? (response.next_cursor as string) : null,
       };
     },
@@ -711,27 +647,9 @@ export async function getSpeakingItems(): Promise<NotionSpeakingItem[]> {
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-          const properties = pageWithProps.properties as {
-            Name?: { title: { plain_text: string }[] };
-            Date?: { date: { start: string } | null };
-            URL?: { url: string };
-          };
-
-          return {
-            id: pageWithProps.id,
-            title: properties.Name?.title[0]?.plain_text || "Untitled",
-            date: properties.Date?.date?.start || pageWithProps.created_time,
-            href: properties.URL?.url || undefined,
-          } as NotionSpeakingItem;
-        })
+      return response.results
+        .map(mapSpeakingItem)
         .filter((item): item is NotionSpeakingItem => item !== null);
-
-      return items;
     },
     { ttl: CACHE_TTLS.LIST },
   );
@@ -766,28 +684,10 @@ export async function getTilDatabaseItems(
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-          const properties = pageWithProps.properties as {
-            Title?: { title: { plain_text: string }[] };
-            Published?: { date: { start: string } | null };
-            "Short ID"?: { rich_text: { plain_text: string }[] };
-          };
-
-          return {
-            id: pageWithProps.id,
-            title: properties.Title?.title.map((t) => t.plain_text).join("") || "Untitled",
-            published: properties.Published?.date?.start || pageWithProps.created_time,
-            shortId: properties["Short ID"]?.rich_text[0]?.plain_text || undefined,
-          } as NotionTilItem;
-        })
-        .filter((item): item is NotionTilItem => item !== null);
-
       return {
-        items,
+        items: response.results
+          .map(mapTilItem)
+          .filter((item): item is NotionTilItem => item !== null),
         nextCursor: response.has_more ? (response.next_cursor as string) : null,
       };
     },
@@ -800,22 +700,8 @@ export async function getTilItemContent(pageId: string): Promise<NotionTilItemWi
     `notion:til:content:${pageId}`,
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
-
-      if (!hasProperties(page)) return null;
-
-      const pageWithProps = page as PageObjectResponse;
-      const properties = pageWithProps.properties as {
-        Title?: { title: { plain_text: string }[] };
-        Published?: { date: { start: string } | null };
-        "Short ID"?: { rich_text: { plain_text: string }[] };
-      };
-
-      const item: NotionTilItem = {
-        id: pageWithProps.id,
-        title: properties.Title?.title.map((t) => t.plain_text).join("") || "Untitled",
-        published: properties.Published?.date?.start || pageWithProps.created_time,
-        shortId: properties["Short ID"]?.rich_text[0]?.plain_text || undefined,
-      };
+      const item = mapTilItem(page);
+      if (!item) return null;
 
       const blocks = await getAllBlocks(pageId);
 
@@ -849,7 +735,7 @@ export async function getTilByShortId(shortId: string): Promise<NotionTilItemWit
       }
 
       const page = response.results[0];
-      if (!hasProperties(page)) return null;
+      if (!isFullPage(page)) return null;
 
       return getTilItemContent(page.id);
     },
@@ -881,40 +767,9 @@ export async function getAppDissectionDatabaseItems(): Promise<NotionAppDissecti
         ],
       });
 
-      const items = response.results
-        .map((page) => {
-          if (!hasProperties(page)) return null;
-
-          const pageWithProps = page as PageObjectResponse;
-
-          const icon =
-            pageWithProps.icon?.type === "file"
-              ? pageWithProps.icon.file.url
-              : pageWithProps.icon?.type === "external"
-                ? pageWithProps.icon.external.url
-                : "";
-
-          const properties = pageWithProps.properties as {
-            Name?: { title: { plain_text: string }[] };
-            Slug?: { rich_text: { plain_text: string }[] };
-            Published?: { date: { start: string } | null };
-            Icon?: { url: string };
-            Status?: { select: { name: string } | null };
-          };
-
-          return {
-            id: pageWithProps.id,
-            name: properties.Name?.title[0]?.plain_text || "Untitled",
-            slug: properties.Slug?.rich_text[0]?.plain_text || "",
-            description: "",
-            published: properties.Published?.date?.start || pageWithProps.created_time,
-            icon: properties.Icon?.url || icon,
-            status: properties.Status?.select?.name || "Draft",
-          } as NotionAppDissectionItem;
-        })
+      return response.results
+        .map(mapAppDissectionItem)
         .filter((item): item is NotionAppDissectionItem => item !== null);
-
-      return items;
     },
     { ttl: CACHE_TTLS.LIST },
   );
@@ -953,89 +808,14 @@ export async function getAppDissectionItemBySlug(
       }
 
       const page = response.results[0];
-      if (!hasProperties(page)) return null;
+      const item = mapAppDissectionItem(page);
+      if (!item) return null;
 
-      const pageWithProps = page as PageObjectResponse;
-
-      const icon =
-        pageWithProps.icon?.type === "file"
-          ? pageWithProps.icon.file.url
-          : pageWithProps.icon?.type === "external"
-            ? pageWithProps.icon.external.url
-            : "";
-
-      const properties = pageWithProps.properties as {
-        Name?: { title: { plain_text: string }[] };
-        Slug?: { rich_text: { plain_text: string }[] };
-        Published?: { date: { start: string } | null };
-        Icon?: { url: string };
-        Status?: { select: { name: string } | null };
-      };
-
-      // Get all blocks from the page
       const blocks = await getAllBlocks(page.id);
-
-      // Parse blocks into intro and detail sections
-      const introBlocks: ProcessedBlock[] = [];
-      const details: AppDissectionDetail[] = [];
-
-      let currentDetail: AppDissectionDetail | null = null;
-      let inIntro = true;
-
-      for (const block of blocks) {
-        if (block.type === "divider") {
-          inIntro = false;
-          continue;
-        }
-
-        if (inIntro) {
-          introBlocks.push(block);
-          continue;
-        }
-
-        if (block.type === "heading_2") {
-          if (currentDetail) {
-            details.push(currentDetail);
-          }
-          currentDetail = {
-            title: block.content.map((c) => c.text.content).join(""),
-            descriptionBlocks: [],
-          };
-          continue;
-        }
-
-        if (block.type === "code" && block.language === "json" && currentDetail) {
-          const jsonContent = block.content.map((c) => c.text.content).join("");
-          try {
-            const parsed = JSON.parse(jsonContent);
-            if (isValidVideoMetadata(parsed)) {
-              currentDetail.video = parsed;
-            } else {
-              currentDetail.descriptionBlocks.push(block);
-            }
-          } catch {
-            currentDetail.descriptionBlocks.push(block);
-          }
-          continue;
-        }
-
-        if (currentDetail) {
-          currentDetail.descriptionBlocks.push(block);
-        }
-      }
-
-      if (currentDetail) {
-        details.push(currentDetail);
-      }
+      const { introBlocks, details } = parseAppDissectionDetails(blocks);
 
       return {
-        id: pageWithProps.id,
-        name: properties.Name?.title[0]?.plain_text || "Untitled",
-        slug: properties.Slug?.rich_text[0]?.plain_text || "",
-        description: "",
-        published: properties.Published?.date?.start || pageWithProps.created_time,
-        icon: properties.Icon?.url || icon,
-        status: properties.Status?.select?.name || "Draft",
+        ...item,
         introBlocks,
         details,
       };

--- a/src/lib/notion/types.ts
+++ b/src/lib/notion/types.ts
@@ -9,26 +9,6 @@ import type {
   RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints";
 
-// Re-export generated Zod schemas and types
-export {
-  type AMA,
-  AMASchema,
-  type DesignDetailsEpisodes,
-  DesignDetailsEpisodesSchema,
-  type GoodWebsites,
-  GoodWebsitesSchema,
-  type Music,
-  MusicSchema,
-  type Speaking,
-  SpeakingSchema,
-  type Stack,
-  StackSchema,
-  type TIL,
-  TILSchema,
-  type Writing,
-  WritingSchema,
-} from "../../../schemas/notionSchemas";
-
 // Re-export commonly used Notion SDK types
 export type {
   BlockObjectResponse,
@@ -38,6 +18,9 @@ export type {
   PartialPageObjectResponse,
   RichTextItemResponse,
 };
+
+export const PREVIEW_STATUSES = ["Queued", "Processing", "Done", "Error", "Pending"] as const;
+export type PreviewStatus = (typeof PREVIEW_STATUSES)[number];
 
 // Type for any page response (full or partial) - includes data source types for v5 SDK
 export type PageResponse =
@@ -80,7 +63,8 @@ export type ProcessedBlock = {
   children?: ProcessedBlock[];
 };
 
-// Generic Notion item metadata
+// Generic page metadata for getFullContent / useNotion. Collection-specific
+// records (writing, stack, …) live in their own types below.
 export type NotionItem = {
   id: string;
   title: string;
@@ -88,12 +72,20 @@ export type NotionItem = {
   status: string;
   createdTime: string;
   published?: string;
-  previewBlocks?: ProcessedBlock[];
   source?: string;
   slug?: string;
+};
+
+export type NotionWritingItem = {
+  id: string;
+  title: string;
+  slug: string;
+  published: string;
+  createdTime: string;
   shortId?: string;
   excerpt?: string;
   featureImage?: string;
+  source?: string;
 };
 
 // Stack item type
@@ -110,7 +102,7 @@ export type NotionStackItem = {
   createdTime: string;
   previewImage?: string;
   previewImageDark?: string;
-  previewStatus?: "Queued" | "Processing" | "Done" | "Error";
+  previewStatus?: PreviewStatus;
 };
 
 // Good Website item type
@@ -122,7 +114,8 @@ export type GoodWebsiteItem = {
   icon?: string;
   tags?: string[];
   previewImage?: string;
-  previewStatus?: "Queued" | "Processing" | "Done" | "Error";
+  previewImageDark?: string;
+  previewStatus?: PreviewStatus;
 };
 
 // Good Website item type with date for RSS feed
@@ -220,6 +213,10 @@ export function hasProperties(
   page: PageResponse,
 ): page is PageObjectResponse | PartialPageObjectResponse {
   return "properties" in page;
+}
+
+export function isFullPage(page: PageResponse): page is PageObjectResponse {
+  return page.object === "page" && "properties" in page && "created_time" in page;
 }
 
 // Type guard for BlockObjectResponse

--- a/src/lib/stack.ts
+++ b/src/lib/stack.ts
@@ -1,24 +1,9 @@
-import { getStackDatabaseItems } from "@/lib/notion";
+import { getStackDatabaseItems, type NotionStackItem } from "@/lib/notion";
 
-export type StackItem = {
-  id: string;
-  slug: string;
-  name: string;
-  description?: string;
-  image?: string;
-  icon?: string;
-  url?: string;
-  platforms?: string[];
-  status?: string;
-  createdTime: string;
-  previewImage?: string;
-  previewImageDark?: string;
-  previewStatus?: "Queued" | "Processing" | "Done" | "Error";
-};
+export type StackItem = NotionStackItem;
 
 export async function getStacks(): Promise<StackItem[]> {
-  const items = await getStackDatabaseItems();
-  return items as StackItem[];
+  return getStackDatabaseItems();
 }
 
 export async function getStackBySlug(slug: string): Promise<StackItem | undefined> {

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -1,20 +1,20 @@
 import { cache } from "react";
 
 import { InfiniteScrollPage, useInfiniteScroll } from "@/hooks/useInfiniteScroll";
-import { getWritingDatabaseItems, NotionItem } from "@/lib/notion";
+import { getWritingDatabaseItems, NotionWritingItem } from "@/lib/notion";
 
-export type WritingPage = InfiniteScrollPage<NotionItem>;
+export type WritingPage = InfiniteScrollPage<NotionWritingItem>;
 
 export function useWritingPosts() {
-  return useInfiniteScroll<NotionItem>((index: number, previousPage: WritingPage | null) => {
+  return useInfiniteScroll<NotionWritingItem>((index: number, previousPage: WritingPage | null) => {
     if (previousPage && !previousPage.nextCursor) return null;
     if (index === 0) return `/api/writing?limit=20`;
     return `/api/writing?cursor=${previousPage?.nextCursor}&limit=20`;
   });
 }
 
-async function fetchAllWritingPosts(): Promise<NotionItem[]> {
-  let allPosts: NotionItem[] = [];
+async function fetchAllWritingPosts(): Promise<NotionWritingItem[]> {
+  let allPosts: NotionWritingItem[] = [];
   let cursor: string | undefined;
   let hasMore = true;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slice A of the read-only Notion structure audit: one owned domain record per collection, plus a shared property-reader module so query mappers stop recasting nested API blobs.

- Added `src/lib/notion/properties.ts` readers (and small writers) that know each Notion wire shape once. Title keys are passed in — TIL still uses `Title`, everyone else uses `Name`.
- Query mappers in `src/lib/notion/queries.ts` are now field lists over those readers. No more `properties as { Name?: { title: … } }` blobs or `as NotionStackItem` / `as GoodWebsiteItem` casts.
- Introduced `NotionWritingItem` (required `slug` / `published`, optional `shortId` / `excerpt` / `featureImage`). Slimmed `NotionItem` for `getFullContent` / `useNotion` by dropping unused `previewBlocks` and writing-only fields.
- Aligned `previewStatus` with the real select (`Pending` included). Added `previewImageDark` on the canonical sites type.
- Stopped re-exporting generated Zod names (`Stack`, `Writing`, `*Schema`, …) from `@/lib/notion`. JSON snapshots in `schemas/` stay as generate-time drift artifacts. App Dissection is now on the generator list with a snapshot.
- S02 adapters alias S01 types (`StackItem = NotionStackItem`, same for music / design-details / sites) and no longer `as`-cast arrays.

## Test plan

- [x] `bun test` (88 passing, including new `properties.test.ts`)
- [x] `bun run lint:fix` / `bunx tsc --noEmit`
- [x] Grep: no `as StackItem[]` / `as MusicItem[]` / `as GoodWebsiteItem[]` / `as DesignDetailsEpisode[]` in S02 adapters
- [x] Grep: production app code no longer imports generated `Stack` / `Writing` / `*Schema` from `@/lib/notion`
- [x] Live smoke reads (field presence only) for writing, stack, sites, music, design-details, AMA, TIL, speaking, and app dissection — required fields still populate

## Follow-ups (out of scope)

- `useNotion` still types `{ metadata: NotionItem }` for the generic content endpoint. Writing pages now use `NotionWritingItem`.
- `/api/writing` no longer emits the hardcoded `category: "Writing"` / `status: "Published"` fields (they were not Notion properties).
- App Dissection `description` is still an empty string; the live DB has `Tint` but nothing reads it yet.
- Do not change Redis/cache keys in this PR (`ProcessedBlock` is unchanged).
- Later slices: likes, HN, purge, chrome.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13704fb1-0e26-4394-8b18-b828c8a90867?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13704fb1-0e26-4394-8b18-b828c8a90867&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

