### PR TITLE
Slim HN digest subscribers to string[] and map DigestPost at the email boundary

### DIFF
--- a/src/app/api/hn-digest/send/route.ts
+++ b/src/app/api/hn-digest/send/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
+import { toDigestPosts } from "@/lib/digest";
 import { BASE_EMAIL, generateUnsubscribeUrl, sendHNDigestEmailBatch } from "@/lib/email";
 import { getHNPostsForDigest } from "@/lib/hn";
 import { getHNSubscribers } from "@/lib/subscriptions";
@@ -29,17 +30,19 @@ export async function GET(request: Request) {
 
     // In development, only send to the base email for testing
     if (!IS_PROD) {
-      subscribers = subscribers.filter((sub) => sub.email === BASE_EMAIL);
+      subscribers = subscribers.filter((email) => email === BASE_EMAIL);
       console.log(`[DEV] Filtered to ${subscribers.length} test subscriber(s)`);
     }
 
     console.log(`Sending digest to ${subscribers.length} subscribers`);
 
-    const emails = subscribers.map((subscriber) => ({
-      to: subscriber.email,
+    const digestPosts = toDigestPosts(posts);
+
+    const emails = subscribers.map((email) => ({
+      to: email,
       date,
-      posts,
-      unsubscribeUrl: generateUnsubscribeUrl(subscriber.email),
+      posts: digestPosts,
+      unsubscribeUrl: generateUnsubscribeUrl(email),
     }));
 
     const { successCount, failureCount } = await sendHNDigestEmailBatch(emails);

--- a/src/app/api/hn-digest/test/route.ts
+++ b/src/app/api/hn-digest/test/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { errorResponse } from "@/lib/api-utils";
+import { toDigestPosts } from "@/lib/digest";
 import { BASE_EMAIL, generateUnsubscribeUrl, sendHNDigestEmail } from "@/lib/email";
 import { getHNPostsForDigest } from "@/lib/hn";
 import { formatDigestDate } from "@/lib/urls";
@@ -33,7 +34,7 @@ export async function GET(request: Request) {
     await sendHNDigestEmail({
       to: testEmail,
       date,
-      posts,
+      posts: toDigestPosts(posts),
       unsubscribeUrl,
     });
 

--- a/src/lib/digest.test.ts
+++ b/src/lib/digest.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import { toDigestPost, toDigestPosts } from "@/lib/digest";
+import { HackerNewsComment, HackerNewsPost } from "@/types/hackernews";
+
+function makePost(overrides: Partial<HackerNewsPost> = {}): HackerNewsPost {
+  return {
+    id: 42,
+    title: "Show HN: Digest",
+    points: 99,
+    user: "pg",
+    time: 1_700_000_000,
+    time_ago: "1 hour ago",
+    type: "link",
+    content: "<p>body</p>",
+    url: "https://example.com",
+    domain: "example.com",
+    comments_count: 7,
+    ...overrides,
+  };
+}
+
+function makeComment(overrides: Partial<HackerNewsComment> = {}): HackerNewsComment {
+  return {
+    id: 99,
+    user: "alice",
+    content: "<p>hello</p>",
+    level: 0,
+    comments: [],
+    ...overrides,
+  };
+}
+
+describe("toDigestPost", () => {
+  test("maps a list post that has no comments key", () => {
+    const listPost = makePost();
+    delete listPost.comments;
+
+    const digest = toDigestPost(listPost);
+
+    expect(digest).toEqual({
+      id: 42,
+      title: "Show HN: Digest",
+      url: "https://example.com",
+      domain: "example.com",
+      comments_count: 7,
+    });
+    expect(digest).not.toHaveProperty("comments");
+    expect(digest).not.toHaveProperty("content");
+    expect(digest).not.toHaveProperty("points");
+  });
+
+  test("drops comments and other thread fields from a detail post", () => {
+    const detailPost = makePost({
+      comments: [makeComment()],
+      comments_count: 1,
+    });
+
+    const digest = toDigestPost(detailPost);
+
+    expect(digest.comments_count).toBe(1);
+    expect(digest).not.toHaveProperty("comments");
+    expect(JSON.parse(JSON.stringify(digest))).not.toHaveProperty("comments");
+  });
+});
+
+describe("toDigestPosts", () => {
+  test("maps a list of posts without requiring comments", () => {
+    const posts = [makePost({ id: 1 }), makePost({ id: 2, comments_count: 0 })];
+    for (const post of posts) {
+      delete post.comments;
+    }
+
+    const digest = toDigestPosts(posts);
+
+    expect(digest).toHaveLength(2);
+    expect(digest[0]?.id).toBe(1);
+    expect(digest[1]?.comments_count).toBe(0);
+    expect(digest.every((post) => !("comments" in post))).toBe(true);
+  });
+});

--- a/src/lib/digest.ts
+++ b/src/lib/digest.ts
@@ -1,0 +1,22 @@
+import { HackerNewsPost } from "@/types/hackernews";
+
+/** Fields the HN digest email template actually renders. */
+export type DigestPost = Pick<HackerNewsPost, "id" | "title" | "url" | "domain" | "comments_count">;
+
+/**
+ * Project a list (or detail) HN post to the digest email shape.
+ * Does not read `comments` — list posts omit that key after S03-2.
+ */
+export function toDigestPost(post: Pick<HackerNewsPost, keyof DigestPost>): DigestPost {
+  return {
+    id: post.id,
+    title: post.title,
+    url: post.url,
+    domain: post.domain,
+    comments_count: post.comments_count,
+  };
+}
+
+export function toDigestPosts(posts: Pick<HackerNewsPost, keyof DigestPost>[]): DigestPost[] {
+  return posts.map(toDigestPost);
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,6 +1,6 @@
 import { ServerClient } from "postmark";
 
-import { HackerNewsPost } from "@/types/hackernews";
+import { DigestPost } from "@/lib/digest";
 
 import { generateUnsubscribeToken } from "./jwt";
 import { buildUnsubscribeUrl } from "./urls";
@@ -32,7 +32,7 @@ const postmarkClient = new ServerClient(process.env.POSTMARK_CLIENT_ID);
 export interface DigestEmailData {
   to: string;
   date: string;
-  posts: HackerNewsPost[];
+  posts: DigestPost[];
   unsubscribeUrl: string;
 }
 

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -4,12 +4,6 @@ import { Redis } from "@upstash/redis";
  * Email subscription management using Upstash Redis
  */
 
-// TypeScript interface for subscription rows (keeping interface for compatibility)
-export interface EmailSubscriptionRow {
-  email: string;
-  type: string;
-}
-
 // Environment validation
 if (!process.env.UPSTASH_REDIS_REST_URL) {
   throw new Error("UPSTASH_REDIS_REST_URL environment variable is not set");
@@ -31,17 +25,8 @@ const HN_SUBSCRIBERS_KEY = "hn:subscribers";
 /**
  * Fetch all email subscribers for Hacker News digest
  */
-export async function getHNSubscribers(): Promise<EmailSubscriptionRow[]> {
-  const emails = await redis.smembers(HN_SUBSCRIBERS_KEY);
-  return emails.map((email) => ({ email, type: "HACKER_NEWS" }));
-}
-
-/**
- * Fetch a single subscriber by email
- */
-export async function getSubscriberByEmail(email: string): Promise<EmailSubscriptionRow | null> {
-  const exists = await redis.sismember(HN_SUBSCRIBERS_KEY, email);
-  return exists ? { email, type: "HACKER_NEWS" } : null;
+export async function getHNSubscribers(): Promise<string[]> {
+  return await redis.smembers(HN_SUBSCRIBERS_KEY);
 }
 
 /**
@@ -53,39 +38,14 @@ export async function deleteSubscription(email: string): Promise<boolean> {
 }
 
 /**
- * Get count of HN subscribers
- */
-export async function getHNSubscriberCount(): Promise<number> {
-  return await redis.scard(HN_SUBSCRIBERS_KEY);
-}
-
-/**
  * Create a new subscription
  */
 export async function createSubscription(
   email: string,
 ): Promise<{ success: boolean; alreadyExists: boolean }> {
-  // Check if subscription already exists
-  const exists = await redis.sismember(HN_SUBSCRIBERS_KEY, email);
-  if (exists) {
+  const added = await redis.sadd(HN_SUBSCRIBERS_KEY, email);
+  if (added === 0) {
     return { success: false, alreadyExists: true };
   }
-
-  // Add to subscribers set
-  await redis.sadd(HN_SUBSCRIBERS_KEY, email);
   return { success: true, alreadyExists: false };
-}
-
-/**
- * Bulk add subscribers (for backfill)
- */
-export async function bulkAddSubscribers(emails: string[]): Promise<number> {
-  if (emails.length === 0) return 0;
-  // Use pipeline for bulk operations
-  const pipeline = redis.pipeline();
-  for (const email of emails) {
-    pipeline.sadd(HN_SUBSCRIBERS_KEY, email);
-  }
-  await pipeline.exec();
-  return emails.length;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S05-1 and S05-2 of the structure audit: digest/subscriber types only. Independent of ProcessedBlock work. Builds on #2269 (optional HN comments). Rebased onto main after #2272 merged.

**S05-1 — subscribers are `string[]`**

Redis `hn:subscribers` is already a set of emails. The `{ email, type: "HACKER_NEWS" }` DTO was a leftover SQL-era column. This PR:

- Changes `getHNSubscribers()` to `Promise<string[]>` (no remap/unwrap)
- Deletes `EmailSubscriptionRow`, `getSubscriberByEmail`, `getHNSubscriberCount`, and `bulkAddSubscribers`
- Makes `createSubscription` a single `SADD` and uses the return value (`0` = already exists)
- Updates the send route to iterate emails directly (`to: email`, not `subscriber.email`)
- Leaves the Redis key as `hn:subscribers`

**S05-2 — slim `DigestPost`**

The digest template only renders `id`, `title`, `url`, `domain`, and `comments_count`. `toDigestPost` / `toDigestPosts` copy those fields at the email boundary so:

- List posts without a `comments` key are valid input
- Comment bodies and other thread fields never reach Postmark
- `DigestEmailData.posts` is `DigestPost[]`, not `HackerNewsPost[]`

**Kept from #2272**

- `jwt.ts` does not import email/Postmark
- `BASE_URL`, `formatDigestDate`, `buildUnsubscribeUrl` live in `src/lib/urls.ts`
- Digest send/test build unsubscribe URLs via `email.ts` → `generateUnsubscribeToken` + `buildUnsubscribeUrl`

Postmark templates/copy are unchanged.

## Test plan

- [x] `bun test` — 147 pass after rebase, including `toDigestPost` cases and #2272 jwt/urls isolation tests
- [x] `bun run lint` and `tsc --noEmit` clean
- [x] Grep: no `type: "HACKER_NEWS"` subscriber DTO; unused helpers gone; send path iterates emails
- [x] Digest mapper does not require `comments` on a list post
- [x] Rebased onto current main; `gh pr view 2275` is `MERGEABLE` (no longer dirty)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9f54e5b-59b7-49a5-afc8-8e616ceb1cc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9f54e5b-59b7-49a5-afc8-8e616ceb1cc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

