### PR TITLE
Share Notion cache purge across webhooks and /api/purge-cache

### DIFF
--- a/src/app/api/purge-cache/route.ts
+++ b/src/app/api/purge-cache/route.ts
@@ -7,7 +7,7 @@ import {
   type PurgeableContentType,
   type PurgeCacheType,
   purgeContentType,
-} from "@/lib/notion";
+} from "@/lib/notion/purge";
 
 async function purgeCache(request: Request): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);

--- a/src/app/api/purge-cache/route.ts
+++ b/src/app/api/purge-cache/route.ts
@@ -1,52 +1,13 @@
-import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
-import { invalidateNotionCache } from "@/lib/notion";
-
-const CONTENT_TYPES = ["writing", "til", "ama", "stack", "sites", "all"] as const;
-type ContentType = (typeof CONTENT_TYPES)[number];
-
-/**
- * Redis key patterns, Next cache tags, and paths to revalidate per content type.
- * `pagePaths` holds dynamic-segment paths that require the "page" type arg to
- * `revalidatePath` — without it, individual slug/id pages keep serving stale HTML.
- */
-const PURGE_CONFIG: Record<
-  Exclude<ContentType, "all">,
-  { patterns: string[]; tags: string[]; paths: string[]; pagePaths: string[] }
-> = {
-  writing: {
-    patterns: ["notion:writing:*"],
-    tags: ["notion:writing"],
-    paths: ["/writing", "/api/writing"],
-    pagePaths: ["/writing/[slug]"],
-  },
-  til: {
-    patterns: ["notion:til:*"],
-    tags: ["notion:til"],
-    paths: ["/til", "/api/til"],
-    pagePaths: ["/til/[slug]"],
-  },
-  ama: {
-    patterns: ["notion:ama:*"],
-    tags: ["notion:ama"],
-    paths: ["/ama", "/api/ama"],
-    pagePaths: ["/ama/[id]"],
-  },
-  stack: {
-    patterns: ["notion:stack:*"],
-    tags: ["notion:stack"],
-    paths: ["/stack", "/api/stacks"],
-    pagePaths: [],
-  },
-  sites: {
-    patterns: ["notion:good-websites:*"],
-    tags: ["notion:good-websites"],
-    paths: ["/sites", "/api/sites"],
-    pagePaths: [],
-  },
-};
+import {
+  PURGE_CACHE_TYPES,
+  PURGEABLE_CONTENT_TYPES,
+  type PurgeableContentType,
+  type PurgeCacheType,
+  purgeContentType,
+} from "@/lib/notion";
 
 async function purgeCache(request: Request): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
@@ -57,37 +18,16 @@ async function purgeCache(request: Request): Promise<NextResponse> {
     return errorResponse("Unauthorized", 401);
   }
 
-  if (!CONTENT_TYPES.includes(type as ContentType)) {
-    return errorResponse(`Invalid type. Must be one of: ${CONTENT_TYPES.join(", ")}`, 400);
+  if (!PURGE_CACHE_TYPES.includes(type as PurgeCacheType)) {
+    return errorResponse(`Invalid type. Must be one of: ${PURGE_CACHE_TYPES.join(", ")}`, 400);
   }
 
-  const types =
-    type === "all" ? (["writing", "til", "ama", "stack", "sites"] as const) : ([type] as const);
+  const types: readonly PurgeableContentType[] =
+    type === "all" ? PURGEABLE_CONTENT_TYPES : [type as PurgeableContentType];
   const results: Record<string, number> = {};
 
   for (const t of types) {
-    const config = PURGE_CONFIG[t as Exclude<ContentType, "all">];
-
-    let deleted = 0;
-    for (const pattern of config.patterns) {
-      deleted += await invalidateNotionCache(pattern);
-    }
-    results[t] = deleted;
-
-    // Invalidate the Next.js data cache layer alongside the Upstash layer.
-    // Next 16 requires a cacheLife profile as the second arg; "max" gives
-    // stale-while-revalidate behavior (serve existing cached data while
-    // regenerating in the background).
-    for (const tag of config.tags) {
-      revalidateTag(tag, "max");
-    }
-
-    for (const path of config.paths) {
-      revalidatePath(path);
-    }
-    for (const path of config.pagePaths) {
-      revalidatePath(path, "page");
-    }
+    results[t] = await purgeContentType(t);
   }
 
   console.log(`[Cache Purge] Purged type=${type}:`, results);

--- a/src/app/api/webhooks/capture-site-preview/route.ts
+++ b/src/app/api/webhooks/capture-site-preview/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSitePreview } from "@/lib/image-processing/optimize";
-import { notion, purgeContentType } from "@/lib/notion";
+import { notion } from "@/lib/notion";
+import { purgeContentType } from "@/lib/notion/purge";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 import { captureScreenshot } from "@/lib/screenshot";
 

--- a/src/app/api/webhooks/capture-site-preview/route.ts
+++ b/src/app/api/webhooks/capture-site-preview/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSitePreview } from "@/lib/image-processing/optimize";
-import { notion } from "@/lib/notion";
+import { notion, purgeContentType } from "@/lib/notion";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 import { captureScreenshot } from "@/lib/screenshot";
 
@@ -111,6 +111,8 @@ export async function POST(request: Request) {
         },
       });
 
+      await purgeContentType("sites");
+
       return NextResponse.json(
         {
           success: true,
@@ -133,6 +135,8 @@ export async function POST(request: Request) {
           },
         },
       });
+
+      await purgeContentType("sites");
 
       throw captureError;
     }

--- a/src/app/api/webhooks/generate-short-id/route.ts
+++ b/src/app/api/webhooks/generate-short-id/route.ts
@@ -1,8 +1,7 @@
-import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
-import { invalidateNotionCache } from "@/lib/notion";
+import { purgeContentType } from "@/lib/notion";
 import { updateWritingShortId } from "@/lib/notion/mutations";
 import { getWritingPostByShortId, getWritingPostContent } from "@/lib/notion/queries";
 import { generateShortId, isValidShortId } from "@/lib/short-id";
@@ -87,11 +86,7 @@ export async function POST(request: Request) {
     await updateWritingShortId(pageId, shortId);
 
     // Invalidate writing cache so the new short ID is picked up
-    await invalidateNotionCache("notion:writing:*");
-    revalidateTag("notion:writing", "max");
-    revalidatePath("/writing");
-    revalidatePath("/api/writing");
-    revalidatePath("/writing/[slug]", "page");
+    await purgeContentType("writing");
 
     console.log(`✅ Successfully generated Short ID: ${shortId} for "${content.metadata.title}"\n`);
 

--- a/src/app/api/webhooks/generate-short-id/route.ts
+++ b/src/app/api/webhooks/generate-short-id/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
-import { purgeContentType } from "@/lib/notion";
 import { updateWritingShortId } from "@/lib/notion/mutations";
+import { purgeContentType } from "@/lib/notion/purge";
 import { getWritingPostByShortId, getWritingPostContent } from "@/lib/notion/queries";
 import { generateShortId, isValidShortId } from "@/lib/short-id";
 

--- a/src/app/api/webhooks/optimize-writing-images/route.ts
+++ b/src/app/api/webhooks/optimize-writing-images/route.ts
@@ -1,9 +1,8 @@
-import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeWritingImage } from "@/lib/image-processing/optimize";
-import { invalidateNotionCache, notion } from "@/lib/notion";
+import { notion, purgeContentType } from "@/lib/notion";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 
 /**
@@ -334,12 +333,8 @@ export async function POST(request: Request) {
     const totalSavings =
       totalOriginalSize > 0 ? ((1 - totalOptimizedSize / totalOriginalSize) * 100).toFixed(1) : "0";
 
-    // Invalidate all cached writing content (covers pageId, slug, and shortId keys)
-    await invalidateNotionCache("notion:writing:content:*");
-    revalidateTag("notion:writing", "max");
-    revalidatePath("/writing");
-    revalidatePath("/api/writing");
-    revalidatePath("/writing/[slug]", "page");
+    // Same writing purge as /api/purge-cache (widens Redis from content:* to writing:*)
+    await purgeContentType("writing");
 
     const successCount = imageSuccessCount + videoSuccessCount;
     const errorCount = imageErrorCount + videoErrorCount;

--- a/src/app/api/webhooks/optimize-writing-images/route.ts
+++ b/src/app/api/webhooks/optimize-writing-images/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeWritingImage } from "@/lib/image-processing/optimize";
-import { notion, purgeContentType } from "@/lib/notion";
+import { notion } from "@/lib/notion";
+import { purgeContentType } from "@/lib/notion/purge";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 
 /**

--- a/src/app/api/webhooks/process-stack-icon/route.ts
+++ b/src/app/api/webhooks/process-stack-icon/route.ts
@@ -1,9 +1,8 @@
-import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSiteIcon } from "@/lib/image-processing/optimize";
-import { invalidateNotionCache, notion } from "@/lib/notion";
+import { notion, purgeContentType } from "@/lib/notion";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 
 /**
@@ -90,10 +89,7 @@ export async function POST(request: Request) {
     });
 
     // Invalidate stack cache so the updated icon is picked up
-    await invalidateNotionCache("notion:stack:*");
-    revalidateTag("notion:stack", "max");
-    revalidatePath("/stack");
-    revalidatePath("/api/stacks");
+    await purgeContentType("stack");
 
     return NextResponse.json(
       {

--- a/src/app/api/webhooks/process-stack-icon/route.ts
+++ b/src/app/api/webhooks/process-stack-icon/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSiteIcon } from "@/lib/image-processing/optimize";
-import { notion, purgeContentType } from "@/lib/notion";
+import { notion } from "@/lib/notion";
+import { purgeContentType } from "@/lib/notion/purge";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 
 /**

--- a/src/app/api/webhooks/update-site-icon/route.ts
+++ b/src/app/api/webhooks/update-site-icon/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSiteIcon } from "@/lib/image-processing/optimize";
-import { notion, purgeContentType } from "@/lib/notion";
+import { notion } from "@/lib/notion";
+import { purgeContentType } from "@/lib/notion/purge";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 import { getBestFaviconUrl, isDataUrl, parseDataUrl } from "@/lib/utils/favicon";
 

--- a/src/app/api/webhooks/update-site-icon/route.ts
+++ b/src/app/api/webhooks/update-site-icon/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSiteIcon } from "@/lib/image-processing/optimize";
-import { notion } from "@/lib/notion";
+import { notion, purgeContentType } from "@/lib/notion";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 import { getBestFaviconUrl, isDataUrl, parseDataUrl } from "@/lib/utils/favicon";
 
@@ -110,6 +110,8 @@ export async function POST(request: Request) {
         external: { url: r2Url },
       },
     });
+
+    await purgeContentType("sites");
 
     return NextResponse.json(
       {

--- a/src/lib/notion/index.ts
+++ b/src/lib/notion/index.ts
@@ -71,6 +71,13 @@ export {
 
 // Cache
 export { invalidateNotionCache } from "./cache";
+export type { PurgeableContentType, PurgeCacheType } from "./purge";
+export {
+  PURGE_CACHE_TYPES,
+  PURGE_CONFIG,
+  PURGEABLE_CONTENT_TYPES,
+  purgeContentType,
+} from "./purge";
 
 // Mutations
 export {

--- a/src/lib/notion/index.ts
+++ b/src/lib/notion/index.ts
@@ -71,13 +71,6 @@ export {
 
 // Cache
 export { invalidateNotionCache } from "./cache";
-export type { PurgeableContentType, PurgeCacheType } from "./purge";
-export {
-  PURGE_CACHE_TYPES,
-  PURGE_CONFIG,
-  PURGEABLE_CONTENT_TYPES,
-  purgeContentType,
-} from "./purge";
 
 // Mutations
 export {

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -1,0 +1,137 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+const revalidateTag = mock(() => {});
+const revalidatePath = mock(() => {});
+
+mock.module("next/cache", () => ({
+  revalidateTag,
+  revalidatePath,
+}));
+
+import * as cache from "./cache";
+import {
+  PURGE_CACHE_TYPES,
+  PURGE_CONFIG,
+  PURGEABLE_CONTENT_TYPES,
+  purgeContentType,
+} from "./purge";
+
+describe("PURGE_CONFIG", () => {
+  test("covers every purgeable content type", () => {
+    expect(Object.keys(PURGE_CONFIG).sort()).toEqual([...PURGEABLE_CONTENT_TYPES].sort());
+  });
+
+  test("maps each content type to its Redis prefix, Next tag, and paths", () => {
+    expect(PURGE_CONFIG.writing).toEqual({
+      patterns: ["notion:writing:*"],
+      tags: ["notion:writing"],
+      paths: ["/writing", "/api/writing"],
+      pagePaths: ["/writing/[slug]"],
+    });
+    expect(PURGE_CONFIG.til).toEqual({
+      patterns: ["notion:til:*"],
+      tags: ["notion:til"],
+      paths: ["/til", "/api/til"],
+      pagePaths: ["/til/[slug]"],
+    });
+    expect(PURGE_CONFIG.ama).toEqual({
+      patterns: ["notion:ama:*"],
+      tags: ["notion:ama"],
+      paths: ["/ama", "/api/ama"],
+      pagePaths: ["/ama/[id]"],
+    });
+    expect(PURGE_CONFIG.stack).toEqual({
+      patterns: ["notion:stack:*"],
+      tags: ["notion:stack"],
+      paths: ["/stack", "/api/stacks"],
+      pagePaths: [],
+    });
+    expect(PURGE_CONFIG.sites).toEqual({
+      patterns: ["notion:good-websites:*"],
+      tags: ["notion:good-websites"],
+      paths: ["/sites", "/api/sites"],
+      pagePaths: [],
+    });
+  });
+
+  test("includes all as a purge-cache type without its own config row", () => {
+    expect(PURGE_CACHE_TYPES).toEqual(["writing", "til", "ama", "stack", "sites", "all"]);
+    expect(PURGE_CONFIG).not.toHaveProperty("all");
+  });
+});
+
+describe("purgeContentType", () => {
+  afterEach(() => {
+    revalidateTag.mockClear();
+    revalidatePath.mockClear();
+    mock.restore();
+  });
+
+  test("invalidates Redis, tags, and paths for writing", async () => {
+    const invalidate = spyOn(cache, "invalidateNotionCache").mockResolvedValue(4);
+
+    await expect(purgeContentType("writing")).resolves.toBe(4);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(invalidate).toHaveBeenCalledWith("notion:writing:*");
+    expect(revalidateTag).toHaveBeenCalledWith("notion:writing", "max");
+    expect(revalidatePath).toHaveBeenCalledTimes(3);
+    expect(revalidatePath).toHaveBeenCalledWith("/writing");
+    expect(revalidatePath).toHaveBeenCalledWith("/api/writing");
+    expect(revalidatePath).toHaveBeenCalledWith("/writing/[slug]", "page");
+  });
+
+  test("uses the good-websites prefix for sites", async () => {
+    const invalidate = spyOn(cache, "invalidateNotionCache").mockResolvedValue(2);
+
+    await expect(purgeContentType("sites")).resolves.toBe(2);
+    expect(invalidate).toHaveBeenCalledWith("notion:good-websites:*");
+    expect(revalidateTag).toHaveBeenCalledWith("notion:good-websites", "max");
+    expect(revalidatePath).toHaveBeenCalledTimes(2);
+    expect(revalidatePath).toHaveBeenCalledWith("/sites");
+    expect(revalidatePath).toHaveBeenCalledWith("/api/sites");
+  });
+
+  test("uses the stack prefix and has no pagePaths", async () => {
+    const invalidate = spyOn(cache, "invalidateNotionCache").mockResolvedValue(1);
+
+    await expect(purgeContentType("stack")).resolves.toBe(1);
+    expect(invalidate).toHaveBeenCalledWith("notion:stack:*");
+    expect(revalidateTag).toHaveBeenCalledWith("notion:stack", "max");
+    expect(revalidatePath).toHaveBeenCalledTimes(2);
+    expect(revalidatePath).toHaveBeenCalledWith("/stack");
+    expect(revalidatePath).toHaveBeenCalledWith("/api/stacks");
+  });
+});
+
+describe("webhook callers", () => {
+  test("every webhook that writes Notion calls purgeContentType", () => {
+    const webhooksDir = join(import.meta.dir, "../../app/api/webhooks");
+    const routes = readdirSync(webhooksDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(webhooksDir, entry.name, "route.ts"));
+
+    expect(routes.length).toBeGreaterThan(0);
+
+    for (const route of routes) {
+      const source = readFileSync(route, "utf8");
+      const writesNotion =
+        /notion\.(pages|blocks)\.update/.test(source) ||
+        /updateWritingShortId|updateStackItem|createStackItem|createAmaQuestion/.test(source);
+      if (writesNotion) {
+        expect(source.includes("purgeContentType(")).toBe(true);
+      }
+    }
+  });
+
+  test("purge-cache uses the shared helper instead of an inline table", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../../app/api/purge-cache/route.ts"),
+      "utf8",
+    );
+    expect(source.includes("purgeContentType(")).toBe(true);
+    expect(source.includes("PURGE_CONFIG")).toBe(false);
+  });
+});

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -134,4 +134,9 @@ describe("webhook callers", () => {
     expect(source.includes("purgeContentType(")).toBe(true);
     expect(source.includes("PURGE_CONFIG")).toBe(false);
   });
+
+  test("does not re-export purge from the notion barrel (client-imported)", () => {
+    const source = readFileSync(join(import.meta.dir, "index.ts"), "utf8");
+    expect(source.includes("purge")).toBe(false);
+  });
 });

--- a/src/lib/notion/purge.ts
+++ b/src/lib/notion/purge.ts
@@ -1,0 +1,86 @@
+import { revalidatePath, revalidateTag } from "next/cache";
+
+import { invalidateNotionCache } from "./cache";
+
+export const PURGEABLE_CONTENT_TYPES = ["writing", "til", "ama", "stack", "sites"] as const;
+export type PurgeableContentType = (typeof PURGEABLE_CONTENT_TYPES)[number];
+
+export const PURGE_CACHE_TYPES = [...PURGEABLE_CONTENT_TYPES, "all"] as const;
+export type PurgeCacheType = (typeof PURGE_CACHE_TYPES)[number];
+
+/**
+ * Redis key patterns, Next cache tags, and paths to revalidate per content type.
+ * `pagePaths` holds dynamic-segment paths that require the "page" type arg to
+ * `revalidatePath` — without it, individual slug/id pages keep serving stale HTML.
+ *
+ * Prefixes match `cachedNotionQuery` keys in `queries.ts`:
+ * - writing → `notion:writing:*` (list + content by id/slug/shortId)
+ * - til → `notion:til:*`
+ * - ama → `notion:ama:*`
+ * - stack → `notion:stack:*`
+ * - sites → `notion:good-websites:*` (list + rss; content type name ≠ Redis prefix)
+ */
+export const PURGE_CONFIG: Record<
+  PurgeableContentType,
+  { patterns: string[]; tags: string[]; paths: string[]; pagePaths: string[] }
+> = {
+  writing: {
+    patterns: ["notion:writing:*"],
+    tags: ["notion:writing"],
+    paths: ["/writing", "/api/writing"],
+    pagePaths: ["/writing/[slug]"],
+  },
+  til: {
+    patterns: ["notion:til:*"],
+    tags: ["notion:til"],
+    paths: ["/til", "/api/til"],
+    pagePaths: ["/til/[slug]"],
+  },
+  ama: {
+    patterns: ["notion:ama:*"],
+    tags: ["notion:ama"],
+    paths: ["/ama", "/api/ama"],
+    pagePaths: ["/ama/[id]"],
+  },
+  stack: {
+    patterns: ["notion:stack:*"],
+    tags: ["notion:stack"],
+    paths: ["/stack", "/api/stacks"],
+    pagePaths: [],
+  },
+  sites: {
+    patterns: ["notion:good-websites:*"],
+    tags: ["notion:good-websites"],
+    paths: ["/sites", "/api/sites"],
+    pagePaths: [],
+  },
+};
+
+/**
+ * Invalidate Upstash + Next.js caches for one content type.
+ * Used by `/api/purge-cache` and every webhook that writes Notion.
+ */
+export async function purgeContentType(type: PurgeableContentType): Promise<number> {
+  const config = PURGE_CONFIG[type];
+
+  let deleted = 0;
+  for (const pattern of config.patterns) {
+    deleted += await invalidateNotionCache(pattern);
+  }
+
+  // Next 16 requires a cacheLife profile as the second arg; "max" gives
+  // stale-while-revalidate behavior (serve existing cached data while
+  // regenerating in the background).
+  for (const tag of config.tags) {
+    revalidateTag(tag, "max");
+  }
+
+  for (const path of config.paths) {
+    revalidatePath(path);
+  }
+  for (const path of config.pagePaths) {
+    revalidatePath(path, "page");
+  }
+
+  return deleted;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slice D (S09-1) of the structure audit: one shared `purgeContentType()` so webhooks and `/api/purge-cache` invalidate the same way. Notion-write/purge only — independent of #2267 (types), #2268 (likes), and #2269 (HN).

`PURGE_CONFIG` now lives in `src/lib/notion/purge.ts` next to `invalidateNotionCache`. `/api/purge-cache` and every Notion-writing webhook import `purgeContentType` from `@/lib/notion/purge` — not the `@/lib/notion` barrel, which client layouts import and cannot pull `revalidatePath` / `revalidateTag`.

### Prefix map

| Content type | Redis pattern | Next tag | Paths | Page paths |
|---|---|---|---|---|
| `writing` | `notion:writing:*` | `notion:writing` | `/writing`, `/api/writing` | `/writing/[slug]` |
| `til` | `notion:til:*` | `notion:til` | `/til`, `/api/til` | `/til/[slug]` |
| `ama` | `notion:ama:*` | `notion:ama` | `/ama`, `/api/ama` | `/ama/[id]` |
| `stack` | `notion:stack:*` | `notion:stack` | `/stack`, `/api/stacks` | — |
| `sites` | `notion:good-websites:*` | `notion:good-websites` | `/sites`, `/api/sites` | — |

`all` is a `/api/purge-cache` query alias that loops the five types. It is not a config row.

### Callers

- `/api/purge-cache` — loops the requested type (or `all`) through the helper
- `generate-short-id` → `writing`
- `optimize-writing-images` → `writing`
- `process-stack-icon` → `stack`
- `capture-site-preview` → `sites` (after Done or Error writes)
- `update-site-icon` → `sites`

### Intentional widening

- `optimize-writing-images` previously deleted only `notion:writing:content:*`. It now uses `notion:writing:*` so it matches `/api/purge-cache` and `generate-short-id` (list keys included).
- `capture-site-preview` and `update-site-icon` previously invalidated nothing. They now purge `sites` (`notion:good-websites:*`).

S09-2 (Image/Video union in `optimize-writing-images`) is out of scope.

## Test plan

- [x] `bun test` — 106 pass, including new `purge.test.ts` (prefix map, helper mocks, webhook/purge-cache callers, no barrel re-export)
- [x] `bun run lint` / `bunx tsc --noEmit`
- [x] Grep: every webhook under `src/app/api/webhooks/**` that writes Notion calls `purgeContentType`
- [ ] CI `Build / build` after the barrel-export fix
- [ ] Optional live check after merge: `/api/purge-cache?type=sites` then confirm `/sites` is not stale after an icon or preview write

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3056284-b438-4ae4-9e11-b88f310e51ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3056284-b438-4ae4-9e11-b88f310e51ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

