### PR TITLE
Replace grab-bag ProcessedBlock with a discriminated union

### DIFF
--- a/src/components/renderBlocks.test.tsx
+++ b/src/components/renderBlocks.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { ProcessedBlock, RichTextContent } from "@/lib/notion";
+
+import { renderBlocks } from "./renderBlocks";
+
+function text(content: string): RichTextContent {
+  return {
+    type: "text",
+    text: { content, link: undefined },
+    annotations: {
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: "default",
+    },
+  };
+}
+
+function html(blocks: ProcessedBlock[]): string {
+  return renderToStaticMarkup(<div>{renderBlocks(blocks)}</div>);
+}
+
+describe("renderBlocks", () => {
+  test("renders image from url, not content[0]", () => {
+    const markup = html([{ id: "img-1", type: "image", url: "https://cdn.example/photo.jpg" }]);
+
+    expect(markup).toContain('src="https://cdn.example/photo.jpg"');
+    expect(markup).toContain("<img");
+  });
+
+  test("renders to_do checked state", () => {
+    const checked = html([{ id: "todo-1", type: "to_do", content: [text("Done")], checked: true }]);
+    const unchecked = html([
+      { id: "todo-2", type: "to_do", content: [text("Open")], checked: false },
+    ]);
+
+    expect(checked).toContain("Done");
+    expect(checked).toMatch(/checked/);
+    expect(unchecked).toContain("Open");
+    expect(unchecked).not.toMatch(/checked/);
+  });
+
+  test("renders video from videoUrl", () => {
+    const markup = html([{ id: "vid-1", type: "video", videoUrl: "https://cdn.example/clip.mp4" }]);
+
+    expect(markup).toContain("<video");
+    expect(markup).toContain('src="https://cdn.example/clip.mp4"');
+  });
+});

--- a/src/components/renderBlocks.test.tsx
+++ b/src/components/renderBlocks.test.tsx
@@ -50,4 +50,43 @@ describe("renderBlocks", () => {
     expect(markup).toContain("<video");
     expect(markup).toContain('src="https://cdn.example/clip.mp4"');
   });
+
+  test("keeps nested mixed list runs as separate ul then ol", () => {
+    const markup = html([
+      {
+        id: "parent",
+        type: "bulleted_list_item",
+        content: [text("Parent")],
+        children: [
+          { id: "b1", type: "bulleted_list_item", content: [text("Nested bullet")] },
+          { id: "n1", type: "numbered_list_item", content: [text("Nested number")] },
+        ],
+      },
+    ]);
+
+    expect(markup).toContain("Nested bullet");
+    expect(markup).toContain("Nested number");
+    expect(markup).toMatch(/Nested bullet[\s\S]*?<\/ul><ol[\s\S]*?Nested number/);
+    expect((markup.match(/<ul/g) ?? []).length).toBe(2);
+    expect((markup.match(/<ol/g) ?? []).length).toBe(1);
+  });
+
+  test("preview mode skips list-run grouping", () => {
+    const markup = renderToStaticMarkup(
+      <div>
+        {renderBlocks(
+          [
+            { id: "b1", type: "bulleted_list_item", content: [text("A")] },
+            { id: "b2", type: "bulleted_list_item", content: [text("B")] },
+          ],
+          true,
+        )}
+      </div>,
+    );
+
+    expect(markup).not.toContain("<ul");
+    expect(markup).not.toContain("<ol");
+    expect(markup).toContain("A");
+    expect(markup).toContain("B");
+  });
 });

--- a/src/components/renderBlocks.tsx
+++ b/src/components/renderBlocks.tsx
@@ -1,7 +1,12 @@
 import { ReactNode } from "react";
 
 import { CodeBlock } from "@/components/CodeBlock";
-import type { ProcessedBlock, RichTextContent, RichTextItemResponse } from "@/lib/notion";
+import {
+  type ProcessedBlock,
+  type RichTextContent,
+  type RichTextItemResponse,
+  richTextPlainText,
+} from "@/lib/notion";
 
 // URL regex pattern to match http/https URLs
 const URL_REGEX = /(https?:\/\/[^\s]+)/g;
@@ -101,63 +106,64 @@ function renderChildList(children: ProcessedBlock[]): ReactNode {
 
 function renderSingleBlock(block: ProcessedBlock, isPreview: boolean): ReactNode {
   if (isPreview) {
-    // For preview mode, render all blocks as paragraphs with rich text
-    if (block.type === "table" && block.tableRows) {
+    if (block.type === "table") {
       return (
         <p key={block.id} className="text-secondary leading-[1.6]">
-          [Table with {block.tableRows.length} rows]
+          [Table with {block.tableRows?.length ?? 0} rows]
         </p>
       );
     }
-    return (
-      <p key={block.id} className="text-secondary leading-[1.6]">
-        {renderRichText(block.content)}
-      </p>
-    );
-  }
-
-  // Full rendering mode - handle table blocks with their children rows
-  if (block.type === "table" && block.tableRows) {
-    return (
-      <div key={block.id} className="my-6 overflow-x-auto">
-        <table className="border-secondary w-full border-collapse rounded-md border text-sm">
-          <tbody>
-            {block.tableRows.map((row, rowIndex) => {
-              const cells = row.cells || [];
-              const isHeaderRow = rowIndex === 0 && block.hasColumnHeader;
-
-              return (
-                <tr key={row.id} className={isHeaderRow ? "bg-tertiary" : ""}>
-                  {cells.map((cell, cellIndex) => {
-                    const cellContent = cell.map(
-                      (richText: RichTextItemResponse, index: number) => (
-                        <span key={index}>{richText.plain_text}</span>
-                      ),
-                    );
-
-                    const CellComponent = isHeaderRow ? "th" : "td";
-
-                    return (
-                      <CellComponent
-                        key={cellIndex}
-                        className={`border-secondary border px-3 py-2 text-left ${
-                          isHeaderRow ? "text-primary font-semibold" : "text-secondary"
-                        }`}
-                      >
-                        {cellContent.length > 0 ? cellContent : ""}
-                      </CellComponent>
-                    );
-                  })}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    );
+    if ("content" in block) {
+      return (
+        <p key={block.id} className="text-secondary leading-[1.6]">
+          {renderRichText(block.content)}
+        </p>
+      );
+    }
+    return null;
   }
 
   switch (block.type) {
+    case "table": {
+      if (!block.tableRows) return null;
+
+      return (
+        <div key={block.id} className="my-6 overflow-x-auto">
+          <table className="border-secondary w-full border-collapse rounded-md border text-sm">
+            <tbody>
+              {block.tableRows.map((row, rowIndex) => {
+                const isHeaderRow = rowIndex === 0 && block.hasColumnHeader;
+
+                return (
+                  <tr key={row.id} className={isHeaderRow ? "bg-tertiary" : ""}>
+                    {row.cells.map((cell, cellIndex) => {
+                      const cellContent = cell.map(
+                        (richText: RichTextItemResponse, index: number) => (
+                          <span key={index}>{richText.plain_text}</span>
+                        ),
+                      );
+
+                      const CellComponent = isHeaderRow ? "th" : "td";
+
+                      return (
+                        <CellComponent
+                          key={cellIndex}
+                          className={`border-secondary border px-3 py-2 text-left ${
+                            isHeaderRow ? "text-primary font-semibold" : "text-secondary"
+                          }`}
+                        >
+                          {cellContent.length > 0 ? cellContent : ""}
+                        </CellComponent>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
     case "quote":
       return (
         <blockquote
@@ -208,7 +214,7 @@ function renderSingleBlock(block: ProcessedBlock, isPreview: boolean): ReactNode
     case "to_do":
       return (
         <div key={block.id} className="text-secondary flex items-start gap-2 leading-[1.6]">
-          <input type="checkbox" disabled className="mt-1" />
+          <input type="checkbox" disabled checked={block.checked} className="mt-1" />
           <span>{renderRichText(block.content)}</span>
         </div>
       );
@@ -222,8 +228,8 @@ function renderSingleBlock(block: ProcessedBlock, isPreview: boolean): ReactNode
       return (
         <CodeBlock
           key={block.id}
-          code={block.content.map((text) => text.text.content).join("")}
-          language={block.language || "plaintext"}
+          code={richTextPlainText(block.content)}
+          language={block.language}
         />
       );
     case "divider":
@@ -232,12 +238,7 @@ function renderSingleBlock(block: ProcessedBlock, isPreview: boolean): ReactNode
       return (
         <div key={block.id}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={block.content[0].text.content}
-            alt=""
-            className="w-full rounded-lg"
-            loading="lazy"
-          />
+          <img src={block.url} alt="" className="w-full rounded-lg" loading="lazy" />
         </div>
       );
     case "video":

--- a/src/components/renderBlocks.tsx
+++ b/src/components/renderBlocks.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from "react";
 
 import { CodeBlock } from "@/components/CodeBlock";
 import {
+  groupListRuns,
+  type ListRun,
   type ProcessedBlock,
   type RichTextContent,
   type RichTextItemResponse,
@@ -93,15 +95,28 @@ function renderRichText(richText: RichTextContent[]) {
   });
 }
 
-function renderChildList(children: ProcessedBlock[]): ReactNode {
-  const hasBulleted = children.some((c) => c.type === "bulleted_list_item");
-  const hasNumbered = children.some((c) => c.type === "numbered_list_item");
-  const Tag = hasNumbered && !hasBulleted ? "ol" : "ul";
-  const listClass = Tag === "ol" ? "space-y-2 mt-2" : "list-disc space-y-2 mt-2";
+function listClassName(type: "bulleted_list_item" | "numbered_list_item", nested: boolean): string {
+  if (type === "numbered_list_item") {
+    return nested ? "space-y-2 mt-2" : "space-y-2";
+  }
+  return nested ? "list-disc space-y-2 mt-2" : "list-disc space-y-2";
+}
 
+function renderListRun(run: ListRun, isPreview: boolean, nested: boolean): ReactNode {
+  if (run.kind === "block") {
+    return renderSingleBlock(run.block, isPreview);
+  }
+
+  const Tag = run.type === "numbered_list_item" ? "ol" : "ul";
   return (
-    <Tag className={listClass}>{children.map((child) => renderSingleBlock(child, false))}</Tag>
+    <Tag key={`${Tag}-${run.items[0].id}`} className={listClassName(run.type, nested)}>
+      {run.items.map((item) => renderSingleBlock(item, isPreview))}
+    </Tag>
   );
+}
+
+function renderChildList(children: ProcessedBlock[]): ReactNode {
+  return groupListRuns(children).map((run) => renderListRun(run, false, true));
 }
 
 function renderSingleBlock(block: ProcessedBlock, isPreview: boolean): ReactNode {
@@ -259,52 +274,9 @@ function renderSingleBlock(block: ProcessedBlock, isPreview: boolean): ReactNode
 }
 
 export function renderBlocks(blocks: ProcessedBlock[], isPreview: boolean = false): ReactNode[] {
-  const result: ReactNode[] = [];
-  let i = 0;
-
-  while (i < blocks.length) {
-    const block = blocks[i];
-
-    // Group consecutive bulleted list items
-    if (block.type === "bulleted_list_item" && !isPreview) {
-      const listItems: ReactNode[] = [];
-      const startIndex = i;
-
-      while (i < blocks.length && blocks[i].type === "bulleted_list_item") {
-        listItems.push(renderSingleBlock(blocks[i], isPreview));
-        i++;
-      }
-
-      result.push(
-        <ul key={`ul-${blocks[startIndex].id}`} className="list-disc space-y-2">
-          {listItems}
-        </ul>,
-      );
-      continue;
-    }
-
-    // Group consecutive numbered list items
-    if (block.type === "numbered_list_item" && !isPreview) {
-      const listItems: ReactNode[] = [];
-      const startIndex = i;
-
-      while (i < blocks.length && blocks[i].type === "numbered_list_item") {
-        listItems.push(renderSingleBlock(blocks[i], isPreview));
-        i++;
-      }
-
-      result.push(
-        <ol key={`ol-${blocks[startIndex].id}`} className="space-y-2">
-          {listItems}
-        </ol>,
-      );
-      continue;
-    }
-
-    // Render non-list blocks normally
-    result.push(renderSingleBlock(block, isPreview));
-    i++;
+  if (isPreview) {
+    return blocks.map((block) => renderSingleBlock(block, true));
   }
 
-  return result;
+  return groupListRuns(blocks).map((run) => renderListRun(run, false, false));
 }

--- a/src/lib/notion/blocks.test.ts
+++ b/src/lib/notion/blocks.test.ts
@@ -1,0 +1,230 @@
+import type {
+  BlockObjectResponse,
+  RichTextItemResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+import { describe, expect, test } from "bun:test";
+
+import { processBlockFromResponse } from "./blocks";
+import { extractPreviewText } from "./types";
+
+function richTextItem(content: string): RichTextItemResponse {
+  return {
+    type: "text",
+    text: { content, link: null },
+    annotations: {
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: "default",
+    },
+    plain_text: content,
+    href: null,
+  };
+}
+
+function asBlock(block: object): BlockObjectResponse {
+  return block as BlockObjectResponse;
+}
+
+describe("processBlockFromResponse", () => {
+  test("maps a paragraph to rich text content", () => {
+    const result = processBlockFromResponse(
+      asBlock({
+        id: "p1",
+        type: "paragraph",
+        paragraph: { rich_text: [richTextItem("Hello")] },
+      }),
+    );
+
+    expect(result).toEqual({
+      id: "p1",
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: { content: "Hello", link: undefined },
+          annotations: {
+            bold: false,
+            italic: false,
+            strikethrough: false,
+            underline: false,
+            code: false,
+            color: "default",
+          },
+        },
+      ],
+    });
+  });
+
+  test("keeps to_do checked state", () => {
+    const checked = processBlockFromResponse(
+      asBlock({
+        id: "todo-1",
+        type: "to_do",
+        to_do: { rich_text: [richTextItem("Done")], checked: true },
+      }),
+    );
+    const unchecked = processBlockFromResponse(
+      asBlock({
+        id: "todo-2",
+        type: "to_do",
+        to_do: { rich_text: [richTextItem("Open")], checked: false },
+      }),
+    );
+
+    expect(checked).toMatchObject({ type: "to_do", checked: true });
+    expect(unchecked).toMatchObject({ type: "to_do", checked: false });
+    expect(checked).not.toHaveProperty("videoUrl");
+    expect(checked).not.toHaveProperty("url");
+  });
+
+  test("maps image to a real url, not fake rich text", () => {
+    const external = processBlockFromResponse(
+      asBlock({
+        id: "img-ext",
+        type: "image",
+        image: { type: "external", external: { url: "https://cdn.example/pic.jpg" } },
+      }),
+    );
+    const file = processBlockFromResponse(
+      asBlock({
+        id: "img-file",
+        type: "image",
+        image: { type: "file", file: { url: "https://notion.so/file.png" } },
+      }),
+    );
+
+    expect(external).toEqual({
+      id: "img-ext",
+      type: "image",
+      url: "https://cdn.example/pic.jpg",
+    });
+    expect(file).toEqual({
+      id: "img-file",
+      type: "image",
+      url: "https://notion.so/file.png",
+    });
+    expect(external).not.toHaveProperty("content");
+  });
+
+  test("maps video to videoUrl without content", () => {
+    const result = processBlockFromResponse(
+      asBlock({
+        id: "vid-1",
+        type: "video",
+        video: { type: "external", external: { url: "https://cdn.example/clip.mp4" } },
+      }),
+    );
+
+    expect(result).toEqual({
+      id: "vid-1",
+      type: "video",
+      videoUrl: "https://cdn.example/clip.mp4",
+    });
+    expect(result).not.toHaveProperty("content");
+  });
+
+  test("maps code language and table metadata", () => {
+    const code = processBlockFromResponse(
+      asBlock({
+        id: "code-1",
+        type: "code",
+        code: { rich_text: [richTextItem("const x = 1")], language: "typescript" },
+      }),
+    );
+    const table = processBlockFromResponse(
+      asBlock({
+        id: "table-1",
+        type: "table",
+        table: { table_width: 3, has_column_header: true, has_row_header: false },
+      }),
+    );
+    const row = processBlockFromResponse(
+      asBlock({
+        id: "row-1",
+        type: "table_row",
+        table_row: { cells: [[richTextItem("A")], [richTextItem("B")]] },
+      }),
+    );
+
+    expect(code).toMatchObject({ type: "code", language: "typescript" });
+    expect(table).toEqual({
+      id: "table-1",
+      type: "table",
+      tableWidth: 3,
+      hasColumnHeader: true,
+      hasRowHeader: false,
+    });
+    expect(row).toMatchObject({
+      type: "table_row",
+      cells: [[richTextItem("A")], [richTextItem("B")]],
+    });
+    expect(table).not.toHaveProperty("content");
+    expect(row).not.toHaveProperty("content");
+  });
+
+  test("maps divider without content and drops unsupported types", () => {
+    expect(
+      processBlockFromResponse(
+        asBlock({
+          id: "div-1",
+          type: "divider",
+          divider: {},
+        }),
+      ),
+    ).toEqual({ id: "div-1", type: "divider" });
+
+    expect(processBlockFromResponse(asBlock({ id: "bm-1", type: "bookmark", bookmark: {} }))).toBe(
+      null,
+    );
+  });
+});
+
+describe("extractPreviewText", () => {
+  test("joins paragraph text and ignores image/video blocks", () => {
+    const text = extractPreviewText([
+      {
+        id: "p1",
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: { content: "Hello", link: undefined },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: "default",
+            },
+          },
+        ],
+      },
+      { id: "img", type: "image", url: "https://cdn.example/x.jpg" },
+      { id: "vid", type: "video", videoUrl: "https://cdn.example/x.mp4" },
+      {
+        id: "p2",
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: { content: "World", link: undefined },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: "default",
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(text).toBe("Hello\n\nWorld");
+  });
+});

--- a/src/lib/notion/blocks.ts
+++ b/src/lib/notion/blocks.ts
@@ -4,7 +4,12 @@ import type {
 } from "@notionhq/client/build/src/api-endpoints";
 
 import { notion } from "./client";
-import type { ProcessedBlock, RichTextContent } from "./types";
+import {
+  isTableRowBlock,
+  type ProcessedBlock,
+  type RichTextContent,
+  type TableRowBlock,
+} from "./types";
 
 // Helper to convert Notion rich text to our processed format
 function processRichText(richText: RichTextItemResponse[]): RichTextContent[] {
@@ -77,6 +82,7 @@ export function processBlockFromResponse(block: BlockObjectResponse): ProcessedB
           id: block.id,
           type: "to_do",
           content: processRichText(block.to_do.rich_text),
+          checked: block.to_do.checked,
         };
 
       case "toggle":
@@ -112,32 +118,15 @@ export function processBlockFromResponse(block: BlockObjectResponse): ProcessedB
         return {
           id: block.id,
           type: "divider",
-          content: [],
         };
 
       case "image": {
-        const imageUrl =
+        const url =
           block.image.type === "external" ? block.image.external.url : block.image.file.url;
         return {
           id: block.id,
           type: "image",
-          content: [
-            {
-              type: "text",
-              text: {
-                content: imageUrl,
-                link: undefined,
-              },
-              annotations: {
-                bold: false,
-                italic: false,
-                strikethrough: false,
-                underline: false,
-                code: false,
-                color: "default",
-              },
-            },
-          ],
+          url,
         };
       }
 
@@ -147,7 +136,6 @@ export function processBlockFromResponse(block: BlockObjectResponse): ProcessedB
         return {
           id: block.id,
           type: "video",
-          content: [],
           videoUrl,
         };
       }
@@ -156,7 +144,6 @@ export function processBlockFromResponse(block: BlockObjectResponse): ProcessedB
         return {
           id: block.id,
           type: "table",
-          content: [], // Table blocks don't have direct content, children are table_row blocks
           tableWidth: block.table.table_width,
           hasColumnHeader: block.table.has_column_header,
           hasRowHeader: block.table.has_row_header,
@@ -166,7 +153,6 @@ export function processBlockFromResponse(block: BlockObjectResponse): ProcessedB
         return {
           id: block.id,
           type: "table_row",
-          content: [],
           cells: block.table_row.cells,
         };
 
@@ -217,7 +203,7 @@ export async function getAllBlocks(pageId: string): Promise<ProcessedBlock[]> {
     for (const { block: blockObj, processed: processedBlock } of processed) {
       if (!processedBlock || !blockObj.has_children) continue;
 
-      if (blockObj.type === "table") {
+      if (processedBlock.type === "table") {
         try {
           const childrenResponse = await notion.blocks.children.list({
             block_id: blockObj.id,
@@ -225,13 +211,16 @@ export async function getAllBlocks(pageId: string): Promise<ProcessedBlock[]> {
           });
           processedBlock.tableRows = childrenResponse.results
             .map((childBlock) => processBlockFromResponse(childBlock as BlockObjectResponse))
-            .filter((row): row is ProcessedBlock => row !== null && row.type === "table_row");
+            .filter((row): row is TableRowBlock => row !== null && isTableRowBlock(row));
         } catch (error) {
           console.error(`Error fetching table children for ${blockObj.id}:`, error);
         }
       }
 
-      if (blockObj.type === "bulleted_list_item" || blockObj.type === "numbered_list_item") {
+      if (
+        processedBlock.type === "bulleted_list_item" ||
+        processedBlock.type === "numbered_list_item"
+      ) {
         try {
           const childrenResponse = await notion.blocks.children.list({
             block_id: blockObj.id,

--- a/src/lib/notion/cache.test.ts
+++ b/src/lib/notion/cache.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { CONTENT_CACHE_VERSION, notionContentCacheKey } from "./cache";
+
+describe("notionContentCacheKey", () => {
+  test("bumps processed content keys to v2", () => {
+    expect(CONTENT_CACHE_VERSION).toBe("v2");
+    expect(notionContentCacheKey(null, "page-1")).toBe("notion:content:v2:page-1");
+    expect(notionContentCacheKey("writing", "page-1")).toBe("notion:writing:content:v2:page-1");
+    expect(notionContentCacheKey("writing", "slug", "hello")).toBe(
+      "notion:writing:content:v2:slug:hello",
+    );
+    expect(notionContentCacheKey("til", "shortid", "abc1234")).toBe(
+      "notion:til:content:v2:shortid:abc1234",
+    );
+    expect(notionContentCacheKey("app-dissection", "instagram")).toBe(
+      "notion:app-dissection:content:v2:instagram",
+    );
+  });
+});

--- a/src/lib/notion/cache.ts
+++ b/src/lib/notion/cache.ts
@@ -33,6 +33,24 @@ export const CACHE_TTLS = {
   DATA_SOURCE: 86400,
 } as const;
 
+/**
+ * Bumped when the serialized ProcessedBlock shape changes so Next (24h) and
+ * Redis (7d) cannot serve the old grab-bag payload as the new union.
+ */
+export const CONTENT_CACHE_VERSION = "v2";
+
+/**
+ * Cache key for processed page content.
+ * `notionContentCacheKey("writing", pageId)` → `notion:writing:content:v2:<id>`
+ * `notionContentCacheKey(null, pageId)` → `notion:content:v2:<id>`
+ */
+export function notionContentCacheKey(collection: string | null, ...parts: string[]): string {
+  if (collection) {
+    return ["notion", collection, "content", CONTENT_CACHE_VERSION, ...parts].join(":");
+  }
+  return ["notion", "content", CONTENT_CACHE_VERSION, ...parts].join(":");
+}
+
 /** Redis key TTL: 7 days (emergency fallback window) */
 const REDIS_KEY_TTL = 7 * 24 * 3600;
 
@@ -42,7 +60,7 @@ interface CachedNotionQueryOptions {
 }
 
 /**
- * Derive a coarse cache tag from a key like `notion:writing:content:<id>`.
+ * Derive a coarse cache tag from a key like `notion:writing:content:v2:<id>`.
  * Returns the first two segments so a whole content type can be invalidated
  * at once via `revalidateTag("notion:writing", "max")`.
  */

--- a/src/lib/notion/index.ts
+++ b/src/lib/notion/index.ts
@@ -3,11 +3,17 @@ export { notion } from "./client";
 
 // Types
 export type {
-  // SDK types
   BlockObjectResponse,
+  BulletedListItemBlock,
+  CalloutBlock,
   DatabaseObjectResponse,
+  DividerBlock,
   GoodWebsiteItem,
   GoodWebsiteItemWithDate,
+  Heading1Block,
+  Heading2Block,
+  Heading3Block,
+  ImageBlock,
   NotionAmaItem,
   NotionAmaItemWithContent,
   NotionAppDissectionItem,
@@ -20,19 +26,35 @@ export type {
   NotionTilItem,
   NotionTilItemWithContent,
   NotionWritingItem,
+  NumberedListItemBlock,
   PageObjectResponse,
   PageResponse,
+  ParagraphBlock,
   PartialDatabaseObjectResponse,
   PartialPageObjectResponse,
   PreviewStatus,
   ProcessedBlock,
+  ProcessedCodeBlock,
+  QuoteBlock,
   RichTextContent,
   RichTextItemResponse,
+  TableBlock,
+  TableRowBlock,
+  TodoBlock,
+  ToggleBlock,
+  VideoBlock,
 } from "./types";
 export { PREVIEW_STATUSES } from "./types";
 
 // Type guards and utilities
-export { extractPlainText, hasProperties, isBlockObjectResponse, isFullPage } from "./types";
+export {
+  extractPlainText,
+  hasProperties,
+  isBlockObjectResponse,
+  isFullPage,
+  isTableRowBlock,
+  richTextPlainText,
+} from "./types";
 
 // Block processing
 export { getAllBlocks, processBlockFromResponse } from "./blocks";
@@ -70,7 +92,7 @@ export {
 } from "./queries";
 
 // Cache
-export { invalidateNotionCache } from "./cache";
+export { CONTENT_CACHE_VERSION, invalidateNotionCache, notionContentCacheKey } from "./cache";
 
 // Mutations
 export {

--- a/src/lib/notion/index.ts
+++ b/src/lib/notion/index.ts
@@ -14,6 +14,7 @@ export type {
   Heading2Block,
   Heading3Block,
   ImageBlock,
+  ListItemBlock,
   NotionAmaItem,
   NotionAmaItemWithContent,
   NotionAppDissectionItem,
@@ -47,11 +48,14 @@ export type {
 export { PREVIEW_STATUSES } from "./types";
 
 // Type guards and utilities
+export type { ListRun } from "./list-runs";
+export { groupListRuns } from "./list-runs";
 export {
   extractPlainText,
   hasProperties,
   isBlockObjectResponse,
   isFullPage,
+  isListItemBlock,
   isTableRowBlock,
   richTextPlainText,
 } from "./types";

--- a/src/lib/notion/list-runs.test.ts
+++ b/src/lib/notion/list-runs.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { groupListRuns } from "./list-runs";
+import type { ProcessedBlock, RichTextContent } from "./types";
+
+function text(content: string): RichTextContent {
+  return {
+    type: "text",
+    text: { content, link: undefined },
+    annotations: {
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: "default",
+    },
+  };
+}
+
+function bullet(id: string, label: string): ProcessedBlock {
+  return { id, type: "bulleted_list_item", content: [text(label)] };
+}
+
+function numbered(id: string, label: string): ProcessedBlock {
+  return { id, type: "numbered_list_item", content: [text(label)] };
+}
+
+describe("groupListRuns", () => {
+  test("groups consecutive same-type list items and splits mixed runs", () => {
+    const runs = groupListRuns([
+      bullet("b1", "one"),
+      bullet("b2", "two"),
+      numbered("n1", "first"),
+      numbered("n2", "second"),
+      { id: "p1", type: "paragraph", content: [text("break")] },
+      bullet("b3", "again"),
+    ]);
+
+    expect(runs.map((run) => run.kind + (run.kind === "list" ? `:${run.type}` : ""))).toEqual([
+      "list:bulleted_list_item",
+      "list:numbered_list_item",
+      "block",
+      "list:bulleted_list_item",
+    ]);
+    expect(runs[0].kind === "list" && runs[0].items.map((item) => item.id)).toEqual(["b1", "b2"]);
+    expect(runs[1].kind === "list" && runs[1].items.map((item) => item.id)).toEqual(["n1", "n2"]);
+  });
+});

--- a/src/lib/notion/list-runs.ts
+++ b/src/lib/notion/list-runs.ts
@@ -1,0 +1,53 @@
+import type {
+  BulletedListItemBlock,
+  ListItemBlock,
+  NumberedListItemBlock,
+  ProcessedBlock,
+} from "./types";
+
+export type ListRun =
+  | { kind: "list"; type: "bulleted_list_item"; items: BulletedListItemBlock[] }
+  | { kind: "list"; type: "numbered_list_item"; items: NumberedListItemBlock[] }
+  | { kind: "block"; block: Exclude<ProcessedBlock, ListItemBlock> };
+
+/**
+ * Group consecutive same-type list items so mixed bullet/number runs
+ * stay as separate lists at every depth.
+ */
+export function groupListRuns(blocks: ProcessedBlock[]): ListRun[] {
+  const runs: ListRun[] = [];
+  let i = 0;
+
+  while (i < blocks.length) {
+    const block = blocks[i];
+
+    if (block.type === "bulleted_list_item") {
+      const items: BulletedListItemBlock[] = [];
+      while (i < blocks.length) {
+        const next = blocks[i];
+        if (next.type !== "bulleted_list_item") break;
+        items.push(next);
+        i++;
+      }
+      runs.push({ kind: "list", type: "bulleted_list_item", items });
+      continue;
+    }
+
+    if (block.type === "numbered_list_item") {
+      const items: NumberedListItemBlock[] = [];
+      while (i < blocks.length) {
+        const next = blocks[i];
+        if (next.type !== "numbered_list_item") break;
+        items.push(next);
+        i++;
+      }
+      runs.push({ kind: "list", type: "numbered_list_item", items });
+      continue;
+    }
+
+    runs.push({ kind: "block", block });
+    i++;
+  }
+
+  return runs;
+}

--- a/src/lib/notion/queries.ts
+++ b/src/lib/notion/queries.ts
@@ -1,7 +1,7 @@
 import type { DatabaseObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 
 import { getAllBlocks } from "./blocks";
-import { CACHE_TTLS, cachedNotionQuery } from "./cache";
+import { CACHE_TTLS, cachedNotionQuery, notionContentCacheKey } from "./cache";
 import { notion } from "./client";
 import {
   createdTime,
@@ -35,6 +35,7 @@ import {
   type NotionWritingItem,
   type PageResponse,
   type ProcessedBlock,
+  richTextPlainText,
 } from "./types";
 
 async function getDataSourceId(databaseId: string): Promise<string> {
@@ -247,14 +248,14 @@ function parseAppDissectionDetails(blocks: ProcessedBlock[]): {
         details.push(currentDetail);
       }
       currentDetail = {
-        title: block.content.map((c) => c.text.content).join(""),
+        title: richTextPlainText(block.content),
         descriptionBlocks: [],
       };
       continue;
     }
 
     if (block.type === "code" && block.language === "json" && currentDetail) {
-      const jsonContent = block.content.map((c) => c.text.content).join("");
+      const jsonContent = richTextPlainText(block.content);
       try {
         const parsed = JSON.parse(jsonContent);
         if (isValidVideoMetadata(parsed)) {
@@ -286,7 +287,7 @@ export async function getFullContent(
   pageId: string,
 ): Promise<{ blocks: ProcessedBlock[]; metadata: NotionItem } | null> {
   return cachedNotionQuery(
-    `notion:content:${pageId}`,
+    notionContentCacheKey(null, pageId),
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
       const metadata = mapGenericItem(page);
@@ -420,7 +421,7 @@ export async function getWritingPostContent(
   pageId: string,
 ): Promise<{ blocks: ProcessedBlock[]; metadata: NotionWritingItem } | null> {
   return cachedNotionQuery(
-    `notion:writing:content:${pageId}`,
+    notionContentCacheKey("writing", pageId),
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
       const metadata = mapWritingItem(page);
@@ -438,7 +439,7 @@ export async function getWritingPostContentBySlug(
   slug: string,
 ): Promise<{ blocks: ProcessedBlock[]; metadata: NotionWritingItem } | null> {
   return cachedNotionQuery(
-    `notion:writing:content:slug:${slug}`,
+    notionContentCacheKey("writing", "slug", slug),
     async () => {
       const databaseId = process.env.NOTION_WRITING_DATABASE_ID || "";
       const dataSourceId = await getDataSourceId(databaseId);
@@ -469,7 +470,7 @@ export async function getWritingPostByShortId(
   shortId: string,
 ): Promise<{ blocks: ProcessedBlock[]; metadata: NotionWritingItem } | null> {
   return cachedNotionQuery(
-    `notion:writing:content:shortid:${shortId}`,
+    notionContentCacheKey("writing", "shortid", shortId),
     async () => {
       const databaseId = process.env.NOTION_WRITING_DATABASE_ID || "";
       const dataSourceId = await getDataSourceId(databaseId);
@@ -500,7 +501,7 @@ export async function getWritingPostByShortId(
 
 export async function getAmaItemContent(pageId: string): Promise<NotionAmaItemWithContent | null> {
   return cachedNotionQuery(
-    `notion:ama:content:${pageId}`,
+    notionContentCacheKey("ama", pageId),
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
       const item = mapAmaItem(page);
@@ -697,7 +698,7 @@ export async function getTilDatabaseItems(
 
 export async function getTilItemContent(pageId: string): Promise<NotionTilItemWithContent | null> {
   return cachedNotionQuery(
-    `notion:til:content:${pageId}`,
+    notionContentCacheKey("til", pageId),
     async () => {
       const page = await notion.pages.retrieve({ page_id: pageId });
       const item = mapTilItem(page);
@@ -716,7 +717,7 @@ export async function getTilItemContent(pageId: string): Promise<NotionTilItemWi
 
 export async function getTilByShortId(shortId: string): Promise<NotionTilItemWithContent | null> {
   return cachedNotionQuery(
-    `notion:til:content:shortid:${shortId}`,
+    notionContentCacheKey("til", "shortid", shortId),
     async () => {
       const databaseId = process.env.NOTION_TIL_DATABASE_ID || "";
       const dataSourceId = await getDataSourceId(databaseId);
@@ -779,7 +780,7 @@ export async function getAppDissectionItemBySlug(
   slug: string,
 ): Promise<NotionAppDissectionItemWithContent | null> {
   return cachedNotionQuery(
-    `notion:app-dissection:content:${slug}`,
+    notionContentCacheKey("app-dissection", slug),
     async () => {
       const databaseId = process.env.NOTION_APP_DISSECTION_DATABASE_ID || "";
       const dataSourceId = await getDataSourceId(databaseId);

--- a/src/lib/notion/types.ts
+++ b/src/lib/notion/types.ts
@@ -73,6 +73,8 @@ export type NumberedListItemBlock = RichTextBlock<"numbered_list_item"> & {
   children?: ProcessedBlock[];
 };
 
+export type ListItemBlock = BulletedListItemBlock | NumberedListItemBlock;
+
 export type TodoBlock = RichTextBlock<"to_do"> & {
   checked: boolean;
 };
@@ -132,6 +134,10 @@ export type ProcessedBlock =
 
 export function isTableRowBlock(block: ProcessedBlock): block is TableRowBlock {
   return block.type === "table_row";
+}
+
+export function isListItemBlock(block: ProcessedBlock): block is ListItemBlock {
+  return block.type === "bulleted_list_item" || block.type === "numbered_list_item";
 }
 
 export function richTextPlainText(content: RichTextContent[]): string {

--- a/src/lib/notion/types.ts
+++ b/src/lib/notion/types.ts
@@ -48,20 +48,95 @@ export type RichTextContent = {
   };
 };
 
-// Processed block type for rendering
-export type ProcessedBlock = {
+type BlockBase = {
   id: string;
-  type: string;
+};
+
+type RichTextBlock<T extends string> = BlockBase & {
+  type: T;
   content: RichTextContent[];
-  language?: string;
-  videoUrl?: string;
-  tableWidth?: number;
-  hasColumnHeader?: boolean;
-  hasRowHeader?: boolean;
-  cells?: RichTextItemResponse[][];
-  tableRows?: ProcessedBlock[];
+};
+
+export type ParagraphBlock = RichTextBlock<"paragraph">;
+export type Heading1Block = RichTextBlock<"heading_1">;
+export type Heading2Block = RichTextBlock<"heading_2">;
+export type Heading3Block = RichTextBlock<"heading_3">;
+export type QuoteBlock = RichTextBlock<"quote">;
+export type CalloutBlock = RichTextBlock<"callout">;
+export type ToggleBlock = RichTextBlock<"toggle">;
+
+export type BulletedListItemBlock = RichTextBlock<"bulleted_list_item"> & {
   children?: ProcessedBlock[];
 };
+
+export type NumberedListItemBlock = RichTextBlock<"numbered_list_item"> & {
+  children?: ProcessedBlock[];
+};
+
+export type TodoBlock = RichTextBlock<"to_do"> & {
+  checked: boolean;
+};
+
+export type ProcessedCodeBlock = RichTextBlock<"code"> & {
+  language: string;
+};
+
+export type DividerBlock = BlockBase & {
+  type: "divider";
+};
+
+export type ImageBlock = BlockBase & {
+  type: "image";
+  url: string;
+};
+
+export type VideoBlock = BlockBase & {
+  type: "video";
+  videoUrl: string;
+};
+
+export type TableRowBlock = BlockBase & {
+  type: "table_row";
+  cells: RichTextItemResponse[][];
+};
+
+export type TableBlock = BlockBase & {
+  type: "table";
+  tableWidth: number;
+  hasColumnHeader: boolean;
+  hasRowHeader: boolean;
+  tableRows?: TableRowBlock[];
+};
+
+/**
+ * Discriminated union of Notion blocks the mapper emits.
+ * Narrow on `type` — image has `url`, video has `videoUrl`, to_do has `checked`.
+ */
+export type ProcessedBlock =
+  | ParagraphBlock
+  | Heading1Block
+  | Heading2Block
+  | Heading3Block
+  | BulletedListItemBlock
+  | NumberedListItemBlock
+  | TodoBlock
+  | ToggleBlock
+  | ProcessedCodeBlock
+  | QuoteBlock
+  | CalloutBlock
+  | DividerBlock
+  | ImageBlock
+  | VideoBlock
+  | TableBlock
+  | TableRowBlock;
+
+export function isTableRowBlock(block: ProcessedBlock): block is TableRowBlock {
+  return block.type === "table_row";
+}
+
+export function richTextPlainText(content: RichTextContent[]): string {
+  return content.map((c) => c.text.content).join("");
+}
 
 // Generic page metadata for getFullContent / useNotion. Collection-specific
 // records (writing, stack, …) live in their own types below.
@@ -251,9 +326,9 @@ export function extractPreviewText(
   options: { maxBlocks?: number; separator?: string } = {},
 ): string {
   const { maxBlocks, separator = "\n\n" } = options;
-  const paragraphs = blocks.filter((block) => block.type === "paragraph");
+  const paragraphs = blocks.filter((block): block is ParagraphBlock => block.type === "paragraph");
   const limited = maxBlocks ? paragraphs.slice(0, maxBlocks) : paragraphs;
-  return limited.map((block) => block.content.map((c) => c.text.content).join("")).join(separator);
+  return limited.map((block) => richTextPlainText(block.content)).join(separator);
 }
 
 // Type guard for video metadata validation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S01-2 + S13-1 of the Notion structure audit.

**S01-2 — ProcessedBlock union.** Replace the grab-bag `ProcessedBlock` (`type: string` plus optional `videoUrl` / `cells` / `language` / fake image rich text) with a discriminated union that matches the existing mapper + renderer switch.

Union members are only types the mapper already emits:

- Text: `paragraph`, `heading_1`–`heading_3`, `quote`, `callout`, `toggle`, list items (optional `children`)
- `to_do` keeps `checked`
- `code` has required `language`
- `image` has a real `url` (no fake rich text)
- `video` keeps `videoUrl`
- `table` / `table_row` have table fields only
- `divider` is id + type

Call sites narrow on `type`. Collection/domain types from #2267 are unchanged. No plugin registry. No TIL feed (S02-1).

**S13-1 — One list-run grouping.** `groupListRuns(blocks)` groups consecutive same-type list items. Top-level `renderBlocks` and nested `renderChildList` both use it, so mixed nested children (bulleted then numbered) render as separate `ul` then `ol` instead of collapsing into one list. Preview mode still skips grouping.

## Cache-key note

Processed content keys are bumped to **`v2`** via `CONTENT_CACHE_VERSION` / `notionContentCacheKey()` so Next (24h) and Redis (7d) cannot serve old bag-shaped payloads as the new union.

Examples:

- `notion:content:v2:<id>`
- `notion:writing:content:v2:<id>`
- `notion:writing:content:v2:slug:<slug>`
- `notion:writing:content:v2:shortid:<id>`
- `notion:ama:content:v2:<id>`
- `notion:til:content:v2:<id>`
- `notion:til:content:v2:shortid:<id>`
- `notion:app-dissection:content:v2:<slug>`

List keys (`notion:writing:list`, etc.) are unchanged. Purge patterns (`notion:writing:*`) still match. No post-merge purge is required for correctness; stale v1 content keys expire on their own.

## Test plan

- [x] `bun test` — 124 pass (mapper: image url / todo checked / video; renderer: same + nested mixed list; `groupListRuns`; cache key v2)
- [x] `bun run lint` / `bunx tsc --noEmit`
- [x] Grep: no grab-bag `ProcessedBlock` with optional `videoUrl`/`cells`/`language` on one type
- [x] Call sites narrow on `type` (image uses `url`, todo uses `checked`)
- [x] Nested mixed list (bulleted then numbered children) renders `ul` then `ol`, not one collapsed list
- [x] Preview mode still skips list-run grouping

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff6bfeab-e16e-4f0e-b756-71f958a50d9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff6bfeab-e16e-4f0e-b756-71f958a50d9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

