### PR TITLE
Split likes SSR count from viewer overlay; drop users set

### DIFF
--- a/scripts/scan-abandoned-likes-users.ts
+++ b/scripts/scan-abandoned-likes-users.ts
@@ -1,0 +1,31 @@
+/**
+ * Dry-run: list leftover `likes:users:*` keys.
+ * Does not delete. Historical membership sets were abandoned in the S07 likes model.
+ *
+ * Usage: bun scripts/scan-abandoned-likes-users.ts
+ */
+import { Redis } from "@upstash/redis";
+
+const url = process.env.UPSTASH_LIKES_REST_URL;
+const token = process.env.UPSTASH_LIKES_REST_TOKEN;
+
+if (!url || !token) {
+  console.error("UPSTASH_LIKES_REST_URL and UPSTASH_LIKES_REST_TOKEN are required.");
+  process.exit(1);
+}
+
+const redis = new Redis({ url, token });
+const pattern = "likes:users:*";
+const keys: string[] = [];
+let cursor = 0;
+
+do {
+  const [nextCursor, batch] = await redis.scan(cursor, { match: pattern, count: 100 });
+  cursor = Number(nextCursor);
+  keys.push(...batch);
+} while (cursor !== 0);
+
+console.log(`Found ${keys.length} abandoned ${pattern} key(s).`);
+for (const key of keys) {
+  console.log(key);
+}

--- a/src/app/api/likes/[id]/route.ts
+++ b/src/app/api/likes/[id]/route.ts
@@ -8,7 +8,6 @@ import {
   getLikeCount,
   getMaxLikesPerUser,
   getUserLikeCount,
-  hasUserLiked,
   removeLike,
 } from "@/lib/likes-redis";
 import { getClientIp, hashUserIp } from "@/lib/user-hash";
@@ -25,19 +24,11 @@ export async function GET(request: Request, props: { params: Promise<{ id: strin
     const ip = getClientIp(request);
     const userId = hashUserIp(ip);
 
-    const [count, userLikes, hasLiked] = await Promise.all([
-      getLikeCount(id),
-      getUserLikeCount(userId, id),
-      hasUserLiked(userId, id),
-    ]);
-
-    const maxLikes = getMaxLikesPerUser();
+    const [count, userLikes] = await Promise.all([getLikeCount(id), getUserLikeCount(userId, id)]);
 
     return NextResponse.json({
       count,
       userLikes,
-      hasLiked,
-      canLike: userLikes < maxLikes,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -75,8 +66,6 @@ export async function POST(request: Request, props: { params: Promise<{ id: stri
     return NextResponse.json({
       count: newCount,
       userLikes: userLikes + 1,
-      hasLiked: true,
-      canLike: userLikes + 1 < maxLikes,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -109,13 +98,10 @@ export async function DELETE(request: Request, props: { params: Promise<{ id: st
 
     // Remove the like
     const { count: newCount, userLikes: newUserLikes } = await removeLike(userId, id);
-    const maxLikes = getMaxLikesPerUser();
 
     return NextResponse.json({
       count: newCount,
       userLikes: newUserLikes,
-      hasLiked: newUserLikes > 0,
-      canLike: newUserLikes < maxLikes,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/src/app/api/likes/batch/route.ts
+++ b/src/app/api/likes/batch/route.ts
@@ -36,16 +36,7 @@ export async function GET(request: Request) {
 
     const likeData = await getBatchUserLikeData(userId, pageIds);
 
-    // Convert Map to object for JSON serialization
-    const result: Record<
-      string,
-      { count: number; userLikes: number; hasLiked: boolean; canLike: boolean }
-    > = {};
-    likeData.forEach((data, pageId) => {
-      result[pageId] = data;
-    });
-
-    return NextResponse.json(result);
+    return NextResponse.json(Object.fromEntries(likeData));
   } catch (error) {
     if (error instanceof z.ZodError) {
       return errorResponse("Invalid request parameters", 400);

--- a/src/app/design-details/[id]/page.tsx
+++ b/src/app/design-details/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
-import { getServerLikes, type LikeData } from "@/lib/likes-server";
+import { getServerLikes, type LikeCount } from "@/lib/likes-server";
 import { getFullContent } from "@/lib/notion";
 
 export default function EpisodePage(props: { params: Promise<{ id: string }> }) {
@@ -32,13 +32,13 @@ async function EpisodeContent(props: { params: Promise<{ id: string }> }) {
   // Likes are non-essential — if the fetch fails, render zero counts instead
   // of crashing the whole page. The client-side BatchLikesProvider will
   // refresh the real count after hydration.
-  let initialLikes: Record<string, LikeData>;
+  let initialLikes: Record<string, LikeCount>;
   try {
     initialLikes = await getServerLikes([metadata.id]);
   } catch (err) {
     console.error(`[design-details] getServerLikes failed for ${metadata.id}:`, err);
     initialLikes = {
-      [metadata.id]: { count: 0, userLikes: 0, hasLiked: false, canLike: true },
+      [metadata.id]: { count: 0 },
     };
   }
 

--- a/src/components/TilFeed.tsx
+++ b/src/components/TilFeed.tsx
@@ -9,14 +9,14 @@ import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
 import { fetcher } from "@/lib/fetcher";
-import type { LikeData } from "@/lib/hooks/useLikes";
+import type { LikeCount } from "@/lib/hooks/useLikes";
 import type { NotionTilItem, NotionTilItemWithContent } from "@/lib/notion";
 import { buildSlug } from "@/lib/short-id";
 import { useTilEntries } from "@/lib/til";
 
 interface TilFeedProps {
   initialEntries: NotionTilItemWithContent[];
-  initialLikes?: Record<string, LikeData>;
+  initialLikes?: Record<string, LikeCount>;
 }
 
 function formatDate(dateString: string) {

--- a/src/components/good-websites/GoodWebsiteGalleryItem.tsx
+++ b/src/components/good-websites/GoodWebsiteGalleryItem.tsx
@@ -27,7 +27,7 @@ export function GoodWebsiteGalleryItem({ item }: GoodWebsiteGalleryItemProps) {
     isCached ? "loaded" : "loading",
   );
   const [isHovered, setIsHovered] = useState(false);
-  const { hasLiked } = useLikes(item.id);
+  const { userLikes } = useLikes(item.id);
 
   // Preload image using Image API to avoid broken image flicker
   useEffect(() => {
@@ -107,7 +107,7 @@ export function GoodWebsiteGalleryItem({ item }: GoodWebsiteGalleryItemProps) {
           </div>
           {/* Desktop: permanently visible if liked, otherwise animated on hover */}
           <div className="hidden sm:block">
-            {hasLiked ? (
+            {userLikes > 0 ? (
               <LikeButton pageId={item.id} variant="ghost-light" />
             ) : (
               <AnimatePresence>

--- a/src/components/good-websites/GoodWebsitesPageClient.tsx
+++ b/src/components/good-websites/GoodWebsitesPageClient.tsx
@@ -20,7 +20,7 @@ import { LoadingSpinner, PreviewCardProvider, PreviewCardTrigger } from "@/compo
 import { TableSortHeader } from "@/components/ui/TableSortHeader";
 import type { GoodWebsiteItem } from "@/lib/goodWebsites";
 import { useGoodWebsites } from "@/lib/hooks/useGoodWebsites";
-import type { LikeData } from "@/lib/hooks/useLikes";
+import type { LikeCount } from "@/lib/hooks/useLikes";
 
 import { Linked } from "../icons/Linked";
 import { XIcon } from "../icons/SocialIcons";
@@ -28,7 +28,7 @@ import { useTopBarActions } from "../TopBarActions";
 
 interface GoodWebsitesPageClientProps {
   initialData: GoodWebsiteItem[];
-  initialLikes?: Record<string, LikeData>;
+  initialLikes?: Record<string, LikeCount>;
 }
 
 // Hydration check using useSyncExternalStore to avoid layout flicker

--- a/src/components/likes/BatchLikesProvider.tsx
+++ b/src/components/likes/BatchLikesProvider.tsx
@@ -2,18 +2,18 @@
 
 import { ReactNode, useEffect, useMemo, useState } from "react";
 
-import { BatchLikesContext, type LikeData } from "@/lib/hooks/useLikes";
+import { BatchLikesContext, type LikeCount, type LikeData } from "@/lib/hooks/useLikes";
 
 interface BatchLikesProviderProps {
   pageIds: string[];
-  initialData?: Record<string, LikeData>;
+  initialData?: Record<string, LikeCount>;
   children: ReactNode;
 }
 
 export function BatchLikesProvider({ pageIds, initialData, children }: BatchLikesProviderProps) {
-  const [fetchedData, setFetchedData] = useState<Record<string, LikeData>>({});
+  const [viewer, setViewer] = useState<Record<string, LikeData> | null>(null);
 
-  // Always fetch user-specific data client-side (SSR only provides counts)
+  // Always fetch viewer overlay client-side (SSR only provides counts)
   useEffect(() => {
     if (pageIds.length === 0) return;
 
@@ -26,7 +26,7 @@ export function BatchLikesProvider({ pageIds, initialData, children }: BatchLike
         });
         if (res.ok) {
           const data: Record<string, LikeData> = await res.json();
-          setFetchedData(data);
+          setViewer(data);
         }
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") return;
@@ -39,12 +39,12 @@ export function BatchLikesProvider({ pageIds, initialData, children }: BatchLike
     return () => controller.abort();
   }, [pageIds]);
 
-  // Use fetched data (has user-specific info) if available, fall back to SSR counts
   const contextValue = useMemo(
     () => ({
-      initialData: Object.keys(fetchedData).length > 0 ? fetchedData : (initialData ?? {}),
+      counts: initialData ?? {},
+      viewer,
     }),
-    [initialData, fetchedData],
+    [initialData, viewer],
   );
 
   return <BatchLikesContext.Provider value={contextValue}>{children}</BatchLikesContext.Provider>;

--- a/src/components/likes/LikeButton.tsx
+++ b/src/components/likes/LikeButton.tsx
@@ -84,7 +84,7 @@ function generateParticles(intensity: number) {
 }
 
 export function LikeButton({ pageId, className, variant = "default" }: LikeButtonProps) {
-  const { count, userLikes, canLike, isLoading, addLike, removeLike } = useLikes(pageId);
+  const { count, userLikes, isLoading, addLike, removeLike } = useLikes(pageId);
   const [isShaking, setIsShaking] = useState(false);
   const [particles, setParticles] = useState<ReturnType<typeof generateParticles>>([]);
   const [particleKey, setParticleKey] = useState(0);
@@ -100,7 +100,7 @@ export function LikeButton({ pageId, className, variant = "default" }: LikeButto
   const handleClick = async () => {
     if (isLoading) return;
 
-    if (!canLike) {
+    if (userLikes >= MAX_LIKES_PER_USER) {
       // At max likes - shake it!
       setIsShaking(true);
       heartScale.set(1.2);
@@ -201,7 +201,11 @@ export function LikeButton({ pageId, className, variant = "default" }: LikeButto
           ],
           className,
         )}
-        aria-label={`Like this. Current likes: ${count}. You've liked ${userLikes} times.`}
+        aria-label={
+          isLoading
+            ? `Like this. Current likes: ${count}.`
+            : `Like this. Current likes: ${count}. You've liked ${userLikes} times.`
+        }
         style={isFilled ? { color: heartColor } : undefined}
       >
         <div className="relative">

--- a/src/components/stack/StackPageClient.tsx
+++ b/src/components/stack/StackPageClient.tsx
@@ -17,7 +17,7 @@ import { StackFilters } from "@/components/stack/StackFilters";
 import { LoadingSpinner, PreviewCardProvider, PreviewCardTrigger } from "@/components/ui";
 import { PlatformBadge } from "@/components/ui/PlatformBadge";
 import { TableSortHeader } from "@/components/ui/TableSortHeader";
-import type { LikeData } from "@/lib/hooks/useLikes";
+import type { LikeCount } from "@/lib/hooks/useLikes";
 import { useStacks } from "@/lib/hooks/useStacks";
 import type { StackItem as StackItemType } from "@/lib/stack";
 
@@ -25,7 +25,7 @@ import { useTopBarActions } from "../TopBarActions";
 
 interface StackPageClientProps {
   initialData: StackItemType[];
-  initialLikes?: Record<string, LikeData>;
+  initialLikes?: Record<string, LikeCount>;
 }
 
 const subscribe = () => () => {};

--- a/src/lib/hooks/useLikes.ts
+++ b/src/lib/hooks/useLikes.ts
@@ -4,29 +4,35 @@ import { createContext, useContext } from "react";
 import useSWR, { mutate } from "swr";
 
 import { fetcher } from "@/lib/fetcher";
-import { type LikeData, MAX_LIKES_PER_USER } from "@/lib/likes-constants";
+import {
+  type LikeCount,
+  type LikeData,
+  MAX_LIKES_PER_USER,
+  resolveLikeState,
+} from "@/lib/likes-constants";
 
-export type { LikeData };
+export type { LikeCount, LikeData };
 
-// Context to provide initial likes data from server
 type BatchLikesContextType = {
-  initialData: Record<string, LikeData>;
+  counts: Record<string, LikeCount>;
+  /** null until the viewer batch returns. */
+  viewer: Record<string, LikeData> | null;
 };
 
 export const BatchLikesContext = createContext<BatchLikesContextType | null>(null);
 
 /**
- * Hook for individual like button
- * Uses initial data from context as fallback, then SWR for updates
+ * Hook for individual like button.
+ * SSR counts are display-only. Viewer state comes from the batch overlay
+ * (or an individual GET when there is no batch provider).
  */
 export function useLikes(pageId: string) {
   const batchContext = useContext(BatchLikesContext);
-  const initialData = batchContext?.initialData?.[pageId];
+  const inBatch = batchContext !== null;
 
-  const { data, error, isLoading } = useSWR<LikeData>(
+  const { data, error } = useSWR<LikeData>(
     pageId ? `/api/likes/${pageId}` : null,
-    // Don't fetch individually if batch context provides data
-    initialData ? null : fetcher,
+    inBatch ? null : fetcher,
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
@@ -34,16 +40,18 @@ export function useLikes(pageId: string) {
     },
   );
 
-  const addLike = async () => {
-    const currentData = data ?? initialData;
-    if (!currentData?.canLike) return;
+  const { count, userLikes, viewerKnown } = resolveLikeState(
+    batchContext?.counts?.[pageId],
+    batchContext?.viewer?.[pageId],
+    data,
+  );
 
-    // Optimistic update
+  const addLike = async () => {
+    if (!viewerKnown || userLikes >= MAX_LIKES_PER_USER) return;
+
     const optimisticData: LikeData = {
-      count: (currentData?.count ?? 0) + 1,
-      userLikes: (currentData?.userLikes ?? 0) + 1,
-      hasLiked: true,
-      canLike: (currentData?.userLikes ?? 0) + 1 < MAX_LIKES_PER_USER,
+      count: count + 1,
+      userLikes: userLikes + 1,
     };
 
     await mutate(
@@ -64,17 +72,11 @@ export function useLikes(pageId: string) {
   };
 
   const removeLike = async () => {
-    const currentData = data ?? initialData;
-    const currentUserLikes = currentData?.userLikes ?? 0;
-    if (currentUserLikes <= 0) return;
+    if (!viewerKnown || userLikes <= 0) return;
 
-    // Optimistic update
-    const newUserLikes = currentUserLikes - 1;
     const optimisticData: LikeData = {
-      count: Math.max(0, (currentData?.count ?? 0) - 1),
-      userLikes: newUserLikes,
-      hasLiked: newUserLikes > 0,
-      canLike: true,
+      count: Math.max(0, count - 1),
+      userLikes: userLikes - 1,
     };
 
     await mutate(
@@ -94,14 +96,10 @@ export function useLikes(pageId: string) {
     );
   };
 
-  const likeData = data ?? initialData;
-
   return {
-    count: likeData?.count ?? 0,
-    userLikes: likeData?.userLikes ?? 0,
-    hasLiked: likeData?.hasLiked ?? false,
-    canLike: likeData?.canLike ?? false,
-    isLoading: isLoading && !initialData,
+    count,
+    userLikes,
+    isLoading: !viewerKnown,
     isError: error,
     addLike,
     removeLike,

--- a/src/lib/likes-constants.test.ts
+++ b/src/lib/likes-constants.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isViewerLikeData,
+  type LikeCount,
+  type LikeData,
+  resolveLikeState,
+} from "@/lib/likes-constants";
+
+describe("isViewerLikeData", () => {
+  test("is false for count-only SSR payloads", () => {
+    const countOnly: LikeCount = { count: 12 };
+    expect(isViewerLikeData(countOnly)).toBe(false);
+  });
+
+  test("is true when the viewer overlay is present", () => {
+    const viewer: LikeData = { count: 12, userLikes: 3 };
+    expect(isViewerLikeData(viewer)).toBe(true);
+  });
+});
+
+describe("resolveLikeState", () => {
+  test("treats SSR count-only data as viewer-unknown", () => {
+    expect(resolveLikeState({ count: 7 }, undefined)).toEqual({
+      count: 7,
+      userLikes: 0,
+      viewerKnown: false,
+    });
+  });
+
+  test("does not invent a clickable empty viewer from missing data", () => {
+    expect(resolveLikeState(undefined, undefined)).toEqual({
+      count: 0,
+      userLikes: 0,
+      viewerKnown: false,
+    });
+  });
+
+  test("overlays viewer likes on the SSR count", () => {
+    expect(resolveLikeState({ count: 7 }, { count: 8, userLikes: 2 })).toEqual({
+      count: 8,
+      userLikes: 2,
+      viewerKnown: true,
+    });
+  });
+
+  test("lets SWR/optimistic overlay win over the batch viewer", () => {
+    expect(
+      resolveLikeState({ count: 7 }, { count: 8, userLikes: 2 }, { count: 9, userLikes: 3 }),
+    ).toEqual({
+      count: 9,
+      userLikes: 3,
+      viewerKnown: true,
+    });
+  });
+
+  test("treats userLikes 0 as a known viewer who has not liked", () => {
+    expect(resolveLikeState({ count: 4 }, { count: 4, userLikes: 0 })).toEqual({
+      count: 4,
+      userLikes: 0,
+      viewerKnown: true,
+    });
+  });
+});

--- a/src/lib/likes-constants.ts
+++ b/src/lib/likes-constants.ts
@@ -5,9 +5,34 @@
 
 export const MAX_LIKES_PER_USER = 16;
 
+/** SSR / cached count. Viewer state is unknown. */
+export interface LikeCount {
+  count: number;
+}
+
+/** Count plus the current viewer's like count (hash of IP + salt). */
 export interface LikeData {
   count: number;
   userLikes: number;
-  hasLiked: boolean;
-  canLike: boolean;
+}
+
+export function isViewerLikeData(data: LikeCount | LikeData): data is LikeData {
+  return "userLikes" in data;
+}
+
+/**
+ * Merge SSR count, batch viewer overlay, and optional SWR/optimistic overlay.
+ * `userLikes` is only meaningful when `viewerKnown` is true.
+ */
+export function resolveLikeState(
+  countOnly: LikeCount | undefined,
+  viewer: LikeData | undefined,
+  overlay?: LikeData,
+): { count: number; userLikes: number; viewerKnown: boolean } {
+  const likeData = overlay ?? viewer;
+  return {
+    count: likeData?.count ?? countOnly?.count ?? 0,
+    userLikes: likeData?.userLikes ?? 0,
+    viewerKnown: likeData !== undefined,
+  };
 }

--- a/src/lib/likes-redis.test.ts
+++ b/src/lib/likes-redis.test.ts
@@ -1,0 +1,76 @@
+import { Redis } from "@upstash/redis";
+import { describe, expect, test } from "bun:test";
+
+import { MAX_LIKES_PER_USER } from "@/lib/likes-constants";
+import {
+  addLike,
+  getBatchLikeCounts,
+  getBatchUserLikeData,
+  getLikeCount,
+  getMaxLikesPerUser,
+  getUserLikeCount,
+  removeLike,
+} from "@/lib/likes-redis";
+
+describe("getMaxLikesPerUser", () => {
+  test("matches the shared constant", () => {
+    expect(getMaxLikesPerUser()).toBe(MAX_LIKES_PER_USER);
+  });
+});
+
+const redisConfigured = Boolean(
+  process.env.UPSTASH_LIKES_REST_URL && process.env.UPSTASH_LIKES_REST_TOKEN,
+);
+
+describe.skipIf(!redisConfigured)("likes redis (count + viewer only)", () => {
+  const pageId = `__s07_likes_model_${crypto.randomUUID()}`;
+  const userId = "s07-test-viewer";
+  const totalKey = `likes:total:${pageId}`;
+  const userKey = `likes:user:${userId}:${pageId}`;
+  const abandonedSetKey = `likes:users:${pageId}`;
+
+  async function likesClient(): Promise<Redis> {
+    return new Redis({
+      url: process.env.UPSTASH_LIKES_REST_URL!,
+      token: process.env.UPSTASH_LIKES_REST_TOKEN!,
+    });
+  }
+
+  async function cleanup() {
+    const client = await likesClient();
+    await client.del(totalKey, userKey, abandonedSetKey);
+  }
+
+  test("like and unlike update count and userLikes without a users set", async () => {
+    const client = await likesClient();
+    await cleanup();
+
+    try {
+      expect(await getLikeCount(pageId)).toBe(0);
+      expect(await getUserLikeCount(userId, pageId)).toBe(0);
+
+      const afterLike = await addLike(userId, pageId);
+      expect(afterLike).toBe(1);
+      expect(await getLikeCount(pageId)).toBe(1);
+      expect(await getUserLikeCount(userId, pageId)).toBe(1);
+
+      const batch = await getBatchUserLikeData(userId, [pageId]);
+      expect(batch.get(pageId)).toEqual({ count: 1, userLikes: 1 });
+      expect(batch.get(pageId)).not.toHaveProperty("hasLiked");
+      expect(batch.get(pageId)).not.toHaveProperty("canLike");
+
+      const counts = await getBatchLikeCounts([pageId]);
+      expect(counts.get(pageId)).toBe(1);
+
+      expect(await client.exists(abandonedSetKey)).toBe(0);
+
+      const afterUnlike = await removeLike(userId, pageId);
+      expect(afterUnlike).toEqual({ count: 0, userLikes: 0 });
+      expect(await getLikeCount(pageId)).toBe(0);
+      expect(await getUserLikeCount(userId, pageId)).toBe(0);
+      expect(await client.exists(abandonedSetKey)).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/lib/likes-redis.ts
+++ b/src/lib/likes-redis.ts
@@ -23,9 +23,11 @@ function getLikesRedis(): Redis | null {
 
 // Key prefixes
 const TOTAL_PREFIX = "likes:total:";
-const USERS_PREFIX = "likes:users:";
 const USER_LIKES_PREFIX = "likes:user:";
 const RATE_LIMIT_PREFIX = "ratelimit:likes:";
+
+// Historical `likes:users:{pageId}` sets are abandoned (not scanned or deleted).
+// Viewer state is `likes:user:{userId}:{pageId}` (hash of IP + LIKES_HASH_SALT).
 
 // Constants
 const RATE_LIMIT_WINDOW = 60; // seconds
@@ -64,22 +66,6 @@ export async function getUserLikeCount(userId: string, pageId: string): Promise<
 }
 
 /**
- * Check if a user has liked a page
- */
-export async function hasUserLiked(userId: string, pageId: string): Promise<boolean> {
-  const client = getLikesRedis();
-  if (!client) return false;
-
-  try {
-    const isMember = await client.sismember(`${USERS_PREFIX}${pageId}`, userId);
-    return isMember === 1;
-  } catch (error) {
-    console.error("[Likes] Error checking user liked:", error);
-    return false;
-  }
-}
-
-/**
  * Add a like from a user to a page
  * Returns the new total count
  */
@@ -92,9 +78,6 @@ export async function addLike(userId: string, pageId: string): Promise<number> {
 
     // Increment total count
     pipeline.incr(`${TOTAL_PREFIX}${pageId}`);
-
-    // Add user to the set of users who liked this page
-    pipeline.sadd(`${USERS_PREFIX}${pageId}`, userId);
 
     // Increment user's like count for this page
     pipeline.incr(`${USER_LIKES_PREFIX}${userId}:${pageId}`);
@@ -140,11 +123,6 @@ export async function removeLike(
 
     const newCount = Math.max(0, (results[0] as number) ?? 0);
     const newUserLikes = Math.max(0, (results[1] as number) ?? 0);
-
-    // If user has no more likes, remove from the set
-    if (newUserLikes === 0) {
-      await client.srem(`${USERS_PREFIX}${pageId}`, userId);
-    }
 
     return { count: newCount, userLikes: newUserLikes };
   } catch (error) {
@@ -248,22 +226,19 @@ export async function getBatchLikeCounts(pageIds: string[]): Promise<Map<string,
 }
 
 /**
- * Batch get user like data for multiple pages
- * Returns a Map of pageId -> { count, userLikes, hasLiked, canLike }
+ * Batch get viewer like data for multiple pages (2N: totals + per-user counts).
+ * Returns a Map of pageId -> { count, userLikes }
  */
 export async function getBatchUserLikeData(
   userId: string,
   pageIds: string[],
-): Promise<Map<string, { count: number; userLikes: number; hasLiked: boolean; canLike: boolean }>> {
+): Promise<Map<string, LikeData>> {
   const client = getLikesRedis();
-  const result = new Map<
-    string,
-    { count: number; userLikes: number; hasLiked: boolean; canLike: boolean }
-  >();
+  const result = new Map<string, LikeData>();
 
   if (!client || pageIds.length === 0) {
     pageIds.forEach((id) => {
-      result.set(id, { count: 0, userLikes: 0, hasLiked: false, canLike: true });
+      result.set(id, { count: 0, userLikes: 0 });
     });
     return result;
   }
@@ -271,19 +246,12 @@ export async function getBatchUserLikeData(
   try {
     const pipeline = client.pipeline();
 
-    // Get total counts
     for (const pageId of pageIds) {
       pipeline.get(`${TOTAL_PREFIX}${pageId}`);
     }
 
-    // Get user like counts
     for (const pageId of pageIds) {
       pipeline.get(`${USER_LIKES_PREFIX}${userId}:${pageId}`);
-    }
-
-    // Check if user has liked each page
-    for (const pageId of pageIds) {
-      pipeline.sismember(`${USERS_PREFIX}${pageId}`, userId);
     }
 
     const results = await pipeline.exec();
@@ -292,21 +260,15 @@ export async function getBatchUserLikeData(
     pageIds.forEach((pageId, index) => {
       const count = (results[index] as number | null) ?? 0;
       const userLikes = (results[n + index] as number | null) ?? 0;
-      const hasLiked = results[2 * n + index] === 1;
 
-      result.set(pageId, {
-        count,
-        userLikes,
-        hasLiked,
-        canLike: userLikes < MAX_LIKES_PER_USER,
-      });
+      result.set(pageId, { count, userLikes });
     });
 
     return result;
   } catch (error) {
     console.error("[Likes] Error getting batch user like data:", error);
     pageIds.forEach((id) => {
-      result.set(id, { count: 0, userLikes: 0, hasLiked: false, canLike: true });
+      result.set(id, { count: 0, userLikes: 0 });
     });
     return result;
   }

--- a/src/lib/likes-server.ts
+++ b/src/lib/likes-server.ts
@@ -2,43 +2,38 @@ import "server-only";
 
 import { unstable_cache } from "next/cache";
 
-import { getBatchLikeCounts, type LikeData } from "./likes-redis";
+import { type LikeCount } from "./likes-constants";
+import { getBatchLikeCounts } from "./likes-redis";
 
-export type { LikeData };
+export type { LikeCount, LikeData } from "./likes-constants";
 
 /**
  * Revalidate matches the default page revalidate (1h) so wrapping this call
  * does NOT force pages to regenerate more often than they otherwise would
  * (Next.js uses the minimum revalidate across all layers of a route).
  *
- * Client-side SWR inside BatchLikesProvider refreshes counts live after
- * hydration, so the server-rendered count lagging by up to 1h is acceptable.
+ * Client-side batch fetch inside BatchLikesProvider overlays viewer state
+ * after hydration, so the server-rendered count lagging by up to 1h is acceptable.
  */
 const LIKES_REVALIDATE = 3600;
 
 /**
  * Server-side function to get batch like counts for multiple pages.
- * Returns counts only (no user-specific data).
- * User-specific data (hasLiked, userLikes) is fetched client-side.
+ * Returns counts only — viewer state is unknown until the client batch overlay.
  *
  * Wrapped in `unstable_cache` so Server Components using it can be ISR'd
  * instead of bailed to dynamic rendering (Upstash REST calls are uncached
  * fetch POSTs that otherwise force a route dynamic).
  */
 export const getServerLikes = unstable_cache(
-  async (pageIds: string[]): Promise<Record<string, LikeData>> => {
+  async (pageIds: string[]): Promise<Record<string, LikeCount>> => {
     if (pageIds.length === 0) return {};
 
     const counts = await getBatchLikeCounts(pageIds);
 
-    const result: Record<string, LikeData> = {};
+    const result: Record<string, LikeCount> = {};
     for (const pageId of pageIds) {
-      result[pageId] = {
-        count: counts.get(pageId) ?? 0,
-        userLikes: 0,
-        hasLiked: false,
-        canLike: true,
-      };
+      result[pageId] = { count: counts.get(pageId) ?? 0 };
     }
 
     return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Likes-only Slice B of the structure audit. Independent of https://github.com/brianlovin/briOS/pull/2267 (Notion types) so this can merge on its own.

## Summary

Two related likes-model fixes:

**S07-1 — Drop `likes:users:{pageId}` and derived DTO booleans**
- Persist only `likes:total:{pageId}` and `likes:user:{userId}:{pageId}` (viewer is a hash of IP + `LIKES_HASH_SALT`).
- DTO is `{ count, userLikes }`. UI already treats liked as `userLikes > 0` and the cap as `userLikes >= 16`.
- Batch reads go 3N → 2N (no `SISMEMBER`).
- `sadd` / `srem` on the users set are gone, so unlike can no longer drift the set from the count.
- Historical `likes:users:*` keys are abandoned, not scanned or deleted in production.

**S07-2 — SSR count vs viewer overlay**
- `getServerLikes` returns `Record<string, LikeCount>` (`{ count }` only). It no longer forges `userLikes: 0, hasLiked: false, canLike: true`.
- `BatchLikesProvider` keeps SSR counts and a separate `viewer` map that stays `null` until `/api/likes/batch` returns.
- `useLikes` / `LikeButton` stay in a loading (non-interactive) state until viewer data exists, so pre-batch buttons do not claim the viewer can like or has not liked.

HTTP routes are unchanged (`GET/POST/DELETE /api/likes/[id]`, `GET /api/likes/batch`). Response bodies drop the derived booleans only. Visible behavior after hydrate is the same.

## Test plan

- [x] `bun run lint` and `tsc --noEmit` on touched files
- [x] `bun test` — 87 pass, including new likes unit tests and the Upstash integration case
- [x] Smoke like/unlike on a throwaway page id: count and `userLikes` move; `likes:users:{pageId}` is not created; test keys cleaned up
- [x] Grep: `hasLiked` / `canLike` / `likes:users` gone from live paths (comment + dry-run script + tests only)

## Follow-up

Optional cleanup of leftover `likes:users:*` keys. A dry-run against the likes Redis currently reports **100** abandoned keys. List them with:

```bash
bun scripts/scan-abandoned-likes-users.ts
```

Do not `DEL` those keys from this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8a2bdf9-84e2-4797-850c-641d038047c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8a2bdf9-84e2-4797-850c-641d038047c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

