### PR TITLE
Unify TIL feed on one TilEntry store (S02-1)

### DIFF
--- a/src/app/til/page.tsx
+++ b/src/app/til/page.tsx
@@ -7,8 +7,8 @@ import { PageTitle } from "@/components/Typography";
 import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
 import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
-import { getTilDatabaseItems } from "@/lib/notion";
-import { getTilEntriesWithContent } from "@/lib/til";
+import { getTilDatabaseItems, getTilItemContent } from "@/lib/notion";
+import { hydrateTilEntries } from "@/lib/til";
 
 export const metadata: Metadata = {
   ...createMetadata({
@@ -63,15 +63,17 @@ function TilFeedFallback() {
 
 async function TilFeedContent() {
   await connection();
-  // Fetch the first 10 entries for SSR
-  const { items: initialEntries } = await getTilDatabaseItems(undefined, 10);
-
-  // Fetch content (blocks) and likes for the initial entries in parallel
-  const pageIds = initialEntries.map((entry) => entry.id);
-  const [initialEntriesWithContent, initialLikes] = await Promise.all([
-    getTilEntriesWithContent(initialEntries),
+  const { items, nextCursor } = await getTilDatabaseItems(undefined, 10);
+  const pageIds = items.map((entry) => entry.id);
+  const [contents, initialLikes] = await Promise.all([
+    Promise.all(items.map((entry) => getTilItemContent(entry.id))),
     getServerLikes(pageIds),
   ]);
 
-  return <TilFeed initialEntries={initialEntriesWithContent} initialLikes={initialLikes} />;
+  return (
+    <TilFeed
+      fallbackData={[{ items: hydrateTilEntries(items, contents), nextCursor }]}
+      initialLikes={initialLikes}
+    />
+  );
 }

--- a/src/components/TilFeed.tsx
+++ b/src/components/TilFeed.tsx
@@ -10,12 +10,12 @@ import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
 import { fetcher } from "@/lib/fetcher";
 import type { LikeCount } from "@/lib/hooks/useLikes";
-import type { NotionTilItem, NotionTilItemWithContent } from "@/lib/notion";
+import type { NotionTilItemWithContent } from "@/lib/notion";
 import { buildSlug } from "@/lib/short-id";
-import { useTilEntries } from "@/lib/til";
+import { type TilEntry, type TilPage, useTilEntries } from "@/lib/til";
 
 interface TilFeedProps {
-  initialEntries: NotionTilItemWithContent[];
+  fallbackData: TilPage[];
   initialLikes?: Record<string, LikeCount>;
 }
 
@@ -47,15 +47,9 @@ function TilEntryContent({ entryId }: { entryId: string }) {
   return <div className="notion-blocks flex flex-col gap-3">{renderBlocks(data.blocks)}</div>;
 }
 
-function TilEntry({
-  entry,
-  initialContent,
-}: {
-  entry: NotionTilItem;
-  initialContent?: NotionTilItemWithContent;
-}) {
+function TilEntry({ entry }: { entry: TilEntry }) {
   const slug = entry.shortId ? buildSlug(entry.title, entry.shortId) : null;
-  const hasInitialContent = initialContent && initialContent.blocks.length > 0;
+  const blocks = entry.blocks;
 
   return (
     <article className="grid grid-cols-1 gap-2 sm:grid-cols-[140px_1fr] sm:items-baseline sm:gap-6 md:grid-cols-[180px_1fr]">
@@ -80,11 +74,10 @@ function TilEntry({
           <h2 className="text-primary text-xl font-medium">{entry.title}</h2>
         )}
 
-        {/* Inline expanded content */}
-        {hasInitialContent ? (
-          <div className="notion-blocks flex flex-col gap-3">
-            {renderBlocks(initialContent.blocks)}
-          </div>
+        {blocks ? (
+          blocks.length > 0 ? (
+            <div className="notion-blocks flex flex-col gap-3">{renderBlocks(blocks)}</div>
+          ) : null
         ) : (
           <TilEntryContent entryId={entry.id} />
         )}
@@ -98,19 +91,11 @@ function TilEntry({
   );
 }
 
-export function TilFeed({ initialEntries, initialLikes }: TilFeedProps) {
-  const { items, isLoading, isLoadingMore, isReachingEnd, setSize, size } = useTilEntries();
+export function TilFeed({ fallbackData, initialLikes }: TilFeedProps) {
+  const { items, isLoading, isLoadingMore, isReachingEnd, setSize, size } =
+    useTilEntries(fallbackData);
 
-  // Build a map of initial content for quick lookup
-  const initialContentMap = new Map<string, NotionTilItemWithContent>(
-    initialEntries.map((entry) => [entry.id, entry]),
-  );
-
-  // Use API-fetched items if available, otherwise fall back to initial entries
-  const entries = items.length > 0 ? items : initialEntries;
-
-  // Collect all page IDs for batch likes fetching
-  const pageIds = useMemo(() => entries.map((entry) => entry.id), [entries]);
+  const pageIds = useMemo(() => items.map((entry) => entry.id), [items]);
 
   const loadMore = useCallback(async () => {
     await setSize(size + 1);
@@ -120,10 +105,8 @@ export function TilFeed({ initialEntries, initialLikes }: TilFeedProps) {
     <BatchLikesProvider pageIds={pageIds} initialData={initialLikes}>
       <InfiniteScrollList
         as="div"
-        items={entries}
-        renderItem={(entry) => (
-          <TilEntry key={entry.id} entry={entry} initialContent={initialContentMap.get(entry.id)} />
-        )}
+        items={items}
+        renderItem={(entry) => <TilEntry key={entry.id} entry={entry} />}
         onLoadMore={loadMore}
         isLoading={isLoading ?? false}
         isLoadingMore={isLoadingMore ?? false}

--- a/src/lib/til.test.ts
+++ b/src/lib/til.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import type { NotionTilItem, NotionTilItemWithContent, ProcessedBlock } from "@/lib/notion";
+import { hydrateTilEntries, type TilEntry } from "@/lib/til";
+
+function item(id: string, title = id): NotionTilItem {
+  return { id, title, published: "2026-01-01" };
+}
+
+function content(id: string, blocks: ProcessedBlock[]): NotionTilItemWithContent {
+  return { ...item(id), blocks };
+}
+
+function paragraph(id: string, text: string): ProcessedBlock {
+  return {
+    id,
+    type: "paragraph",
+    content: [
+      {
+        type: "text",
+        text: { content: text },
+        annotations: {
+          bold: false,
+          italic: false,
+          strikethrough: false,
+          underline: false,
+          code: false,
+          color: "default",
+        },
+      },
+    ],
+  };
+}
+
+describe("hydrateTilEntries", () => {
+  test("attaches blocks from matching content records", () => {
+    const blocks = [paragraph("b1", "hello")];
+    const entries = hydrateTilEntries([item("a"), item("b")], [content("a", blocks), null]);
+
+    expect(entries).toEqual([
+      { ...item("a"), blocks },
+      { ...item("b"), blocks: [] },
+    ]);
+  });
+
+  test("matches content by id, not array position", () => {
+    const blocks = [paragraph("b2", "later")];
+    const entries = hydrateTilEntries([item("a"), item("b")], [null, content("b", blocks)]);
+
+    expect(entries[0]?.blocks).toEqual([]);
+    expect(entries[1]?.blocks).toEqual(blocks);
+  });
+
+  test("uses empty blocks when content is missing so the feed will not refetch", () => {
+    const entries = hydrateTilEntries([item("a")], [null]);
+    expect(entries[0]?.blocks).toEqual([]);
+    expect("blocks" in (entries[0] as TilEntry)).toBe(true);
+  });
+
+  test("keeps list metadata from the feed record", () => {
+    const listed = { id: "a", title: "List title", published: "2026-08-15", shortId: "abc1234" };
+    const [entry] = hydrateTilEntries([listed], [content("a", [paragraph("b1", "body")])]);
+
+    expect(entry).toMatchObject({
+      id: "a",
+      title: "List title",
+      published: "2026-08-15",
+      shortId: "abc1234",
+    });
+  });
+});

--- a/src/lib/til.ts
+++ b/src/lib/til.ts
@@ -3,19 +3,41 @@ import { cache } from "react";
 import { InfiniteScrollPage, useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import {
   getTilDatabaseItems,
-  getTilItemContent,
   NotionTilItem,
   NotionTilItemWithContent,
+  ProcessedBlock,
 } from "@/lib/notion";
 
-export type TilPage = InfiniteScrollPage<NotionTilItem>;
+export type TilEntry = NotionTilItem & { blocks?: ProcessedBlock[] };
 
-export function useTilEntries() {
-  return useInfiniteScroll<NotionTilItem>((index: number, previousPage: TilPage | null) => {
-    if (previousPage && !previousPage.nextCursor) return null;
-    if (index === 0) return `/api/til?limit=20`;
-    return `/api/til?cursor=${previousPage?.nextCursor}&limit=20`;
-  });
+export type TilPage = InfiniteScrollPage<TilEntry>;
+
+export function hydrateTilEntries(
+  items: NotionTilItem[],
+  contents: Array<Pick<NotionTilItemWithContent, "id" | "blocks"> | null>,
+): TilEntry[] {
+  const blocksById = new Map<string, ProcessedBlock[]>();
+  for (const content of contents) {
+    if (content) {
+      blocksById.set(content.id, content.blocks);
+    }
+  }
+
+  return items.map((item) => ({
+    ...item,
+    blocks: blocksById.get(item.id) ?? [],
+  }));
+}
+
+export function useTilEntries(fallbackData?: TilPage[]) {
+  return useInfiniteScroll<TilEntry>(
+    (index: number, previousPage: TilPage | null) => {
+      if (previousPage && !previousPage.nextCursor) return null;
+      if (index === 0) return `/api/til?limit=20`;
+      return `/api/til?cursor=${previousPage?.nextCursor}&limit=20`;
+    },
+    { fallbackData },
+  );
 }
 
 async function fetchAllTilEntries(): Promise<NotionTilItem[]> {
@@ -34,22 +56,3 @@ async function fetchAllTilEntries(): Promise<NotionTilItem[]> {
 }
 
 export const getAllTilEntries = cache(fetchAllTilEntries);
-
-export async function getTilEntriesWithContent(
-  entries: NotionTilItem[],
-): Promise<NotionTilItemWithContent[]> {
-  const entriesWithContent = await Promise.all(
-    entries.map(async (entry) => {
-      const content = await getTilItemContent(entry.id);
-      if (!content) {
-        return {
-          ...entry,
-          blocks: [],
-        };
-      }
-      return content;
-    }),
-  );
-
-  return entriesWithContent;
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S02-1 of the Notion structure audit: the TIL feed is the detail. One `TilEntry` record (`NotionTilItem & { blocks?: ProcessedBlock[] }`) replaces the three-store split (SSR `NotionTilItemWithContent[]`, SWR `NotionTilItem[]`, and `initialContentMap`).

- SSR first page hydrates blocks and is passed as SWR `fallbackData` to `useTilEntries`.
- Deleted `getTilEntriesWithContent` and `initialContentMap`.
- List API (`/api/til`) still returns metadata only. Later rows fetch `/api/til/:id` when `blocks` is missing.
- `NotionTilItemWithContent` is unchanged for `/til/[slug]` and the per-entry content API.
- Rebased onto current `main` after #2273. `ProcessedBlock` is the discriminated union; list-run grouping and content cache `v2` keys are unchanged.

## Test plan

- [x] `bun test` — 151 pass after rebase, including `hydrateTilEntries` and #2273 block/list-run/cache tests
- [x] `bun run lint` / `bunx tsc --noEmit`
- [x] Grep: no `initialContentMap` / `getTilEntriesWithContent`. Feed uses `TilEntry`; `useTilEntries` takes `fallbackData`
- [x] `/til` SSR shows the first 10 entries with inline blocks (no content skeleton flash for those rows)
- [x] Loading more still renders later rows (per-row `/api/til/:id`) — "Noisy Neighbor problem" and later entries show body text
- [x] `/til/[slug]` still renders full content (SNAFU)
- [x] `/api/til?limit=20` payload has no `blocks` field
- [x] `gh pr view 2276` is MERGEABLE after rebase

[TIL feed first SSR entries with inline blocks](https://cursor.com/agents/bc-086b86c1-3e78-4a0c-894e-2e729f6ce0cb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftil_feed_ssr_first_entries.webp)
[TIL feed later entries after Sumo oranges](https://cursor.com/agents/bc-086b86c1-3e78-4a0c-894e-2e729f6ce0cb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftil_feed_later_entries.webp)
[SNAFU detail page with full content](https://cursor.com/agents/bc-086b86c1-3e78-4a0c-894e-2e729f6ce0cb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftil_detail_snafu.webp)
[til_feed_and_detail_walkthrough.mp4](https://cursor.com/agents/bc-086b86c1-3e78-4a0c-894e-2e729f6ce0cb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftil_feed_and_detail_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-086b86c1-3e78-4a0c-894e-2e729f6ce0cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-086b86c1-3e78-4a0c-894e-2e729f6ce0cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

