### PR TITLE
Decouple JWT unsubscribe tokens from the Postmark mailer

### DIFF
--- a/src/app/api/hn-digest/send/route.ts
+++ b/src/app/api/hn-digest/send/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
-import { BASE_EMAIL, sendHNDigestEmailBatch } from "@/lib/email";
+import { BASE_EMAIL, generateUnsubscribeUrl, sendHNDigestEmailBatch } from "@/lib/email";
 import { getHNPostsForDigest } from "@/lib/hn";
-import { formatDigestDate, generateUnsubscribeUrl } from "@/lib/jwt";
 import { getHNSubscribers } from "@/lib/subscriptions";
+import { formatDigestDate } from "@/lib/urls";
 
 const IS_PROD = process.env.NODE_ENV === "production";
 

--- a/src/app/api/hn-digest/test/route.ts
+++ b/src/app/api/hn-digest/test/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 
 import { errorResponse } from "@/lib/api-utils";
-import { BASE_EMAIL, sendHNDigestEmail } from "@/lib/email";
+import { BASE_EMAIL, generateUnsubscribeUrl, sendHNDigestEmail } from "@/lib/email";
 import { getHNPostsForDigest } from "@/lib/hn";
-import { formatDigestDate, generateUnsubscribeUrl } from "@/lib/jwt";
+import { formatDigestDate } from "@/lib/urls";
 
 /**
  * Test endpoint for sending a sample HN digest email

--- a/src/app/api/hn-digest/unsubscribe/route.ts
+++ b/src/app/api/hn-digest/unsubscribe/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 
-import { BASE_URL } from "@/lib/email";
 import { verifyUnsubscribeToken } from "@/lib/jwt";
 import { deleteSubscription } from "@/lib/subscriptions";
+import { BASE_URL } from "@/lib/urls";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -2,6 +2,9 @@ import { ServerClient } from "postmark";
 
 import { HackerNewsPost } from "@/types/hackernews";
 
+import { generateUnsubscribeToken } from "./jwt";
+import { buildUnsubscribeUrl } from "./urls";
+
 /**
  * Email service for sending HN digest emails via Postmark
  */
@@ -9,10 +12,14 @@ import { HackerNewsPost } from "@/types/hackernews";
 // Email constants
 export const BASE_EMAIL = "hi@brianlovin.com";
 
-export const BASE_URL =
-  process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://brianlovin.com";
-
 const POSTMARK_TEMPLATE_ID = 18037634;
+
+/**
+ * Generate unsubscribe URL with JWT token
+ */
+export function generateUnsubscribeUrl(email: string): string {
+  return buildUnsubscribeUrl(generateUnsubscribeToken(email));
+}
 
 // Environment validation
 if (!process.env.POSTMARK_CLIENT_ID) {

--- a/src/lib/jwt.test.ts
+++ b/src/lib/jwt.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 const TEST_JWT_SIGNING_KEY = "test-jwt-signing-key-s08-1";
 
@@ -20,6 +20,16 @@ async function loadJwt() {
 }
 
 describe("jwt", () => {
+  const originalError = console.error;
+
+  beforeAll(() => {
+    console.error = () => {};
+  });
+
+  afterAll(() => {
+    console.error = originalError;
+  });
+
   test("does not import email.ts or postmark", () => {
     const src = readFileSync(join(import.meta.dir, "jwt.ts"), "utf8");
 

--- a/src/lib/jwt.test.ts
+++ b/src/lib/jwt.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const TEST_JWT_SIGNING_KEY = "test-jwt-signing-key-s08-1";
+
+async function loadJwt() {
+  const previousPostmark = process.env.POSTMARK_CLIENT_ID;
+  process.env.JWT_SIGNING_KEY = process.env.JWT_SIGNING_KEY || TEST_JWT_SIGNING_KEY;
+  delete process.env.POSTMARK_CLIENT_ID;
+
+  try {
+    return await import("./jwt");
+  } finally {
+    if (previousPostmark !== undefined) {
+      process.env.POSTMARK_CLIENT_ID = previousPostmark;
+    }
+  }
+}
+
+describe("jwt", () => {
+  test("does not import email.ts or postmark", () => {
+    const src = readFileSync(join(import.meta.dir, "jwt.ts"), "utf8");
+
+    expect(src).not.toContain("./email");
+    expect(src).not.toContain("@/lib/email");
+    expect(src.toLowerCase()).not.toContain("postmark");
+  });
+
+  test("signs and verifies { email } without constructing Postmark", async () => {
+    const { generateUnsubscribeToken, verifyUnsubscribeToken } = await loadJwt();
+    const email = "reader@example.com";
+
+    expect(verifyUnsubscribeToken(generateUnsubscribeToken(email))).toBe(email);
+  });
+
+  test("returns null for an invalid token", async () => {
+    const { verifyUnsubscribeToken } = await loadJwt();
+
+    expect(verifyUnsubscribeToken("not-a-jwt")).toBeNull();
+  });
+
+  test("returns null when the payload is not { email }", async () => {
+    process.env.JWT_SIGNING_KEY = process.env.JWT_SIGNING_KEY || TEST_JWT_SIGNING_KEY;
+    const jwt = await import("jsonwebtoken");
+    const { verifyUnsubscribeToken } = await loadJwt();
+    const token = jwt.default.sign({ notEmail: true }, process.env.JWT_SIGNING_KEY as string);
+
+    expect(verifyUnsubscribeToken(token)).toBeNull();
+  });
+});

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,11 +1,9 @@
-import { format } from "date-fns";
 import jwt from "jsonwebtoken";
 import { z } from "zod";
 
-import { BASE_URL } from "./email";
-
 /**
- * JWT token utilities for unsubscribe links and digest helpers
+ * JWT token utilities for unsubscribe links.
+ * Signs and verifies `{ email }` only — no URL construction, dates, or mailer.
  */
 
 if (!process.env.JWT_SIGNING_KEY) {
@@ -47,19 +45,4 @@ export function verifyUnsubscribeToken(token: string): string | null {
     console.error("Error verifying JWT token:", error);
     return null;
   }
-}
-
-/**
- * Generate unsubscribe URL with JWT token
- */
-export function generateUnsubscribeUrl(email: string): string {
-  const token = generateUnsubscribeToken(email);
-  return `${BASE_URL}/api/hn-digest/unsubscribe?token=${token}`;
-}
-
-/**
- * Format date for digest emails
- */
-export function formatDigestDate(date: Date = new Date()): string {
-  return format(date, "LLLL do, yyyy");
 }

--- a/src/lib/urls.test.ts
+++ b/src/lib/urls.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+describe("urls", () => {
+  test("does not import jwt, email, or postmark", () => {
+    const src = readFileSync(join(import.meta.dir, "urls.ts"), "utf8");
+
+    expect(src).not.toContain("./jwt");
+    expect(src).not.toContain("./email");
+    expect(src).not.toContain("@/lib/jwt");
+    expect(src).not.toContain("@/lib/email");
+    expect(src.toLowerCase()).not.toContain("postmark");
+  });
+
+  test("formatDigestDate is callable without JWT_SIGNING_KEY", async () => {
+    const previous = process.env.JWT_SIGNING_KEY;
+    delete process.env.JWT_SIGNING_KEY;
+
+    try {
+      const { formatDigestDate } = await import("./urls");
+      expect(formatDigestDate(new Date(2026, 7, 15))).toBe("August 15th, 2026");
+    } finally {
+      if (previous !== undefined) {
+        process.env.JWT_SIGNING_KEY = previous;
+      }
+    }
+  });
+
+  test("buildUnsubscribeUrl keeps the hn-digest unsubscribe path", async () => {
+    const { BASE_URL, buildUnsubscribeUrl } = await import("./urls");
+
+    expect(buildUnsubscribeUrl("abc.def.ghi")).toBe(
+      `${BASE_URL}/api/hn-digest/unsubscribe?token=abc.def.ghi`,
+    );
+  });
+});

--- a/src/lib/urls.test.ts
+++ b/src/lib/urls.test.ts
@@ -6,12 +6,14 @@ import { describe, expect, test } from "bun:test";
 describe("urls", () => {
   test("does not import jwt, email, or postmark", () => {
     const src = readFileSync(join(import.meta.dir, "urls.ts"), "utf8");
+    const imports = src
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
 
-    expect(src).not.toContain("./jwt");
-    expect(src).not.toContain("./email");
-    expect(src).not.toContain("@/lib/jwt");
-    expect(src).not.toContain("@/lib/email");
-    expect(src.toLowerCase()).not.toContain("postmark");
+    expect(imports).not.toContain("jwt");
+    expect(imports).not.toContain("email");
+    expect(imports).not.toContain("postmark");
   });
 
   test("formatDigestDate is callable without JWT_SIGNING_KEY", async () => {

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,24 @@
+import { format } from "date-fns";
+
+/**
+ * Site origin and digest helpers that must stay free of Postmark and JWT.
+ * Unsubscribe verify and date formatting should not construct a mailer.
+ */
+
+export const BASE_URL =
+  process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://brianlovin.com";
+
+/**
+ * Format date for digest emails
+ */
+export function formatDigestDate(date: Date = new Date()): string {
+  return format(date, "LLLL do, yyyy");
+}
+
+/**
+ * Build the HN digest unsubscribe URL for a signed token.
+ * Path is `/api/hn-digest/unsubscribe?token=` (old `/api/hn/unsubscribe` redirects).
+ */
+export function buildUnsubscribeUrl(token: string): string {
+  return `${BASE_URL}/api/hn-digest/unsubscribe?token=${token}`;
+}

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,7 +1,7 @@
 import { format } from "date-fns";
 
 /**
- * Site origin and digest helpers that must stay free of Postmark and JWT.
+ * Site origin and digest helpers with no mailer or token dependency.
  * Unsubscribe verify and date formatting should not construct a mailer.
  */
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S08-1 of the structure audit: `jwt.ts` no longer imports the Postmark client (or anything that constructs it at import time).

`src/lib/jwt.ts` previously imported `BASE_URL` from `email.ts`. That module throws if `POSTMARK_CLIENT_ID` is unset and constructs `ServerClient` on import, so the HN digest unsubscribe verify-only path paid for the mailer. `formatDigestDate` was also trapped behind `JWT_SIGNING_KEY`.

This PR is JWT/email coupling only. It does not change digest copy, Postmark templates, subscriber storage, or JWT hardening (`exp` / alg).

### Changes

- `jwt.ts` only signs and verifies `{ email }`. Signing/verify needs `JWT_SIGNING_KEY` only.
- `BASE_URL`, `formatDigestDate`, and `buildUnsubscribeUrl` live in `src/lib/urls.ts` (no Postmark, no JWT).
- Digest send/test build unsubscribe URLs via `email.ts` → `generateUnsubscribeToken` + `buildUnsubscribeUrl`.
- Unsubscribe route still verifies `?token=` and redirects to `/hn`. Path remains `/api/hn-digest/unsubscribe?token=` (`next.config` already redirects `/api/hn/unsubscribe`).

## Test plan

- [x] `bun test` — 117 pass / 0 fail. jwt unit tests import/verify without constructing Postmark; `formatDigestDate` runs with `JWT_SIGNING_KEY` unset
- [x] Lint and `tsc --noEmit` clean for touched files
- [x] Grep: `jwt.ts` does not import `email.ts` or `postmark`; unsubscribe route still calls `verifyUnsubscribeToken`
- [x] Missing `POSTMARK_CLIENT_ID` does not break token verify (jwt unit tests delete that env var before import)
- [x] Unsubscribe URL helper still emits `/api/hn-digest/unsubscribe?token=` (no copy/template changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3310f0eb-4313-4968-a321-da3f61e5a666?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3310f0eb-4313-4968-a321-da3f61e5a666&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

