### PR TITLE
Unify writing image/video optimization behind one media view

### DIFF
--- a/src/app/api/webhooks/optimize-writing-images/media.test.ts
+++ b/src/app/api/webhooks/optimize-writing-images/media.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectMedia,
+  failedMediaResult,
+  getMediaUrl,
+  type MediaBlockLike,
+  mediaBlockUpdate,
+  type MediaResult,
+  type MediaView,
+  summarizeMediaResults,
+} from "./media";
+
+function imageBlock(
+  id: string,
+  file: MediaView["file"],
+): MediaBlockLike & { type: "image"; image: MediaView["file"] } {
+  return { id, type: "image", image: file };
+}
+
+function videoBlock(
+  id: string,
+  file: MediaView["file"],
+): MediaBlockLike & { type: "video"; video: MediaView["file"] } {
+  return { id, type: "video", video: file };
+}
+
+describe("collectMedia", () => {
+  test("walks image and video blocks into one list in document order", () => {
+    const blocks: MediaBlockLike[] = [
+      { id: "p1", type: "paragraph" },
+      imageBlock("img-1", { type: "external", external: { url: "https://img.example/1.jpg" } }),
+      { id: "h1", type: "heading_2" },
+      videoBlock("vid-1", {
+        type: "file",
+        file: { url: "https://vid.example/1.mp4", expiry_time: "t" },
+      }),
+      imageBlock("img-2", {
+        type: "file",
+        file: { url: "https://img.example/2.png", expiry_time: "t" },
+      }),
+    ];
+
+    expect(collectMedia(blocks)).toEqual([
+      {
+        id: "img-1",
+        kind: "image",
+        file: { type: "external", external: { url: "https://img.example/1.jpg" } },
+      },
+      {
+        id: "vid-1",
+        kind: "video",
+        file: { type: "file", file: { url: "https://vid.example/1.mp4", expiry_time: "t" } },
+      },
+      {
+        id: "img-2",
+        kind: "image",
+        file: { type: "file", file: { url: "https://img.example/2.png", expiry_time: "t" } },
+      },
+    ]);
+  });
+
+  test("skips media-typed blocks that are missing a file payload", () => {
+    expect(
+      collectMedia([
+        { id: "img-empty", type: "image" },
+        { id: "vid-empty", type: "video" },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("getMediaUrl", () => {
+  test("reads external and file URLs for both kinds", () => {
+    expect(
+      getMediaUrl({
+        file: { type: "external", external: { url: "https://img.example/a.jpg" } },
+      }),
+    ).toBe("https://img.example/a.jpg");
+    expect(
+      getMediaUrl({
+        file: { type: "file", file: { url: "https://vid.example/a.mp4", expiry_time: "t" } },
+      }),
+    ).toBe("https://vid.example/a.mp4");
+  });
+
+  test("returns null when the declared type has no matching URL", () => {
+    expect(getMediaUrl({ file: { type: "external" } })).toBeNull();
+    expect(getMediaUrl({ file: { type: "file" } })).toBeNull();
+  });
+});
+
+describe("mediaBlockUpdate", () => {
+  test("writes the Notion property that matches kind", () => {
+    const image = collectMedia([
+      imageBlock("img-1", {
+        type: "file",
+        file: { url: "https://notion.example/old.jpg", expiry_time: "t" },
+        caption: [{ plain_text: "hero" }],
+      }),
+    ])[0];
+    const video = collectMedia([
+      videoBlock("vid-1", {
+        type: "external",
+        external: { url: "https://notion.example/old.mp4" },
+      }),
+    ])[0];
+
+    expect(mediaBlockUpdate(image, "https://r2.example/new.jpg")).toEqual({
+      block_id: "img-1",
+      image: {
+        external: { url: "https://r2.example/new.jpg" },
+        caption: [{ plain_text: "hero" }],
+      },
+    });
+    expect(mediaBlockUpdate(video, "https://r2.example/new.mp4")).toEqual({
+      block_id: "vid-1",
+      video: {
+        external: { url: "https://r2.example/new.mp4" },
+        caption: [],
+      },
+    });
+  });
+});
+
+describe("summarizeMediaResults", () => {
+  test("counts a mixed image/video result list in one pass", () => {
+    const results: MediaResult[] = [
+      {
+        kind: "image",
+        success: true,
+        originalUrl: "https://img.example/1.jpg",
+        newUrl: "https://r2.example/1.jpg",
+        originalSize: 1000,
+        optimizedSize: 400,
+        savings: 60,
+      },
+      failedMediaResult("video", "Failed to download video"),
+      {
+        kind: "video",
+        success: true,
+        originalUrl: "https://vid.example/2.mp4",
+        newUrl: "https://r2.example/2.mp4",
+        size: 2048,
+      },
+      failedMediaResult("image", "No image URL found"),
+    ];
+
+    expect(summarizeMediaResults(results)).toEqual({
+      images: {
+        total: 2,
+        successful: 1,
+        failed: 1,
+        originalSize: 1000,
+        optimizedSize: 400,
+        savings: "60.0%",
+      },
+      videos: {
+        total: 2,
+        successful: 1,
+        failed: 1,
+        totalSize: 2048,
+      },
+      total: 4,
+      successful: 2,
+      failed: 2,
+    });
+  });
+
+  test("reports 0% image savings when no successful images ran", () => {
+    expect(summarizeMediaResults([failedMediaResult("video", "boom")]).images.savings).toBe("0%");
+  });
+});

--- a/src/app/api/webhooks/optimize-writing-images/media.ts
+++ b/src/app/api/webhooks/optimize-writing-images/media.ts
@@ -1,0 +1,162 @@
+export type MediaKind = "image" | "video";
+
+export type MediaFile = {
+  type: "external" | "file";
+  external?: { url: string };
+  file?: { url: string; expiry_time: string };
+  caption?: unknown[];
+};
+
+export type MediaView = {
+  id: string;
+  kind: MediaKind;
+  file: MediaFile;
+};
+
+export type MediaBlockLike = {
+  id: string;
+  type: string;
+  image?: MediaFile;
+  video?: MediaFile;
+};
+
+export type MediaResult =
+  | {
+      kind: "image";
+      success: true;
+      originalUrl: string;
+      newUrl: string;
+      originalSize: number;
+      optimizedSize: number;
+      savings: number;
+    }
+  | {
+      kind: "video";
+      success: true;
+      originalUrl: string;
+      newUrl: string;
+      size: number;
+    }
+  | {
+      kind: MediaKind;
+      success: false;
+      error: string;
+    };
+
+export type MediaStats = {
+  images: {
+    total: number;
+    successful: number;
+    failed: number;
+    originalSize: number;
+    optimizedSize: number;
+    savings: string;
+  };
+  videos: {
+    total: number;
+    successful: number;
+    failed: number;
+    totalSize: number;
+  };
+  total: number;
+  successful: number;
+  failed: number;
+};
+
+function isMediaKind(type: string): type is MediaKind {
+  return type === "image" || type === "video";
+}
+
+/**
+ * Flatten image and video blocks into one list, in document order.
+ */
+export function collectMedia(blocks: MediaBlockLike[]): MediaView[] {
+  const media: MediaView[] = [];
+
+  for (const block of blocks) {
+    if (!isMediaKind(block.type)) continue;
+    const file = block[block.type];
+    if (!file) continue;
+    media.push({ id: block.id, kind: block.type, file });
+  }
+
+  return media;
+}
+
+export function getMediaUrl(media: Pick<MediaView, "file">): string | null {
+  if (media.file.type === "external" && media.file.external) {
+    return media.file.external.url;
+  }
+  if (media.file.type === "file" && media.file.file) {
+    return media.file.file.url;
+  }
+  return null;
+}
+
+export function mediaBlockUpdate(media: MediaView, r2Url: string) {
+  return {
+    block_id: media.id,
+    [media.kind]: {
+      external: { url: r2Url },
+      caption: media.file.caption || [],
+    },
+  };
+}
+
+export function failedMediaResult(kind: MediaKind, error: string): MediaResult {
+  return { kind, success: false, error };
+}
+
+export function summarizeMediaResults(results: MediaResult[]): MediaStats {
+  const stats: MediaStats = {
+    images: {
+      total: 0,
+      successful: 0,
+      failed: 0,
+      originalSize: 0,
+      optimizedSize: 0,
+      savings: "0%",
+    },
+    videos: {
+      total: 0,
+      successful: 0,
+      failed: 0,
+      totalSize: 0,
+    },
+    total: results.length,
+    successful: 0,
+    failed: 0,
+  };
+
+  for (const result of results) {
+    if (result.kind === "image") {
+      stats.images.total++;
+      if (result.success) {
+        stats.images.successful++;
+        stats.successful++;
+        stats.images.originalSize += result.originalSize;
+        stats.images.optimizedSize += result.optimizedSize;
+      } else {
+        stats.images.failed++;
+        stats.failed++;
+      }
+      continue;
+    }
+
+    stats.videos.total++;
+    if (result.success) {
+      stats.videos.successful++;
+      stats.successful++;
+      stats.videos.totalSize += result.size;
+    } else {
+      stats.videos.failed++;
+      stats.failed++;
+    }
+  }
+
+  const { originalSize, optimizedSize } = stats.images;
+  stats.images.savings =
+    originalSize > 0 ? `${((1 - optimizedSize / originalSize) * 100).toFixed(1)}%` : "0%";
+
+  return stats;
+}

--- a/src/app/api/webhooks/optimize-writing-images/route.ts
+++ b/src/app/api/webhooks/optimize-writing-images/route.ts
@@ -6,8 +6,18 @@ import { notion } from "@/lib/notion";
 import { purgeContentType } from "@/lib/notion/purge";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
 
+import {
+  collectMedia,
+  failedMediaResult,
+  getMediaUrl,
+  mediaBlockUpdate,
+  type MediaResult,
+  type MediaView,
+  summarizeMediaResults,
+} from "./media";
+
 /**
- * Webhook endpoint to optimize all images in a blog post and upload to R2
+ * Webhook endpoint to optimize writing page media and upload to R2
  *
  * POST /api/webhooks/optimize-writing-images
  * Notion automation payload: { data: { id } }
@@ -15,35 +25,10 @@ import { uploadBufferToR2 } from "@/lib/r2/storage";
  * Flow:
  * 1. Extract page ID from Notion webhook
  * 2. Fetch all blocks from the page (recursively)
- * 3. Find all image blocks
- * 4. For each image:
- *    - Download the image
- *    - Optimize (compress at high quality, keep original dimensions)
- *    - Upload to R2
- *    - Update the block with R2 URL
+ * 3. Collect image and video blocks into one media list
+ * 4. For each item, download, optimize when the kind requires it, upload to R2,
+ *    and update the Notion block
  */
-
-interface ImageBlock {
-  id: string;
-  type: "image";
-  image: {
-    type: "external" | "file";
-    external?: { url: string };
-    file?: { url: string; expiry_time: string };
-    caption?: Array<any>;
-  };
-}
-
-interface VideoBlock {
-  id: string;
-  type: "video";
-  video: {
-    type: "external" | "file";
-    external?: { url: string };
-    file?: { url: string; expiry_time: string };
-    caption?: Array<any>;
-  };
-}
 
 interface BlockWithChildren {
   id: string;
@@ -87,151 +72,64 @@ async function getAllBlocks(blockId: string): Promise<BlockWithChildren[]> {
 }
 
 /**
- * Extract image URL from a block
+ * Download, optimize (images only), upload, and rewrite one media block.
+ * Kind is the only branch: images are compressed, videos are re-hosted as-is.
  */
-function getImageUrl(block: ImageBlock): string | null {
-  if (block.image.type === "external" && block.image.external) {
-    return block.image.external.url;
-  } else if (block.image.type === "file" && block.image.file) {
-    return block.image.file.url;
-  }
-  return null;
-}
-
-/**
- * Optimize a single image block
- */
-async function optimizeImageBlock(block: ImageBlock): Promise<{
-  success: boolean;
-  originalUrl?: string;
-  newUrl?: string;
-  originalSize?: number;
-  optimizedSize?: number;
-  savings?: number;
-  error?: string;
-}> {
+async function optimizeMediaBlock(media: MediaView): Promise<MediaResult> {
   try {
-    const imageUrl = getImageUrl(block);
-    if (!imageUrl) {
-      return { success: false, error: "No image URL found" };
+    const sourceUrl = getMediaUrl(media);
+    if (!sourceUrl) {
+      return failedMediaResult(media.kind, `No ${media.kind} URL found`);
     }
 
-    console.log(`  📥 Downloading image: ${imageUrl.substring(0, 80)}...`);
+    console.log(`  📥 Downloading ${media.kind}: ${sourceUrl.substring(0, 80)}...`);
 
-    // Download the image
-    const imageResponse = await fetch(imageUrl);
-    if (!imageResponse.ok) {
-      return { success: false, error: "Failed to download image" };
+    const response = await fetch(sourceUrl);
+    if (!response.ok) {
+      return failedMediaResult(media.kind, `Failed to download ${media.kind}`);
     }
 
-    const imageArrayBuffer = await imageResponse.arrayBuffer();
-    const imageBuffer = Buffer.from(imageArrayBuffer);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    let r2Url: string;
+    let result: MediaResult;
 
-    console.log(`  🔧 Optimizing image (${(imageBuffer.length / 1024).toFixed(2)}KB)...`);
-
-    // Optimize the image (compress, keep original dimensions)
-    const optimized = await optimizeWritingImage(imageBuffer);
-
-    console.log(
-      `  ✨ Optimized: ${optimized.width}x${optimized.height}, ${(optimized.optimizedSize / 1024).toFixed(2)}KB (saved ${optimized.savings.toFixed(1)}%)`,
-    );
-
-    // Upload to R2
-    console.log(`  📤 Uploading to R2...`);
-    const r2Url = await uploadBufferToR2(optimized.buffer, optimized.contentType);
-
-    // Update the block with the new R2 URL
-    console.log(`  💾 Updating block...`);
-    await notion.blocks.update({
-      block_id: block.id,
-      image: {
-        external: { url: r2Url },
-        caption: block.image.caption || [],
-      },
-    } as any);
-
-    return {
-      success: true,
-      originalUrl: imageUrl,
-      newUrl: r2Url,
-      originalSize: optimized.originalSize,
-      optimizedSize: optimized.optimizedSize,
-      savings: optimized.savings,
-    };
-  } catch (error) {
-    console.error(`  ❌ Error optimizing image block:`, error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
-}
-
-/**
- * Extract video URL from a block
- */
-function getVideoUrl(block: VideoBlock): string | null {
-  if (block.video.type === "external" && block.video.external) {
-    return block.video.external.url;
-  } else if (block.video.type === "file" && block.video.file) {
-    return block.video.file.url;
-  }
-  return null;
-}
-
-/**
- * Upload a single video block to R2 (no transcoding, just re-host)
- */
-async function optimizeVideoBlock(block: VideoBlock): Promise<{
-  success: boolean;
-  originalUrl?: string;
-  newUrl?: string;
-  size?: number;
-  error?: string;
-}> {
-  try {
-    const videoUrl = getVideoUrl(block);
-    if (!videoUrl) {
-      return { success: false, error: "No video URL found" };
+    if (media.kind === "image") {
+      console.log(`  🔧 Optimizing image (${(buffer.length / 1024).toFixed(2)}KB)...`);
+      const optimized = await optimizeWritingImage(buffer);
+      console.log(
+        `  ✨ Optimized: ${optimized.width}x${optimized.height}, ${(optimized.optimizedSize / 1024).toFixed(2)}KB (saved ${optimized.savings.toFixed(1)}%)`,
+      );
+      console.log(`  📤 Uploading to R2...`);
+      r2Url = await uploadBufferToR2(optimized.buffer, optimized.contentType);
+      result = {
+        kind: "image",
+        success: true,
+        originalUrl: sourceUrl,
+        newUrl: r2Url,
+        originalSize: optimized.originalSize,
+        optimizedSize: optimized.optimizedSize,
+        savings: optimized.savings,
+      };
+    } else {
+      const contentType = response.headers.get("content-type") || "video/mp4";
+      console.log(`  📤 Uploading video to R2 (${(buffer.length / 1024 / 1024).toFixed(2)}MB)...`);
+      r2Url = await uploadBufferToR2(buffer, contentType);
+      result = {
+        kind: "video",
+        success: true,
+        originalUrl: sourceUrl,
+        newUrl: r2Url,
+        size: buffer.length,
+      };
     }
-
-    console.log(`  📥 Downloading video: ${videoUrl.substring(0, 80)}...`);
-
-    const videoResponse = await fetch(videoUrl);
-    if (!videoResponse.ok) {
-      return { success: false, error: "Failed to download video" };
-    }
-
-    const contentType = videoResponse.headers.get("content-type") || "video/mp4";
-    const videoBuffer = Buffer.from(await videoResponse.arrayBuffer());
-
-    console.log(
-      `  📤 Uploading video to R2 (${(videoBuffer.length / 1024 / 1024).toFixed(2)}MB)...`,
-    );
-
-    const r2Url = await uploadBufferToR2(videoBuffer, contentType);
 
     console.log(`  💾 Updating block...`);
-    await notion.blocks.update({
-      block_id: block.id,
-      video: {
-        external: { url: r2Url },
-        caption: block.video.caption || [],
-      },
-    } as any);
+    await notion.blocks.update(mediaBlockUpdate(media, r2Url) as any);
 
-    return {
-      success: true,
-      originalUrl: videoUrl,
-      newUrl: r2Url,
-      size: videoBuffer.length,
-    };
+    return result;
   } catch (error) {
-    console.error(`  ❌ Error processing video block:`, error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
+    console.error(`  ❌ Error optimizing ${media.kind} block:`, error);
+    return failedMediaResult(media.kind, error instanceof Error ? error.message : "Unknown error");
   }
 }
 
@@ -262,16 +160,13 @@ export async function POST(request: Request) {
     const allBlocks = await getAllBlocks(pageId);
     console.log(`Found ${allBlocks.length} total blocks\n`);
 
-    // Step 2: Filter for image and video blocks
-    const imageBlocks = allBlocks.filter(
-      (block) => block.type === "image",
-    ) as unknown as ImageBlock[];
-    const videoBlocks = allBlocks.filter(
-      (block) => block.type === "video",
-    ) as unknown as VideoBlock[];
-    console.log(`Found ${imageBlocks.length} image blocks, ${videoBlocks.length} video blocks\n`);
+    // Step 2: Collect image and video blocks into one media list
+    const media = collectMedia(allBlocks);
+    const imageCount = media.filter((item) => item.kind === "image").length;
+    const videoCount = media.length - imageCount;
+    console.log(`Found ${imageCount} image blocks, ${videoCount} video blocks\n`);
 
-    if (imageBlocks.length === 0 && videoBlocks.length === 0) {
+    if (media.length === 0) {
       return NextResponse.json(
         {
           success: true,
@@ -283,97 +178,52 @@ export async function POST(request: Request) {
       );
     }
 
-    // Step 3: Optimize each image
-    const imageResults = [];
-    let imageSuccessCount = 0;
-    let imageErrorCount = 0;
-    let totalOriginalSize = 0;
-    let totalOptimizedSize = 0;
+    // Step 3: Walk, optimize, and count through one list
+    const results: MediaResult[] = [];
 
-    for (let i = 0; i < imageBlocks.length; i++) {
-      const block = imageBlocks[i];
-      console.log(`Processing image ${i + 1}/${imageBlocks.length}:`);
+    for (let i = 0; i < media.length; i++) {
+      const item = media[i];
+      console.log(`Processing ${item.kind} ${i + 1}/${media.length}:`);
 
-      const result = await optimizeImageBlock(block);
-      imageResults.push(result);
+      const result = await optimizeMediaBlock(item);
+      results.push(result);
 
       if (result.success) {
-        imageSuccessCount++;
-        totalOriginalSize += result.originalSize || 0;
-        totalOptimizedSize += result.optimizedSize || 0;
         console.log(`  ✅ Success\n`);
       } else {
-        imageErrorCount++;
         console.log(`  ❌ Error: ${result.error}\n`);
       }
     }
 
-    // Step 4: Upload each video to R2
-    const videoResults = [];
-    let videoSuccessCount = 0;
-    let videoErrorCount = 0;
-    let totalVideoSize = 0;
-
-    for (let i = 0; i < videoBlocks.length; i++) {
-      const block = videoBlocks[i];
-      console.log(`Processing video ${i + 1}/${videoBlocks.length}:`);
-
-      const result = await optimizeVideoBlock(block);
-      videoResults.push(result);
-
-      if (result.success) {
-        videoSuccessCount++;
-        totalVideoSize += result.size || 0;
-        console.log(`  ✅ Success\n`);
-      } else {
-        videoErrorCount++;
-        console.log(`  ❌ Error: ${result.error}\n`);
-      }
-    }
-
-    const totalSavings =
-      totalOriginalSize > 0 ? ((1 - totalOptimizedSize / totalOriginalSize) * 100).toFixed(1) : "0";
+    const stats = summarizeMediaResults(results);
 
     // Same writing purge as /api/purge-cache (widens Redis from content:* to writing:*)
     await purgeContentType("writing");
 
-    const successCount = imageSuccessCount + videoSuccessCount;
-    const errorCount = imageErrorCount + videoErrorCount;
-
     console.log("=".repeat(50));
     console.log(`✅ Optimization complete!`);
-    console.log(`   - Images: ${imageSuccessCount} successful, ${imageErrorCount} failed`);
-    console.log(`   - Videos: ${videoSuccessCount} successful, ${videoErrorCount} failed`);
-    console.log(`   - Image original size: ${(totalOriginalSize / 1024 / 1024).toFixed(2)}MB`);
-    console.log(`   - Image optimized size: ${(totalOptimizedSize / 1024 / 1024).toFixed(2)}MB`);
-    console.log(`   - Image savings: ${totalSavings}%`);
-    console.log(`   - Video size uploaded: ${(totalVideoSize / 1024 / 1024).toFixed(2)}MB`);
+    console.log(
+      `   - Images: ${stats.images.successful} successful, ${stats.images.failed} failed`,
+    );
+    console.log(
+      `   - Videos: ${stats.videos.successful} successful, ${stats.videos.failed} failed`,
+    );
+    console.log(
+      `   - Image original size: ${(stats.images.originalSize / 1024 / 1024).toFixed(2)}MB`,
+    );
+    console.log(
+      `   - Image optimized size: ${(stats.images.optimizedSize / 1024 / 1024).toFixed(2)}MB`,
+    );
+    console.log(`   - Image savings: ${stats.images.savings}`);
+    console.log(`   - Video size uploaded: ${(stats.videos.totalSize / 1024 / 1024).toFixed(2)}MB`);
     console.log("=".repeat(50) + "\n");
 
     return NextResponse.json(
       {
         success: true,
         message: "Writing media optimized and uploaded to R2 successfully",
-        stats: {
-          images: {
-            total: imageBlocks.length,
-            successful: imageSuccessCount,
-            failed: imageErrorCount,
-            originalSize: totalOriginalSize,
-            optimizedSize: totalOptimizedSize,
-            savings: `${totalSavings}%`,
-          },
-          videos: {
-            total: videoBlocks.length,
-            successful: videoSuccessCount,
-            failed: videoErrorCount,
-            totalSize: totalVideoSize,
-          },
-          total: imageBlocks.length + videoBlocks.length,
-          successful: successCount,
-          failed: errorCount,
-        },
-        results: [...imageResults, ...videoResults],
+        stats,
+        results,
       },
       { status: 200 },
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slice S09-2 of the structure audit: one media view + one result union in `optimize-writing-images` so image and video share the walk/optimize/count path. Independent of #2270 (`purgeContentType`); this PR keeps calling `purgeContentType("writing")` after a successful write.

On current `main` the route had parallel `ImageBlock` / `VideoBlock` types, getters, optimizers, and seven counters (the audit’s “six counters” note was close: success/error/size stacks for each kind, plus image original/optimized totals). Results were concatenated at the end.

### What changed

- `MediaView` + `MediaResult` live in `src/app/api/webhooks/optimize-writing-images/media.ts`
- `collectMedia()` walks image and video blocks into one list in document order
- `getMediaUrl()` / `mediaBlockUpdate()` are kind-agnostic
- `optimizeMediaBlock()` is the only kind branch: images are compressed via `optimizeWritingImage`, videos are re-hosted as-is
- `summarizeMediaResults()` replaces the parallel counter stacks
- Response `stats` / empty-page payload / Notion properties (`image` / `video` + captions) are unchanged aside from adding `kind` on each result

Out of scope: S10 `OptimizedImage` / `optimizeR2Images.ts`, S01-2 `ProcessedBlock`, which Notion properties get optimized.

## Test plan

- [x] `bun test` — 117 pass, including new `media.test.ts` (mixed image/video list, URL getter, Notion update payload, one-pass stats)
- [x] `bun run lint` / `bunx tsc --noEmit` clean
- [x] Grep: no remaining parallel Image/Video type + getter + optimizer + counter stacks that only differ by name
- [x] Confirm `purgeContentType("writing")` is still called after a successful write
- [x] CI `Build / build` — all 5 checks passed on `b26cfc4d`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcb9451c-3078-48a4-a3d1-4c9f4225f3db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcb9451c-3078-48a4-a3d1-4c9f4225f3db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

