### PR TITLE
Make HN comments optional and type the public list as HackerNewsPost[]

### DIFF
--- a/src/app/hn/HNPostsContext.tsx
+++ b/src/app/hn/HNPostsContext.tsx
@@ -5,7 +5,7 @@ import React, { createContext, useContext } from "react";
 import { HackerNewsPost } from "@/types/hackernews";
 
 interface HNPostsContextType {
-  posts: (HackerNewsPost | null)[] | undefined;
+  posts: HackerNewsPost[] | undefined;
   isLoading: boolean;
   isError: any;
 }
@@ -23,7 +23,7 @@ export function HNPostsProvider({
   isError,
 }: {
   children: React.ReactNode;
-  posts: (HackerNewsPost | null)[] | undefined;
+  posts: HackerNewsPost[] | undefined;
   isLoading: boolean;
   isError: any;
 }) {

--- a/src/app/hn/[id]/HNPostPageClient.tsx
+++ b/src/app/hn/[id]/HNPostPageClient.tsx
@@ -3,7 +3,7 @@
 import { useAtomValue } from "jotai";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { memo, useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { hnSubscribedAtom } from "@/atoms/hnSubscription";
@@ -19,7 +19,6 @@ import { stripHtmlTags } from "@/lib/utils";
 import { HackerNewsComment, HackerNewsPost } from "@/types/hackernews";
 
 import { HNCLIUpsell, HNDigestCard } from "../HNDigestCard";
-import { useHNPostsContext } from "../HNPostsContext";
 
 // Sanitize HTML content from external sources (Hacker News). Uses an
 // isomorphic sanitizer so content is stripped on both the server (SSR) and the
@@ -34,16 +33,11 @@ interface HNPostPageClientProps {
 
 export default function HNPostPageClient({ initialPost }: HNPostPageClientProps) {
   const { id } = useParams();
-  const { posts } = useHNPostsContext();
   const isSubscribed = useAtomValue(hnSubscribedAtom);
 
-  // Use server-provided initialPost first, then fall back to context posts
-  const fallbackPost = useMemo(
-    () => initialPost ?? posts?.find((p) => p?.id.toString() === id) ?? null,
-    [initialPost, posts, id],
-  );
-
-  const { post, isLoading, isError } = useHNPost(id as string, fallbackPost);
+  // Only hydrate from a detail fetch. List rows omit `comments` and must not
+  // stand in for a loaded thread (`[]` means empty, not "not fetched").
+  const { post, isLoading, isError } = useHNPost(id as string, initialPost ?? null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef(null);
 
@@ -180,13 +174,13 @@ export default function HNPostPageClient({ initialPost }: HNPostPageClientProps)
 
           <FancySeparator />
 
-          {post?.comments && !!post.comments.length && (
+          {post.comments !== undefined && (
             <div className="relative flex flex-1 flex-col pt-8 md:pt-12">
               <PostComments comments={post.comments} />
             </div>
           )}
 
-          {!isSubscribed && post?.comments && !!post.comments.length && (
+          {!isSubscribed && post.comments !== undefined && post.comments.length > 0 && (
             <div className="pt-8 md:pt-12">
               <FancySeparator />
               <div className="mt-8 flex flex-col gap-4">

--- a/src/app/hn/[id]/page.tsx
+++ b/src/app/hn/[id]/page.tsx
@@ -14,7 +14,8 @@ export async function generateMetadata(props: {
   const id = params.id;
 
   try {
-    const post = await getPostById(id, false);
+    // Same args as HNPostContent so React cache() shares the detail fetch.
+    const post = await getPostById(id, true);
 
     if (!post) {
       return {

--- a/src/app/hn/layout.tsx
+++ b/src/app/hn/layout.tsx
@@ -14,6 +14,8 @@ import { HackerNewsPost } from "@/types/hackernews";
 import { LoadingSpinner } from "../../components/ui/LoadingSpinner";
 import { HNPostsProvider, useHNPostsContext } from "./HNPostsContext";
 
+const EMPTY_HN_POSTS: HackerNewsPost[] = [];
+
 export default function HNLayout({ children }: { children: React.ReactNode }) {
   const { data: posts, isLoading, isError } = useHNPosts();
 
@@ -38,12 +40,7 @@ export default function HNLayout({ children }: { children: React.ReactNode }) {
 function HNStoriesList() {
   const pathname = usePathname();
   const { posts, isLoading, isError } = useHNPostsContext();
-
-  // Filter out null posts
-  const validPosts = useMemo(
-    () => posts?.filter((post): post is HackerNewsPost => post !== null) ?? [],
-    [posts],
-  );
+  const validPosts = posts ?? EMPTY_HN_POSTS;
 
   // Get current post ID from URL and find its index
   const currentPostId = pathname.split("/").pop();

--- a/src/lib/hn.test.ts
+++ b/src/lib/hn.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { processPost } from "@/lib/hn";
+import { HackerNewsComment, HackerNewsPost } from "@/types/hackernews";
+
+function makePost(overrides: Partial<HackerNewsPost> = {}): HackerNewsPost {
+  return {
+    id: 1,
+    title: "Ask HN: Test",
+    points: 10,
+    user: "pg",
+    time: 1_700_000_000,
+    time_ago: "1 hour ago",
+    type: "link",
+    content: null,
+    url: "https://example.com",
+    domain: "example.com",
+    comments_count: 0,
+    ...overrides,
+  };
+}
+
+function makeComment(overrides: Partial<HackerNewsComment> = {}): HackerNewsComment {
+  return {
+    id: 2,
+    user: "alice",
+    content: "<p>hello</p>",
+    level: 0,
+    comments: [],
+    ...overrides,
+  };
+}
+
+describe("processPost", () => {
+  test("omits comments on a list projection so [] cannot mean stripped", () => {
+    const post = processPost(makePost({ comments: [makeComment()], comments_count: 1 }), false);
+
+    expect(post.comments).toBeUndefined();
+    expect("comments" in post).toBe(false);
+    expect(JSON.parse(JSON.stringify(post))).not.toHaveProperty("comments");
+  });
+
+  test("keeps an empty comments array after a detail fetch", () => {
+    const post = processPost(makePost({ comments: [], comments_count: 0 }), true);
+
+    expect(post.comments).toEqual([]);
+  });
+
+  test("treats missing comments as an empty thread on a detail fetch", () => {
+    const post = processPost(makePost({ comments_count: 0 }), true);
+
+    expect(post.comments).toEqual([]);
+  });
+
+  test("includes trimmed comments on a detail fetch", () => {
+    const post = processPost(
+      makePost({
+        comments: [makeComment({ id: 3, content: "<p>hello</p>" })],
+        comments_count: 1,
+      }),
+      true,
+    );
+
+    expect(post.comments).toHaveLength(1);
+    expect(post.comments?.[0]?.id).toBe(3);
+  });
+});

--- a/src/lib/hn.ts
+++ b/src/lib/hn.ts
@@ -66,21 +66,26 @@ function trimComments(comment: HackerNewsComment): HackerNewsComment | null {
   };
 }
 
-// Helper to process raw post data into final format
-function processPost(data: HackerNewsPost, includeComments: boolean): HackerNewsPost {
-  const shortComments = data.comments
-    .slice(0, 12)
-    .map(trimComments)
-    .filter(Boolean) as HackerNewsComment[];
-
+// Project raw post data. Comments are omitted unless includeComments is set so
+// `[]` only means "detail fetch, empty thread" — never "list row, stripped".
+export function processPost(data: HackerNewsPost, includeComments: boolean): HackerNewsPost {
   const cleanUrl = data.domain ? `${data.url}` : `${BASE_URL}/hn/${data.id}`;
-
-  return {
+  const projected: HackerNewsPost = {
     ...data,
     content: data.content ? sanitizeExternalHtml(data.content) : data.content,
     url: cleanUrl,
-    comments: includeComments ? shortComments : [],
   };
+
+  if (includeComments) {
+    projected.comments = (data.comments ?? [])
+      .slice(0, 12)
+      .map(trimComments)
+      .filter(Boolean) as HackerNewsComment[];
+  } else {
+    delete projected.comments;
+  }
+
+  return projected;
 }
 
 // Fetch post from external API (no caching)
@@ -175,17 +180,6 @@ export const getPostById = cache(
   async (id: string, includeComments = false): Promise<HackerNewsPost | null> => {
     return fetchPostById(id, includeComments);
   },
-);
-
-export const getHNPosts = unstable_cache(
-  async (): Promise<(HackerNewsPost | null)[]> => {
-    const topPostIds = await fetchPostIds();
-    const ids = topPostIds.slice(0, 24).map((id) => id.toString());
-    const posts = await getBatchPosts(ids, false);
-    return posts.filter(Boolean);
-  },
-  ["hn:list"],
-  { revalidate: HN_REVALIDATE, tags: ["hn:list"] },
 );
 
 export const getRankedHNPosts = unstable_cache(

--- a/src/lib/hooks/useHn.ts
+++ b/src/lib/hooks/useHn.ts
@@ -14,8 +14,8 @@ export function prefetchHNPost(id: string) {
   preload(`/api/hn/${id}`, fetcher);
 }
 
-export function useHNPosts(fallbackData?: (HackerNewsPost | null)[]) {
-  const { data, error, isLoading } = useSWR<(HackerNewsPost | null)[]>("/api/hn", fetcher, {
+export function useHNPosts(fallbackData?: HackerNewsPost[]) {
+  const { data, error, isLoading } = useSWR<HackerNewsPost[]>("/api/hn", fetcher, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     refreshInterval: 1000 * 60 * 60, // 1 hour

--- a/src/types/hackernews.ts
+++ b/src/types/hackernews.ts
@@ -29,6 +29,7 @@ export interface HackerNewsPost {
   content: string | null;
   url: string;
   domain: string | null;
-  comments: HackerNewsComment[];
+  /** `undefined` = not fetched (list projection); `[]` = detail fetch, empty thread. */
+  comments?: HackerNewsComment[];
   comments_count: number;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slice C of the structure audit, HN-reader only (independent of Notion types and likes).

`HackerNewsPost.comments` is now optional:

- `undefined` — not fetched (list projection)
- `[]` — detail fetch, empty thread

`processPost(..., false)` omits the `comments` key instead of writing `[]`, so a list row can no longer be mistaken for a loaded thread.

The story page no longer falls back to `posts.find(...)` from the list context. It hydrates only from `initialPost` (a `getPostById(id, true)` result). `generateMetadata` uses the same `getPostById(id, true)` call so React `cache()` actually dedupes.

The public list path is `HackerNewsPost[]` end to end (`/api/hn` → `useHNPosts` → `HNPostsContext` → layout). Unused `getHNPosts` is deleted. Digest/email is unchanged; it only reads `comments_count`.

## Test plan

- [x] `bun test` — 82 pass, including new `processPost` cases (omitted comments, empty thread, missing comments, trimmed detail comments)
- [x] `bun run lint` and `tsc --noEmit` clean for touched files
- [x] Grep: no leftover public `(HackerNewsPost | null)[]` on the client list path; `getHNPosts` removed. Remaining `(HackerNewsPost | null)[]` is only the internal batch/cache holey array.
- [x] Story page with comments hydrates from `initialPost` — comments visible on first paint, no comment-less flash from a list row
- [x] Show HN / zero-comment post (`/hn/49310834`) shows empty thread copy: "No comments yet..." (`comments: []` after detail fetch)
- [x] Smoke against live HN cache (no tokens logged):
  - `GET /api/hn` → 200, 24 posts, no `comments` key on any row
  - `GET /api/hn/49304447` → 200, `comments` present (trimmed to 12)
  - `GET /api/hn/49313047` and `/api/hn/49310834` → 200, `comments: []`
  - Redis `getCachedPost` still stores the full thread; `processPost(list)` omits comments, `processPost(detail)` keeps them

[HN list page](https://cursor.com/agents/bc-8f4da50b-8ca0-47cf-965e-5346f09fa5c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhn_list_page.webp)
[Story page with comments hydrated](https://cursor.com/agents/bc-8f4da50b-8ca0-47cf-965e-5346f09fa5c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhn_story_with_comments.webp)
[Empty thread shows No comments yet](https://cursor.com/agents/bc-8f4da50b-8ca0-47cf-965e-5346f09fa5c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhn_empty_thread.webp)
[hn_story_comments_hydrate.mp4](https://cursor.com/agents/bc-8f4da50b-8ca0-47cf-965e-5346f09fa5c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhn_story_comments_hydrate.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f4da50b-8ca0-47cf-965e-5346f09fa5c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f4da50b-8ca0-47cf-965e-5346f09fa5c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

