### PR TITLE
Add public /activity feed (cut 1 foundation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,14 @@ UPSTASH_NOTION_CACHE_REST_TOKEN=
 UPSTASH_LIKES_REST_URL=
 UPSTASH_LIKES_REST_TOKEN=
 
+# Upstash Redis (Activity feed). Optional — if unset, likes Redis is reused
+# with an `activity:` key prefix. Do not point this at the HN rate-limit DB.
+UPSTASH_ACTIVITY_REST_URL=
+UPSTASH_ACTIVITY_REST_TOKEN=
+
+# HMAC secret for POST /api/activity (later external producers)
+ACTIVITY_INGEST_HMAC_SECRET=
+
 # Likes system
 LIKES_HASH_SALT=
 LIKES_SYNC_TOKEN=

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { connection } from "next/server";
+import { Suspense } from "react";
 
 import { ActivityFeed } from "@/components/ActivityFeed";
+import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
 import { getActivityPageData } from "@/lib/activity-redis";
 import { createMetadata } from "@/lib/metadata";
 
@@ -11,7 +13,40 @@ export const metadata: Metadata = createMetadata({
   path: "/activity",
 });
 
-export default async function ActivityPage() {
+export default function ActivityPage() {
+  return (
+    <Suspense fallback={<ActivityFallback />}>
+      <ActivityContent />
+    </Suspense>
+  );
+}
+
+function ActivityFallback() {
+  return (
+    <div data-scrollable className="flex-1 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-12 px-4 py-16 lg:flex-row lg:gap-16">
+        <div className="min-w-0 flex-1">
+          <LoadingSkeleton className="h-10 w-40" />
+          <LoadingSkeleton className="mt-3 h-5 w-72" />
+          <div className="mt-10 flex flex-col gap-4">
+            {Array.from({ length: 6 }, (_, index) => (
+              <LoadingSkeleton key={index} className="h-12 w-full" />
+            ))}
+          </div>
+        </div>
+        <aside className="w-full shrink-0 lg:w-56">
+          <LoadingSkeleton className="mb-3 h-4 w-20" />
+          <div className="flex flex-col gap-2">
+            <LoadingSkeleton className="h-5 w-full" />
+            <LoadingSkeleton className="h-5 w-full" />
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+async function ActivityContent() {
   await connection();
   const { events, totals } = await getActivityPageData();
 

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+
+import { ActivityFeed } from "@/components/ActivityFeed";
+import { getActivityPageData } from "@/lib/activity-redis";
+import { createMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = createMetadata({
+  title: "Activity",
+  description: "A live stream of likes, visits, and other things happening on brianlovin.com.",
+  path: "/activity",
+});
+
+export default async function ActivityPage() {
+  await connection();
+  const { events, totals } = await getActivityPageData();
+
+  return <ActivityFeed initialEvents={events} initialTotals={totals} />;
+}

--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,0 +1,48 @@
+import { createHmac } from "crypto";
+import { NextResponse } from "next/server";
+
+import { type ActivityIngestInput, ingestActivityEvent } from "@/lib/activity";
+import { getActivityStore } from "@/lib/activity-redis";
+import { ACTIVITY_BODY_MAX_BYTES } from "@/lib/activity-shared";
+import { errorResponse, safeCompare } from "@/lib/api-utils";
+
+/**
+ * HMAC ingest for later external producers.
+ * In-repo sources (likes, visits) call ingestActivityEvent directly.
+ */
+export async function POST(request: Request) {
+  const secret = process.env.ACTIVITY_INGEST_HMAC_SECRET;
+  if (!secret) {
+    return errorResponse("Activity ingest is not configured", 503);
+  }
+
+  const raw = await request.text();
+  if (raw.length > ACTIVITY_BODY_MAX_BYTES) {
+    return errorResponse("Payload too large", 413);
+  }
+
+  const signature = request.headers.get("x-activity-signature");
+  const expected = createHmac("sha256", secret).update(raw).digest("hex");
+  if (!safeCompare(signature, expected)) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  let body: ActivityIngestInput;
+  try {
+    body = JSON.parse(raw) as ActivityIngestInput;
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+
+  const store = getActivityStore();
+  if (!store) {
+    return errorResponse("Activity store is not configured", 503);
+  }
+
+  const result = await ingestActivityEvent(body, store);
+  if (!result.ok) {
+    return errorResponse(result.error, result.status);
+  }
+
+  return NextResponse.json({ id: result.id, duplicate: result.duplicate });
+}

--- a/src/app/api/activity/tail/route.ts
+++ b/src/app/api/activity/tail/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { getActivityStore } from "@/lib/activity-redis";
+import { errorResponse } from "@/lib/api-utils";
+
+export async function GET() {
+  const store = getActivityStore();
+  if (!store) {
+    return NextResponse.json(
+      { events: [] },
+      { headers: { "Cache-Control": "public, s-maxage=1" } },
+    );
+  }
+
+  try {
+    const events = await store.getTail(100);
+    return NextResponse.json({ events }, { headers: { "Cache-Control": "public, s-maxage=1" } });
+  } catch (error) {
+    console.error("[activity] tail failed", error);
+    return errorResponse("Failed to load activity");
+  }
+}

--- a/src/app/api/activity/totals/route.ts
+++ b/src/app/api/activity/totals/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { getActivityStore } from "@/lib/activity-redis";
+import { errorResponse } from "@/lib/api-utils";
+
+export async function GET() {
+  const store = getActivityStore();
+  if (!store) {
+    return NextResponse.json(
+      { totals: [] },
+      { headers: { "Cache-Control": "public, s-maxage=1" } },
+    );
+  }
+
+  try {
+    const totals = await store.getTotals();
+    return NextResponse.json({ totals }, { headers: { "Cache-Control": "public, s-maxage=1" } });
+  } catch (error) {
+    console.error("[activity] totals failed", error);
+    return errorResponse("Failed to load activity totals");
+  }
+}

--- a/src/app/api/activity/visit/route.ts
+++ b/src/app/api/activity/visit/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getRequestCountry, recordVisit } from "@/lib/activity";
+import { getActivityStore } from "@/lib/activity-redis";
+import { errorResponse } from "@/lib/api-utils";
+
+const bodySchema = z.object({
+  path: z.string().min(1).max(500),
+});
+
+export async function POST(request: Request) {
+  try {
+    const body = bodySchema.parse(await request.json());
+    const store = getActivityStore();
+    if (!store) {
+      return NextResponse.json({ ok: true, skipped: true });
+    }
+
+    const result = await recordVisit(
+      { path: body.path, country: getRequestCountry(request.headers) },
+      store,
+    );
+
+    if ("skipped" in result) {
+      return NextResponse.json({ ok: true, skipped: true });
+    }
+
+    return NextResponse.json({ ok: true, skipped: false });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Invalid path", 400);
+    }
+    console.error("[activity] visit failed", error);
+    return NextResponse.json({ ok: true, skipped: true });
+  }
+}

--- a/src/app/api/likes/[id]/route.ts
+++ b/src/app/api/likes/[id]/route.ts
@@ -1,6 +1,8 @@
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { z } from "zod";
 
+import { likeMetaFromRequest, recordLike } from "@/lib/activity";
+import { getActivityStore } from "@/lib/activity-redis";
 import { errorResponse } from "@/lib/api-utils";
 import {
   addLike,
@@ -14,6 +16,12 @@ import { getClientIp, hashUserIp } from "@/lib/user-hash";
 
 const paramsSchema = z.object({
   id: z.string().min(1).max(50),
+});
+
+const likeActivitySchema = z.object({
+  title: z.string().max(200).optional(),
+  href: z.string().max(500).optional(),
+  content_type: z.string().max(50).optional(),
 });
 
 export async function GET(request: Request, props: { params: Promise<{ id: string }> }) {
@@ -62,6 +70,28 @@ export async function POST(request: Request, props: { params: Promise<{ id: stri
 
     // Add the like
     const newCount = await addLike(userId, id);
+
+    let body: { title?: string; href?: string; content_type?: string } = {};
+    try {
+      const raw = await request.text();
+      if (raw) {
+        body = likeActivitySchema.parse(JSON.parse(raw));
+      }
+    } catch {
+      body = {};
+    }
+
+    const meta = likeMetaFromRequest(request, body);
+    if (meta) {
+      const store = getActivityStore();
+      if (store) {
+        after(() => {
+          void recordLike({ ...meta, pageId: id }, store).catch((error) => {
+            console.error("[activity] like ingest failed", error);
+          });
+        });
+      }
+    }
 
     return NextResponse.json({
       count: newCount,

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,6 +3,7 @@
 import { ThemeProvider } from "next-themes";
 import { SWRConfig } from "swr";
 
+import { ActivityVisit } from "@/components/ActivityVisit";
 import Fathom from "@/components/Fathom";
 import { TopBarActionsProvider } from "@/components/TopBarActions";
 import { swrConfig } from "@/lib/swr-config";
@@ -17,6 +18,7 @@ export function Providers({ children }: ProvidersProps) {
       <ThemeProvider storageKey="prototype-theme" attribute="class" disableTransitionOnChange>
         <TopBarActionsProvider>
           <Fathom />
+          <ActivityVisit />
           {children}
         </TopBarActionsProvider>
       </ThemeProvider>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { PageTitle } from "@/components/Typography";
+import type { ActivityEvent, ActivityTotal } from "@/lib/activity";
+import { formatTotalLabel, getActivityRow } from "@/lib/activity-shared";
+import { useActivity } from "@/lib/hooks/useActivity";
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const delta = Math.max(0, Date.now() - then);
+  const seconds = Math.floor(delta / 1000);
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatFirstTracked(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "First tracked date unknown";
+  return `First tracked ${date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+}
+
+function RelativeTime({ iso }: { iso: string }) {
+  const [label, setLabel] = useState("");
+
+  useEffect(() => {
+    const tick = () => setLabel(formatRelativeTime(iso));
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [iso]);
+
+  return (
+    <time className="text-quaternary shrink-0 text-sm tabular-nums" dateTime={iso} title={iso}>
+      {label || "\u00a0"}
+    </time>
+  );
+}
+
+function ActivityRow({ event }: { event: ActivityEvent }) {
+  const row = getActivityRow(event);
+  const href = row.href;
+
+  return (
+    <li className="border-secondary flex items-baseline justify-between gap-4 border-b py-3">
+      <div className="min-w-0">
+        <p className="text-primary text-pretty">{row.summary}</p>
+        {href ? (
+          <Link
+            href={href}
+            className="text-tertiary hover:text-primary text-sm underline-offset-2 hover:underline"
+          >
+            {row.label ?? href}
+          </Link>
+        ) : null}
+      </div>
+      <RelativeTime iso={event.received_at} />
+    </li>
+  );
+}
+
+function TotalsList({ totals }: { totals: ActivityTotal[] }) {
+  if (totals.length === 0) {
+    return <p className="text-tertiary text-sm">No totals yet.</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {totals.map((total) => (
+        <li
+          key={`${total.source}:${total.type}`}
+          className="flex items-baseline justify-between gap-3"
+          title={formatFirstTracked(total.first_seen)}
+        >
+          <span className="text-secondary capitalize">{formatTotalLabel(total.type)}</span>
+          <span className="text-primary tabular-nums">{total.count.toLocaleString()}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function ActivityFeed({
+  initialEvents,
+  initialTotals,
+}: {
+  initialEvents: ActivityEvent[];
+  initialTotals: ActivityTotal[];
+}) {
+  const { events, totals } = useActivity(initialEvents, initialTotals);
+
+  return (
+    <div data-scrollable className="flex-1 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-12 px-4 py-16 lg:flex-row lg:gap-16">
+        <div className="min-w-0 flex-1">
+          <PageTitle>Activity</PageTitle>
+          <p className="text-tertiary mt-3 text-pretty">
+            A live stream of things happening on this site.
+          </p>
+          {events.length === 0 ? (
+            <p className="text-tertiary mt-10">Nothing yet. Likes and visits will show up here.</p>
+          ) : (
+            <ul className="mt-10">
+              {events.map((event) => (
+                <ActivityRow key={event.id} event={event} />
+              ))}
+            </ul>
+          )}
+        </div>
+        <aside className="w-full shrink-0 lg:w-56">
+          <h2 className="text-secondary mb-3 text-sm font-medium">Lifetime</h2>
+          <TotalsList totals={totals} />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ActivityVisit.tsx
+++ b/src/components/ActivityVisit.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Suspense, useEffect } from "react";
+
+import { shouldRecordVisit } from "@/lib/activity-shared";
+
+function TrackVisit() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname || !shouldRecordVisit(pathname)) return;
+
+    void fetch("/api/activity/visit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: pathname }),
+    }).catch(() => {});
+  }, [pathname]);
+
+  return null;
+}
+
+export function ActivityVisit() {
+  return (
+    <Suspense fallback={null}>
+      <TrackVisit />
+    </Suspense>
+  );
+}

--- a/src/config/navigation.tsx
+++ b/src/config/navigation.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Activity } from "@/components/icons/Activity";
 import { AppDissection } from "@/components/icons/AppDissection";
 import { Ballot } from "@/components/icons/Ballot";
 import { Bookmark } from "@/components/icons/Bookmark";
@@ -42,6 +43,15 @@ export const navigationItems: NavigationItem[] = [
     icon: Person,
     keywords: ["about", "bio", "me"],
     isActive: (pathname) => pathname === "/about",
+    section: "main",
+  },
+  {
+    id: "activity",
+    label: "Activity",
+    href: "/activity",
+    icon: Activity,
+    keywords: ["activity", "feed", "events", "live"],
+    isActive: (pathname) => pathname.startsWith("/activity"),
     section: "main",
   },
   {

--- a/src/lib/activity-redis.ts
+++ b/src/lib/activity-redis.ts
@@ -1,0 +1,229 @@
+import { Redis } from "@upstash/redis";
+
+import { type ActivityEvent, type ActivityStore, type ActivityTotal } from "./activity";
+import { ACTIVITY_STREAM_MAXLEN } from "./activity-shared";
+
+const STREAM_KEY = "activity:stream";
+const TOTALS_PREFIX = "activity:totals:";
+const IDEMP_PREFIX = "activity:idemp:";
+const VISIT_WINDOW_PREFIX = "activity:visit:window:";
+
+export type ActivityRedisSource = "activity" | "likes";
+
+let redis: Redis | null = null;
+let redisSource: ActivityRedisSource | null = null;
+let redisStore: ActivityStore | null = null;
+
+function createClient(url: string, token: string): Redis {
+  return new Redis({ url, token });
+}
+
+export function getActivityRedisSource(): ActivityRedisSource | null {
+  if (redisSource) return redisSource;
+  if (process.env.UPSTASH_ACTIVITY_REST_URL && process.env.UPSTASH_ACTIVITY_REST_TOKEN) {
+    return "activity";
+  }
+  if (process.env.UPSTASH_LIKES_REST_URL && process.env.UPSTASH_LIKES_REST_TOKEN) {
+    return "likes";
+  }
+  return null;
+}
+
+export function getActivityRedis(): Redis | null {
+  if (redis) return redis;
+
+  if (process.env.UPSTASH_ACTIVITY_REST_URL && process.env.UPSTASH_ACTIVITY_REST_TOKEN) {
+    redis = createClient(
+      process.env.UPSTASH_ACTIVITY_REST_URL,
+      process.env.UPSTASH_ACTIVITY_REST_TOKEN,
+    );
+    redisSource = "activity";
+    return redis;
+  }
+
+  // Dedicated activity pair is unset. Reuse likes — never the HN rate-limit DB
+  // (UPSTASH_REDIS_REST_URL) and never FLUSHDB. All keys are prefixed activity:.
+  if (process.env.UPSTASH_LIKES_REST_URL && process.env.UPSTASH_LIKES_REST_TOKEN) {
+    redis = createClient(process.env.UPSTASH_LIKES_REST_URL, process.env.UPSTASH_LIKES_REST_TOKEN);
+    redisSource = "likes";
+    return redis;
+  }
+
+  return null;
+}
+
+function totalsKey(source: string, type: string): string {
+  return `${TOTALS_PREFIX}${source}:${type}`;
+}
+
+export function parseActivityStreamFields(value: unknown): ActivityEvent | null {
+  if (!value) return null;
+
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as ActivityEvent;
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof value !== "object") return null;
+
+  const raw = value as Record<string, unknown>;
+  if ("e" in raw) {
+    const encoded = raw.e;
+    if (typeof encoded === "string") {
+      try {
+        return JSON.parse(encoded) as ActivityEvent;
+      } catch {
+        return null;
+      }
+    }
+    if (encoded && typeof encoded === "object" && "id" in encoded && "summary" in encoded) {
+      return encoded as ActivityEvent;
+    }
+  }
+
+  if ("id" in raw && "summary" in raw) {
+    return raw as ActivityEvent;
+  }
+
+  return null;
+}
+
+function parseXrevrange(result: unknown): ActivityEvent[] {
+  if (!result) return [];
+
+  if (Array.isArray(result)) {
+    const events: ActivityEvent[] = [];
+    for (const entry of result) {
+      if (Array.isArray(entry) && entry.length >= 2) {
+        const parsed = parseActivityStreamFields(entry[1]);
+        if (parsed) events.push(parsed);
+        continue;
+      }
+      if (entry && typeof entry === "object") {
+        const parsed = parseActivityStreamFields(entry);
+        if (parsed) events.push(parsed);
+      }
+    }
+    return events;
+  }
+
+  if (typeof result === "object") {
+    const events: ActivityEvent[] = [];
+    for (const fields of Object.values(result as Record<string, unknown>)) {
+      const parsed = parseActivityStreamFields(fields);
+      if (parsed) events.push(parsed);
+    }
+    return events;
+  }
+
+  return [];
+}
+
+export function createRedisActivityStore(client: Redis): ActivityStore {
+  return {
+    async claimIdempotency(key: string, ttlSeconds: number): Promise<boolean> {
+      const result = await client.set(`${IDEMP_PREFIX}${key}`, "1", {
+        nx: true,
+        ex: ttlSeconds,
+      });
+      return result === "OK";
+    },
+
+    async incrementTotal(source: string, type: string, firstSeen: string): Promise<void> {
+      const key = totalsKey(source, type);
+      const pipeline = client.pipeline();
+      pipeline.hincrby(key, "count", 1);
+      pipeline.hsetnx(key, "first_seen", firstSeen);
+      await pipeline.exec();
+    },
+
+    async addToStream(event: ActivityEvent): Promise<void> {
+      await client.xadd(
+        STREAM_KEY,
+        "*",
+        { e: JSON.stringify(event) },
+        {
+          trim: {
+            type: "MAXLEN",
+            threshold: ACTIVITY_STREAM_MAXLEN,
+            comparison: "~",
+          },
+        },
+      );
+    },
+
+    async getTail(limit: number): Promise<ActivityEvent[]> {
+      const result = await client.xrevrange(STREAM_KEY, "+", "-", limit);
+      return parseXrevrange(result).filter((event) => event.visibility === "public");
+    },
+
+    async getTotals(): Promise<ActivityTotal[]> {
+      const totals: ActivityTotal[] = [];
+      let cursor = 0;
+
+      do {
+        const [nextCursor, keys] = await client.scan(cursor, {
+          match: `${TOTALS_PREFIX}*`,
+          count: 100,
+        });
+        cursor = Number(nextCursor);
+
+        for (const key of keys) {
+          const hash = await client.hgetall<Record<string, string>>(key);
+          if (!hash) continue;
+          const suffix = key.slice(TOTALS_PREFIX.length);
+          const separator = suffix.indexOf(":");
+          if (separator === -1) continue;
+          const source = suffix.slice(0, separator);
+          const type = suffix.slice(separator + 1);
+          const count = Number(hash.count ?? 0);
+          const firstSeen = hash.first_seen;
+          if (!firstSeen || !Number.isFinite(count)) continue;
+          totals.push({ source, type, count, first_seen: firstSeen });
+        }
+      } while (cursor !== 0);
+
+      return totals.sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
+    },
+
+    async getStreamLength(): Promise<number> {
+      return (await client.xlen(STREAM_KEY)) ?? 0;
+    },
+
+    async incrementVisitWindow(windowKey: string, ttlSeconds: number): Promise<number> {
+      const key = `${VISIT_WINDOW_PREFIX}${windowKey}`;
+      const count = await client.incr(key);
+      if (count === 1) {
+        await client.expire(key, ttlSeconds);
+      }
+      return count;
+    },
+  };
+}
+
+export function getActivityStore(): ActivityStore | null {
+  if (redisStore) return redisStore;
+  const client = getActivityRedis();
+  if (!client) return null;
+  redisStore = createRedisActivityStore(client);
+  return redisStore;
+}
+
+export async function getActivityPageData(): Promise<{
+  events: ActivityEvent[];
+  totals: ActivityTotal[];
+}> {
+  const store = getActivityStore();
+  if (!store) return { events: [], totals: [] };
+
+  try {
+    const [events, totals] = await Promise.all([store.getTail(100), store.getTotals()]);
+    return { events, totals };
+  } catch (error) {
+    console.error("[activity] failed to read feed", error);
+    return { events: [], totals: [] };
+  }
+}

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -1,0 +1,191 @@
+/**
+ * Shared activity-feed types and pure helpers.
+ * Safe to import from client components (no Redis / Node crypto).
+ */
+
+export const ACTIVITY_ENVELOPE_VERSION = 1;
+export const ACTIVITY_STREAM_MAXLEN = 1500;
+export const ACTIVITY_VISIT_STREAM_MAX_PER_SEC = 10;
+export const ACTIVITY_IDEMPOTENCY_TTL_SECONDS = 6 * 60 * 60;
+export const ACTIVITY_META_MAX_BYTES = 2048;
+export const ACTIVITY_BODY_MAX_BYTES = 8192;
+export const ACTIVITY_SOURCE_BRIOS = "brios";
+
+export type ActivitySpeed = "event" | "signal";
+export type ActivityVisibility = "public" | "private";
+
+export type ActivityRef = {
+  kind: string;
+  label: string;
+  href?: string;
+};
+
+export type ActivityEvent = {
+  v: number;
+  id: string;
+  ts: string;
+  received_at: string;
+  source: string;
+  type: string;
+  speed: ActivitySpeed;
+  summary: string;
+  visibility: ActivityVisibility;
+  idempotency_key: string;
+  actor?: ActivityRef;
+  subject?: ActivityRef;
+  meta?: Record<string, unknown>;
+};
+
+export type ActivityTotal = {
+  source: string;
+  type: string;
+  count: number;
+  first_seen: string;
+};
+
+export type ActivityIngestInput = {
+  v?: number;
+  id?: string;
+  ts?: string;
+  source: string;
+  type: string;
+  speed: ActivitySpeed;
+  summary: string;
+  visibility?: ActivityVisibility;
+  idempotency_key: string;
+  actor?: ActivityRef;
+  subject?: ActivityRef;
+  meta?: Record<string, unknown>;
+  /** When false, increment totals only (used for sampled visits). */
+  writeToStream?: boolean;
+};
+
+const ACTIVITY_PATH = /^\/activity(?:\/|$)/;
+
+export function isActivityPath(pathname: string): boolean {
+  const path = pathname.split("?")[0] ?? pathname;
+  return ACTIVITY_PATH.test(path);
+}
+
+export function shouldRecordVisit(pathname: string): boolean {
+  if (!pathname || pathname.startsWith("/api/") || pathname.startsWith("/_next/")) {
+    return false;
+  }
+  return !isActivityPath(pathname);
+}
+
+export function inferContentTypeFromPath(pathname: string): string {
+  if (pathname.startsWith("/writing")) return "writing";
+  if (pathname.startsWith("/til")) return "til";
+  if (pathname.startsWith("/stack")) return "stack";
+  if (pathname.startsWith("/sites")) return "site";
+  if (pathname.startsWith("/ama")) return "ama";
+  if (pathname.startsWith("/app-dissection")) return "app_dissection";
+  if (pathname.startsWith("/design-details")) return "design_details";
+  if (pathname.startsWith("/listening")) return "listening";
+  if (pathname === "/") return "home";
+  return "page";
+}
+
+export function inferTitleFromPath(pathname: string): string {
+  const segments = pathname.split("/").filter(Boolean);
+  const last = segments[segments.length - 1];
+  if (!last) return "a page";
+  try {
+    return decodeURIComponent(last).replace(/-/g, " ");
+  } catch {
+    return last;
+  }
+}
+
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
+const IPV6_RE = /\b(?:[0-9a-f]{1,4}:){2,7}[0-9a-f]{1,4}\b/i;
+const FORBIDDEN_KEY_RE =
+  /^(email|e-mail|cookie|cookies|authorization|cf-connecting-ip|set-cookie)$/i;
+const FORBIDDEN_SUBSTRINGS = ["cf-connecting-ip", "authorization:", "cookie:"];
+
+export type PiiRejection = { ok: false; reason: string };
+export type PiiAcceptance = { ok: true };
+
+export function findForbiddenPii(value: unknown): string | null {
+  return scanPii(value, "");
+}
+
+function scanPii(value: unknown, path: string): string | null {
+  if (value == null) return null;
+
+  if (typeof value === "string") {
+    if (EMAIL_RE.test(value)) return path ? `${path}: email` : "email";
+    if (IPV4_RE.test(value) || IPV6_RE.test(value)) return path ? `${path}: ip` : "ip";
+    const lower = value.toLowerCase();
+    for (const token of FORBIDDEN_SUBSTRINGS) {
+      if (lower.includes(token)) return path ? `${path}: ${token}` : token;
+    }
+    return null;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") return null;
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const hit = scanPii(value[i], path ? `${path}[${i}]` : `[${i}]`);
+      if (hit) return hit;
+    }
+    return null;
+  }
+
+  if (typeof value === "object") {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (FORBIDDEN_KEY_RE.test(key) || key.toLowerCase().includes("cf-connecting-ip")) {
+        return `key:${key}`;
+      }
+      const hit = scanPii(child, path ? `${path}.${key}` : key);
+      if (hit) return hit;
+    }
+  }
+
+  return null;
+}
+
+export function getActivityRow(event: ActivityEvent): {
+  summary: string;
+  href?: string;
+  label?: string;
+} {
+  return {
+    summary: event.summary,
+    href: event.subject?.href,
+    label: event.subject?.label,
+  };
+}
+
+export function formatTotalLabel(type: string): string {
+  switch (type) {
+    case "like":
+      return "Likes";
+    case "visit":
+      return "Visits";
+    default:
+      return type.replace(/_/g, " ");
+  }
+}
+
+const COUNTRY_RE = /^[A-Z]{2}$/;
+
+export function normalizeCountryCode(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const code = value.trim().toUpperCase();
+  if (!COUNTRY_RE.test(code)) return undefined;
+  if (code === "XX" || code === "T1") return undefined;
+  return code;
+}
+
+export function getRequestCountry(headers: Headers): string | undefined {
+  return normalizeCountryCode(
+    headers.get("cf-ipcountry") ??
+      headers.get("CF-IPCountry") ??
+      headers.get("x-vercel-ip-country") ??
+      headers.get("x-country"),
+  );
+}

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createMemoryActivityStore,
+  findForbiddenPii,
+  getActivityRow,
+  getRequestCountry,
+  ingestActivityEvent,
+  likeMetaFromRequest,
+  recordLike,
+  recordVisit,
+  shouldRecordVisit,
+} from "@/lib/activity";
+import { parseActivityStreamFields } from "@/lib/activity-redis";
+import { ACTIVITY_STREAM_MAXLEN, ACTIVITY_VISIT_STREAM_MAX_PER_SEC } from "@/lib/activity-shared";
+
+function baseEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    source: "brios",
+    type: "like",
+    speed: "event" as const,
+    summary: "Someone liked a page",
+    visibility: "public" as const,
+    idempotency_key: `test:${crypto.randomUUID()}`,
+    ...overrides,
+  };
+}
+
+describe("findForbiddenPii", () => {
+  test("rejects an email in a nested value", () => {
+    expect(findForbiddenPii({ summary: "hi a@b.com" })).toBe("summary: email");
+  });
+
+  test("rejects a raw IPv4 address", () => {
+    expect(findForbiddenPii({ meta: { host: "203.0.113.10" } })).toBe("meta.host: ip");
+  });
+
+  test("rejects cookie, authorization, and cf-connecting-ip keys", () => {
+    expect(findForbiddenPii({ cookie: "a=b" })).toBe("key:cookie");
+    expect(findForbiddenPii({ authorization: "Bearer x" })).toBe("key:authorization");
+    expect(findForbiddenPii({ "cf-connecting-ip": "1.1.1.1" })).toBe("key:cf-connecting-ip");
+  });
+
+  test("rejects cf-connecting-ip in a string value", () => {
+    expect(findForbiddenPii({ note: "header cf-connecting-ip leaked" })).toContain(
+      "cf-connecting-ip",
+    );
+  });
+
+  test("allows a public like payload", () => {
+    expect(
+      findForbiddenPii({
+        source: "brios",
+        type: "like",
+        summary: "Someone liked Stack",
+        subject: { kind: "stack", label: "Stack", href: "/stack" },
+        meta: { content_type: "stack", title: "Stack", href: "/stack" },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("ingestActivityEvent", () => {
+  test("rejects PII before writing", async () => {
+    const store = createMemoryActivityStore();
+    const result = await ingestActivityEvent(
+      baseEvent({ summary: "email me at test@example.com" }),
+      store,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("forbidden");
+    expect(await store.getStreamLength()).toBe(0);
+    expect(await store.getTotals()).toEqual([]);
+  });
+
+  test("idempotent retry does not double-count totals", async () => {
+    const store = createMemoryActivityStore();
+    const input = baseEvent({ idempotency_key: "like:page:1" });
+
+    const first = await ingestActivityEvent(input, store);
+    const second = await ingestActivityEvent({ ...input, id: crypto.randomUUID() }, store);
+
+    expect(first.ok && !first.duplicate).toBe(true);
+    expect(second.ok && second.duplicate).toBe(true);
+    expect(await store.getStreamLength()).toBe(1);
+    expect(await store.getTotals()).toEqual([
+      expect.objectContaining({ source: "brios", type: "like", count: 1 }),
+    ]);
+  });
+
+  test("unknown type is valid when summary is present", async () => {
+    const store = createMemoryActivityStore();
+    const result = await ingestActivityEvent(
+      baseEvent({
+        type: "weird_new_thing",
+        summary: "A brand new event happened",
+        subject: { kind: "page", label: "Hello", href: "/hello" },
+      }),
+      store,
+    );
+
+    expect(result.ok).toBe(true);
+    const [event] = await store.getTail(10);
+    expect(event?.type).toBe("weird_new_thing");
+    expect(getActivityRow(event!)).toEqual({
+      summary: "A brand new event happened",
+      href: "/hello",
+      label: "Hello",
+    });
+  });
+
+  test("stream MAXLEN drops the oldest events", async () => {
+    const store = createMemoryActivityStore({ maxLen: 5 });
+    for (let i = 0; i < 12; i++) {
+      await ingestActivityEvent(baseEvent({ summary: `event ${i}` }), store);
+    }
+    expect(await store.getStreamLength()).toBe(5);
+    const tail = await store.getTail(10);
+    expect(tail[0]?.summary).toBe("event 11");
+    expect(tail[4]?.summary).toBe("event 7");
+  });
+});
+
+describe("recordVisit", () => {
+  test("does not ingest a visit for /activity", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordVisit({ path: "/activity", country: "US" }, store);
+    expect(result).toEqual({ skipped: true, reason: "activity_path" });
+    expect(await store.getStreamLength()).toBe(0);
+    expect(await store.getTotals()).toEqual([]);
+  });
+
+  test("does not ingest a visit for /activity/nested", async () => {
+    const store = createMemoryActivityStore();
+    await recordVisit({ path: "/activity/nested" }, store);
+    expect(await store.getTotals()).toEqual([]);
+  });
+
+  test("increments totals for every visit but samples stream inserts", async () => {
+    const store = createMemoryActivityStore();
+    const now = new Date("2026-08-16T12:00:00.000Z");
+    const burst = ACTIVITY_VISIT_STREAM_MAX_PER_SEC + 25;
+
+    for (let i = 0; i < burst; i++) {
+      const result = await recordVisit({ path: "/writing", country: "DE" }, store, now);
+      expect("ok" in result && result.ok).toBe(true);
+    }
+
+    const totals = await store.getTotals();
+    expect(totals).toEqual([
+      expect.objectContaining({ source: "brios", type: "visit", count: burst }),
+    ]);
+    expect(await store.getStreamLength()).toBe(ACTIVITY_VISIT_STREAM_MAX_PER_SEC);
+    expect(await store.getStreamLength()).toBeLessThan(ACTIVITY_STREAM_MAXLEN);
+  });
+});
+
+describe("recordLike", () => {
+  test("does not record a like on /activity", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordLike(
+      { title: "Activity", href: "/activity", content_type: "page" },
+      store,
+    );
+    expect(result).toEqual({ skipped: true, reason: "activity_path" });
+    expect(await store.getTotals()).toEqual([]);
+  });
+
+  test("writes a public like with subject + meta and no actor", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordLike(
+      { title: "A post", href: "/writing/a-post", content_type: "writing", pageId: "abc" },
+      store,
+    );
+    expect("ok" in result && result.ok).toBe(true);
+    const [event] = await store.getTail(1);
+    expect(event?.actor).toBeUndefined();
+    expect(event?.subject).toEqual({
+      kind: "writing",
+      label: "A post",
+      href: "/writing/a-post",
+    });
+    expect(event?.meta).toEqual({
+      content_type: "writing",
+      title: "A post",
+      href: "/writing/a-post",
+    });
+  });
+});
+
+describe("parseActivityStreamFields", () => {
+  const event = {
+    v: 1,
+    id: "evt_1",
+    ts: "2026-08-16T00:00:00.000Z",
+    received_at: "2026-08-16T00:00:00.000Z",
+    source: "brios",
+    type: "like",
+    speed: "event" as const,
+    summary: "Someone liked a page",
+    visibility: "public" as const,
+    idempotency_key: "k1",
+  };
+
+  test("parses Upstash auto-decoded stream fields", () => {
+    expect(parseActivityStreamFields({ e: event })?.id).toBe("evt_1");
+  });
+
+  test("parses a JSON string payload", () => {
+    expect(parseActivityStreamFields({ e: JSON.stringify(event) })?.summary).toBe(
+      "Someone liked a page",
+    );
+  });
+});
+
+describe("getRequestCountry", () => {
+  test("prefers Cloudflare country and never reads IP headers", () => {
+    const headers = new Headers({
+      "cf-ipcountry": "de",
+      "x-vercel-ip-country": "US",
+      "cf-connecting-ip": "203.0.113.10",
+      "x-forwarded-for": "203.0.113.10",
+    });
+    expect(getRequestCountry(headers)).toBe("DE");
+  });
+
+  test("falls back to the Vercel country header", () => {
+    expect(getRequestCountry(new Headers({ "x-vercel-ip-country": "jp" }))).toBe("JP");
+  });
+
+  test("ignores Cloudflare unknown / tor codes", () => {
+    expect(getRequestCountry(new Headers({ "cf-ipcountry": "XX" }))).toBeUndefined();
+    expect(getRequestCountry(new Headers({ "cf-ipcountry": "T1" }))).toBeUndefined();
+  });
+});
+
+describe("shouldRecordVisit / likeMetaFromRequest", () => {
+  test("skips the activity page and API routes", () => {
+    expect(shouldRecordVisit("/activity")).toBe(false);
+    expect(shouldRecordVisit("/writing")).toBe(true);
+    expect(shouldRecordVisit("/api/activity/tail")).toBe(false);
+  });
+
+  test("builds like meta from the referer and skips /activity", () => {
+    const writing = likeMetaFromRequest(
+      new Request("https://brianlovin.com/api/likes/1", {
+        headers: { referer: "https://brianlovin.com/writing/hello-world" },
+      }),
+    );
+    expect(writing).toEqual({
+      href: "/writing/hello-world",
+      title: "hello world",
+      content_type: "writing",
+    });
+
+    const activity = likeMetaFromRequest(
+      new Request("https://brianlovin.com/api/likes/1", {
+        headers: { referer: "https://brianlovin.com/activity" },
+      }),
+    );
+    expect(activity).toBeNull();
+  });
+});

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,276 @@
+import {
+  ACTIVITY_ENVELOPE_VERSION,
+  ACTIVITY_IDEMPOTENCY_TTL_SECONDS,
+  ACTIVITY_META_MAX_BYTES,
+  ACTIVITY_SOURCE_BRIOS,
+  ACTIVITY_STREAM_MAXLEN,
+  ACTIVITY_VISIT_STREAM_MAX_PER_SEC,
+  type ActivityEvent,
+  type ActivityIngestInput,
+  type ActivityTotal,
+  findForbiddenPii,
+  inferContentTypeFromPath,
+  inferTitleFromPath,
+  isActivityPath,
+  shouldRecordVisit,
+} from "./activity-shared";
+
+export type {
+  ActivityEvent,
+  ActivityIngestInput,
+  ActivityRef,
+  ActivitySpeed,
+  ActivityTotal,
+  ActivityVisibility,
+} from "./activity-shared";
+export {
+  ACTIVITY_ENVELOPE_VERSION,
+  ACTIVITY_SOURCE_BRIOS,
+  ACTIVITY_STREAM_MAXLEN,
+  ACTIVITY_VISIT_STREAM_MAX_PER_SEC,
+  findForbiddenPii,
+  formatTotalLabel,
+  getActivityRow,
+  getRequestCountry,
+  inferContentTypeFromPath,
+  inferTitleFromPath,
+  isActivityPath,
+  shouldRecordVisit,
+} from "./activity-shared";
+
+export type IngestResult =
+  | { ok: true; id: string; duplicate: boolean; streamed: boolean }
+  | { ok: false; error: string; status: number };
+
+export type ActivityStore = {
+  claimIdempotency(key: string, ttlSeconds: number): Promise<boolean>;
+  incrementTotal(source: string, type: string, firstSeen: string): Promise<void>;
+  addToStream(event: ActivityEvent): Promise<void>;
+  getTail(limit: number): Promise<ActivityEvent[]>;
+  getTotals(): Promise<ActivityTotal[]>;
+  getStreamLength(): Promise<number>;
+  incrementVisitWindow(windowKey: string, ttlSeconds: number): Promise<number>;
+};
+
+export function createMemoryActivityStore(options: { maxLen?: number } = {}): ActivityStore {
+  const maxLen = options.maxLen ?? ACTIVITY_STREAM_MAXLEN;
+  const events: ActivityEvent[] = [];
+  const totals = new Map<string, ActivityTotal>();
+  const claimed = new Set<string>();
+  const visitWindows = new Map<string, number>();
+
+  return {
+    async claimIdempotency(key: string): Promise<boolean> {
+      if (claimed.has(key)) return false;
+      claimed.add(key);
+      return true;
+    },
+    async incrementTotal(source: string, type: string, firstSeen: string): Promise<void> {
+      const id = `${source}:${type}`;
+      const existing = totals.get(id);
+      if (existing) {
+        existing.count += 1;
+        return;
+      }
+      totals.set(id, { source, type, count: 1, first_seen: firstSeen });
+    },
+    async addToStream(event: ActivityEvent): Promise<void> {
+      events.push(event);
+      if (events.length > maxLen) {
+        events.splice(0, events.length - maxLen);
+      }
+    },
+    async getTail(limit: number): Promise<ActivityEvent[]> {
+      return events.slice().reverse().slice(0, limit);
+    },
+    async getTotals(): Promise<ActivityTotal[]> {
+      return Array.from(totals.values()).sort((a, b) => b.count - a.count);
+    },
+    async getStreamLength(): Promise<number> {
+      return events.length;
+    },
+    async incrementVisitWindow(windowKey: string): Promise<number> {
+      const next = (visitWindows.get(windowKey) ?? 0) + 1;
+      visitWindows.set(windowKey, next);
+      return next;
+    },
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateRef(name: string, value: unknown): string | null {
+  if (value === undefined) return null;
+  if (!isPlainObject(value)) return `${name} must be an object`;
+  if (typeof value.kind !== "string" || value.kind.length === 0) {
+    return `${name}.kind is required`;
+  }
+  if (typeof value.label !== "string" || value.label.length === 0) {
+    return `${name}.label is required`;
+  }
+  if (value.href !== undefined && typeof value.href !== "string") {
+    return `${name}.href must be a string`;
+  }
+  return null;
+}
+
+export function validateIngestInput(input: ActivityIngestInput): string | null {
+  if (!input.source || typeof input.source !== "string") return "source is required";
+  if (!input.type || typeof input.type !== "string") return "type is required";
+  if (!input.summary || typeof input.summary !== "string") return "summary is required";
+  if (!input.idempotency_key || typeof input.idempotency_key !== "string") {
+    return "idempotency_key is required";
+  }
+  if (input.speed !== "event" && input.speed !== "signal") {
+    return "speed must be event or signal";
+  }
+  if (input.visibility && input.visibility !== "public" && input.visibility !== "private") {
+    return "visibility must be public or private";
+  }
+  const actorError = validateRef("actor", input.actor);
+  if (actorError) return actorError;
+  const subjectError = validateRef("subject", input.subject);
+  if (subjectError) return subjectError;
+  if (input.meta !== undefined) {
+    if (!isPlainObject(input.meta)) return "meta must be an object";
+    const metaBytes = new TextEncoder().encode(JSON.stringify(input.meta)).byteLength;
+    if (metaBytes > ACTIVITY_META_MAX_BYTES) return "meta exceeds 2kb";
+  }
+  return null;
+}
+
+export async function ingestActivityEvent(
+  input: ActivityIngestInput,
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const fieldError = validateIngestInput(input);
+  if (fieldError) return { ok: false, error: fieldError, status: 400 };
+
+  const pii = findForbiddenPii(input);
+  if (pii) {
+    return { ok: false, error: `payload contains forbidden data (${pii})`, status: 400 };
+  }
+
+  const receivedAt = now.toISOString();
+  const event: ActivityEvent = {
+    v: input.v ?? ACTIVITY_ENVELOPE_VERSION,
+    id: input.id ?? crypto.randomUUID(),
+    ts: input.ts ?? receivedAt,
+    received_at: receivedAt,
+    source: input.source,
+    type: input.type,
+    speed: input.speed,
+    summary: input.summary,
+    visibility: input.visibility ?? "public",
+    idempotency_key: input.idempotency_key,
+    ...(input.actor ? { actor: input.actor } : {}),
+    ...(input.subject ? { subject: input.subject } : {}),
+    ...(input.meta ? { meta: input.meta } : {}),
+  };
+
+  const claimed = await store.claimIdempotency(
+    event.idempotency_key,
+    ACTIVITY_IDEMPOTENCY_TTL_SECONDS,
+  );
+
+  if (!claimed) {
+    return { ok: true, id: event.id, duplicate: true, streamed: false };
+  }
+
+  await store.incrementTotal(event.source, event.type, event.received_at);
+
+  const writeToStream = input.writeToStream !== false;
+  if (writeToStream) {
+    await store.addToStream(event);
+  }
+
+  return { ok: true, id: event.id, duplicate: false, streamed: writeToStream };
+}
+
+export async function recordLike(
+  input: { title: string; href: string; content_type: string; pageId?: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult | { skipped: true; reason: string }> {
+  if (isActivityPath(input.href)) {
+    return { skipped: true, reason: "activity_path" };
+  }
+
+  const title = input.title.trim() || "a page";
+  const href = input.href;
+  const contentType = input.content_type || inferContentTypeFromPath(href);
+
+  return ingestActivityEvent(
+    {
+      source: ACTIVITY_SOURCE_BRIOS,
+      type: "like",
+      speed: "event",
+      summary: `Someone liked ${title}`,
+      visibility: "public",
+      idempotency_key: `brios:like:${input.pageId ?? href}:${crypto.randomUUID()}`,
+      subject: { kind: contentType, label: title, href },
+      meta: { content_type: contentType, title, href },
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordVisit(
+  input: { path: string; country?: string | null },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult | { skipped: true; reason: string }> {
+  if (!shouldRecordVisit(input.path)) {
+    return { skipped: true, reason: "activity_path" };
+  }
+
+  const country = input.country?.trim() || undefined;
+  const windowKey = `visit:${Math.floor(now.getTime() / 1000)}`;
+  const windowCount = await store.incrementVisitWindow(windowKey, 2);
+  const writeToStream = windowCount <= ACTIVITY_VISIT_STREAM_MAX_PER_SEC;
+
+  return ingestActivityEvent(
+    {
+      source: ACTIVITY_SOURCE_BRIOS,
+      type: "visit",
+      speed: "signal",
+      summary: country ? `Visit from ${country}` : "Visit",
+      visibility: "public",
+      idempotency_key: `brios:visit:${crypto.randomUUID()}`,
+      meta: country ? { country } : undefined,
+      writeToStream,
+    },
+    store,
+    now,
+  );
+}
+
+export function likeMetaFromRequest(
+  request: Request,
+  body: { title?: string; href?: string; content_type?: string } = {},
+): { title: string; href: string; content_type: string } | null {
+  let href = body.href;
+  if (!href) {
+    const referer = request.headers.get("referer");
+    if (referer) {
+      try {
+        href = new URL(referer).pathname;
+      } catch {
+        href = undefined;
+      }
+    }
+  }
+
+  if (!href) href = "/";
+  if (isActivityPath(href)) return null;
+
+  return {
+    href,
+    title: body.title?.trim() || inferTitleFromPath(href),
+    content_type: body.content_type || inferContentTypeFromPath(href),
+  };
+}

--- a/src/lib/hooks/useActivity.ts
+++ b/src/lib/hooks/useActivity.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import useSWR from "swr";
+
+import type { ActivityEvent, ActivityTotal } from "@/lib/activity";
+import { fetcher } from "@/lib/fetcher";
+
+type TailResponse = { events: ActivityEvent[] };
+type TotalsResponse = { totals: ActivityTotal[] };
+
+export function useActivity(initialEvents: ActivityEvent[], initialTotals: ActivityTotal[]) {
+  const tail = useSWR<TailResponse>("/api/activity/tail", fetcher, {
+    fallbackData: { events: initialEvents },
+    refreshInterval: 1000,
+    revalidateOnFocus: false,
+    dedupingInterval: 500,
+  });
+
+  const totals = useSWR<TotalsResponse>("/api/activity/totals", fetcher, {
+    fallbackData: { totals: initialTotals },
+    refreshInterval: 1000,
+    revalidateOnFocus: false,
+    dedupingInterval: 500,
+  });
+
+  return {
+    events: tail.data?.events ?? initialEvents,
+    totals: totals.data?.totals ?? initialTotals,
+  };
+}

--- a/src/lib/hooks/useLikes.ts
+++ b/src/lib/hooks/useLikes.ts
@@ -57,7 +57,15 @@ export function useLikes(pageId: string) {
     await mutate(
       `/api/likes/${pageId}`,
       async () => {
-        const res = await fetch(`/api/likes/${pageId}`, { method: "POST" });
+        const res = await fetch(`/api/likes/${pageId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            href: window.location.pathname,
+            title: document.title,
+            content_type: window.location.pathname.split("/").filter(Boolean)[0],
+          }),
+        });
         if (!res.ok) {
           throw new Error("Failed to like");
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cut 1 of the activity feed: `/activity` is a real, updating public page. Not an analytics warehouse. Not a forever event log.

## What shipped
- Envelope + PII rejection + idempotent ingest helper (`ingestActivityEvent`)
- Two Redis structures, prefix `activity:`
  - Stream (`XADD`, `MAXLEN ~1500`) — what the page renders
  - Totals hash per `(source, type)`: `{ count, first_seen }` — never expire
  - Short-TTL idempotency set so retries do not double-count totals
- `/activity` SSR of tail + lifetime sidebar (Suspense + `connection()` so Cache Components can PPR), then 1s client poll of `GET /api/activity/tail` and `GET /api/activity/totals` (`Cache-Control: public, s-maxage=1`)
- Nav item
- HMAC `POST /api/activity` stub for later external sources (not used by in-repo producers)

## Redis
`UPSTASH_ACTIVITY_REST_URL` / `UPSTASH_ACTIVITY_REST_TOKEN` are not set in this environment.

This cut uses the **likes** Upstash DB (`UPSTASH_LIKES_REST_URL` + `UPSTASH_LIKES_REST_TOKEN`) with prefix `activity:`. It does **not** use the HN rate-limit / subscribers DB (`UPSTASH_REDIS_REST_URL`). No `FLUSHDB`.

To give activity its own database later, set the `UPSTASH_ACTIVITY_*` pair; the client prefers those names when present.

## Producers (this PR only)
In-process helper calls, not HMAC:

1. **`like`** (`source: brios`) — after a successful Notion-resource like. Meta: `content_type`, `title`, `href`. No viewer identity. Likes on `/activity` are ignored.
2. **`visit`** (`source: brios`) — country only (`cf-ipcountry` or `x-vercel-ip-country`). Never IP. Every visit increments the lifetime total. Stream inserts are sampled at ~10/sec. Viewing `/activity` does not write a visit.

## How to add the next producer
Call the helper from the mutation site:

```ts
await ingestActivityEvent({
  source: "brios",
  type: "ama_asked",
  speed: "event",
  summary: "Someone asked a question",
  visibility: "public",
  idempotency_key: `brios:ama_asked:${id}`,
  subject: { kind: "ama", label: title, href: `/ama/${id}` },
}, store);
```

Unknown `type` is valid if `summary` is present. The default row renders `summary` + subject link. No per-type renderer required.

## Left out (follow-up)
`ama_asked`, `ama_answered`, `digest_subscribed`, `digest_sent`, `writing_published`, `til_published`, `stack_added`, `site_added`, `design_details_added`, `app_dissection_published`, `visit_country_first`.

No GitHub, Shiori, Spotify, Vercel, podcast, or walk events. No source filter chips. No SSE/websockets. No Postgres event log.

## Tests
- Reject PII in ingest
- Idempotent retry does not double-count totals
- Unknown type still renders
- `/activity` does not ingest a visit
- Visit sampling cannot unbounded-grow the stream
- `bun test`, lint, `tsc`, and `bun run build` clean

Live smoke against the likes Redis in this environment: a like and a non-`/activity` visit landed in the stream; a visit to `/activity` was skipped.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f096e7d6-a19b-4b78-b72d-8cdbe8bb7662?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f096e7d6-a19b-4b78-b72d-8cdbe8bb7662&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

