### PR TITLE
Wire remaining briOS activity producers

### DIFF
--- a/src/app/api/ama/route.ts
+++ b/src/app/api/ama/route.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { recordAmaAsked } from "@/lib/activity";
+import { afterActivity } from "@/lib/activity-schedule";
 import { cachedResponse, errorResponse, parsePaginationParams } from "@/lib/api-utils";
 import { createAmaQuestion, getAmaDatabaseItems } from "@/lib/notion";
 
@@ -34,6 +36,7 @@ export async function POST(request: Request) {
     const validatedData = createQuestionSchema.parse(body);
 
     const page = await createAmaQuestion(validatedData.title, validatedData.description);
+    afterActivity((store) => recordAmaAsked({ id: page.id, title: validatedData.title }, store));
     return cachedResponse({ id: page.id }, 0); // No cache for POST responses
   } catch (error) {
     // Handle validation errors

--- a/src/app/api/hn-digest/send/route.ts
+++ b/src/app/api/hn-digest/send/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { recordDigestSent } from "@/lib/activity";
+import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { toDigestPosts } from "@/lib/digest";
 import { BASE_EMAIL, generateUnsubscribeUrl, sendHNDigestEmailBatch } from "@/lib/email";
@@ -46,6 +48,10 @@ export async function GET(request: Request) {
     }));
 
     const { successCount, failureCount } = await sendHNDigestEmailBatch(emails);
+
+    if (successCount > 0) {
+      afterActivity((store) => recordDigestSent({ date, postCount: digestPosts.length }, store));
+    }
 
     return NextResponse.json({
       status: "done",

--- a/src/app/api/hn-digest/subscribe/route.ts
+++ b/src/app/api/hn-digest/subscribe/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { recordDigestSubscribed } from "@/lib/activity";
+import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse } from "@/lib/api-utils";
 import { createSubscription } from "@/lib/subscriptions";
 
@@ -29,7 +31,9 @@ export async function POST(request: Request) {
       return errorResponse("Failed to subscribe. Please try again.", 500);
     }
 
-    console.log(`✅ New HN digest subscription: ${email}`);
+    afterActivity((store) => recordDigestSubscribed({ email }, store));
+
+    console.log("✅ New HN digest subscription");
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/purge-cache/route.ts
+++ b/src/app/api/purge-cache/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { ingestActivityFromContentPurge } from "@/lib/activity-from-notion";
+import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import {
   PURGE_CACHE_TYPES,
@@ -9,10 +11,21 @@ import {
   purgeContentType,
 } from "@/lib/notion/purge";
 
+async function readNotionPageId(request: Request): Promise<string | undefined> {
+  if (request.method !== "POST") return undefined;
+  try {
+    const body = (await request.json()) as { data?: { id?: unknown } };
+    return typeof body.data?.id === "string" && body.data.id.length > 0 ? body.data.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function purgeCache(request: Request): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
   const secret = searchParams.get("secret");
   const type = searchParams.get("type") || "all";
+  const pageId = await readNotionPageId(request);
 
   if (!safeCompare(secret, process.env.CACHE_PURGE_SECRET)) {
     return errorResponse("Unauthorized", 401);
@@ -28,6 +41,12 @@ async function purgeCache(request: Request): Promise<NextResponse> {
 
   for (const t of types) {
     results[t] = await purgeContentType(t);
+  }
+
+  if (pageId && type !== "all") {
+    afterActivity((store) =>
+      ingestActivityFromContentPurge(type as PurgeableContentType, pageId, store),
+    );
   }
 
   console.log(`[Cache Purge] Purged type=${type}:`, results);

--- a/src/app/api/webhooks/capture-site-preview/route.ts
+++ b/src/app/api/webhooks/capture-site-preview/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 
+import { recordSiteAdded } from "@/lib/activity";
+import { titleFromNotionPage } from "@/lib/activity-from-notion";
+import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSitePreview } from "@/lib/image-processing/optimize";
 import { notion } from "@/lib/notion";
@@ -113,6 +116,10 @@ export async function POST(request: Request) {
       });
 
       await purgeContentType("sites");
+
+      afterActivity((store) =>
+        recordSiteAdded({ id: pageId, title: titleFromNotionPage(currentPage) }, store),
+      );
 
       return NextResponse.json(
         {

--- a/src/app/api/webhooks/generate-short-id/route.ts
+++ b/src/app/api/webhooks/generate-short-id/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
 
+import { recordWritingPublished } from "@/lib/activity";
+import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { updateWritingShortId } from "@/lib/notion/mutations";
 import { purgeContentType } from "@/lib/notion/purge";
 import { getWritingPostByShortId, getWritingPostContent } from "@/lib/notion/queries";
-import { generateShortId, isValidShortId } from "@/lib/short-id";
+import { buildSlug, generateShortId, isValidShortId } from "@/lib/short-id";
 
 /**
  * Webhook endpoint to generate a Short ID for a writing post
@@ -87,6 +89,10 @@ export async function POST(request: Request) {
 
     // Invalidate writing cache so the new short ID is picked up
     await purgeContentType("writing");
+
+    const title = content.metadata.title;
+    const slug = content.metadata.slug || buildSlug(title, shortId);
+    afterActivity((store) => recordWritingPublished({ id: pageId, title, slug }, store));
 
     console.log(`✅ Successfully generated Short ID: ${shortId} for "${content.metadata.title}"\n`);
 

--- a/src/app/api/webhooks/process-stack-icon/route.ts
+++ b/src/app/api/webhooks/process-stack-icon/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 
+import { recordStackAdded } from "@/lib/activity";
+import { titleFromNotionPage } from "@/lib/activity-from-notion";
+import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSiteIcon } from "@/lib/image-processing/optimize";
 import { notion } from "@/lib/notion";
@@ -91,6 +94,10 @@ export async function POST(request: Request) {
 
     // Invalidate stack cache so the updated icon is picked up
     await purgeContentType("stack");
+
+    afterActivity((store) =>
+      recordStackAdded({ id: pageId, title: titleFromNotionPage(page) }, store),
+    );
 
     return NextResponse.json(
       {

--- a/src/app/api/webhooks/update-site-icon/route.ts
+++ b/src/app/api/webhooks/update-site-icon/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 
+import { recordSiteAdded } from "@/lib/activity";
+import { titleFromNotionPage } from "@/lib/activity-from-notion";
+import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { optimizeSiteIcon } from "@/lib/image-processing/optimize";
 import { notion } from "@/lib/notion";
@@ -113,6 +116,11 @@ export async function POST(request: Request) {
     });
 
     await purgeContentType("sites");
+
+    const page = await notion.pages.retrieve({ page_id: pageId });
+    afterActivity((store) =>
+      recordSiteAdded({ id: pageId, title: titleFromNotionPage(page) }, store),
+    );
 
     return NextResponse.json(
       {

--- a/src/lib/activity-from-notion.test.ts
+++ b/src/lib/activity-from-notion.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { titleFromNotionPage } from "./activity-from-notion";
+
+describe("titleFromNotionPage", () => {
+  test("reads a Notion title property", () => {
+    const page = {
+      object: "page",
+      created_time: "2026-08-16T00:00:00.000Z",
+      properties: {
+        Name: {
+          type: "title",
+          title: [{ plain_text: "Hello stack" }],
+        },
+      },
+    };
+
+    expect(titleFromNotionPage(page)).toBe("Hello stack");
+  });
+
+  test("falls back to Untitled for incomplete pages", () => {
+    expect(titleFromNotionPage(null)).toBe("Untitled");
+    expect(titleFromNotionPage({ object: "page" })).toBe("Untitled");
+  });
+});

--- a/src/lib/activity-from-notion.ts
+++ b/src/lib/activity-from-notion.ts
@@ -1,0 +1,64 @@
+import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+
+import {
+  type ActivityStore,
+  recordAmaAnswered,
+  recordSiteAdded,
+  recordStackAdded,
+  recordTilPublished,
+  recordWritingPublished,
+} from "./activity";
+import { notion } from "./notion/client";
+import { richText, select, title } from "./notion/properties";
+import { type PurgeableContentType } from "./notion/purge";
+import { isFullPage, type PageResponse } from "./notion/types";
+import { buildSlug } from "./short-id";
+
+export function titleFromNotionPage(page: unknown, propertyName = "Name"): string {
+  if (!page || typeof page !== "object") return "Untitled";
+  if (!isFullPage(page as PageResponse)) return "Untitled";
+  return title((page as PageObjectResponse).properties, propertyName) ?? "Untitled";
+}
+
+export async function ingestActivityFromContentPurge(
+  type: PurgeableContentType,
+  pageId: string,
+  store: ActivityStore,
+): Promise<void> {
+  const page = await notion.pages.retrieve({ page_id: pageId });
+  if (!isFullPage(page)) return;
+
+  const properties = page.properties;
+
+  switch (type) {
+    case "writing": {
+      const postTitle = title(properties, "Name") ?? "Untitled";
+      const slug = richText(properties, "Slug") ?? "";
+      const shortId = richText(properties, "Short ID");
+      const hrefSlug = slug || (shortId ? buildSlug(postTitle, shortId) : pageId);
+      await recordWritingPublished({ id: pageId, title: postTitle, slug: hrefSlug }, store);
+      return;
+    }
+    case "til": {
+      const tilTitle = title(properties, "Title") ?? "Untitled";
+      const shortId = richText(properties, "Short ID");
+      const href = shortId ? `/til/${buildSlug(tilTitle, shortId)}` : `/til/${pageId}`;
+      await recordTilPublished({ id: pageId, title: tilTitle, href }, store);
+      return;
+    }
+    case "ama": {
+      if (select(properties, "Status") !== "Answered") return;
+      const amaTitle = title(properties, "Name") ?? "Untitled";
+      await recordAmaAnswered({ id: pageId, title: amaTitle }, store);
+      return;
+    }
+    case "stack": {
+      await recordStackAdded({ id: pageId, title: title(properties, "Name") ?? "Untitled" }, store);
+      return;
+    }
+    case "sites": {
+      await recordSiteAdded({ id: pageId, title: title(properties, "Name") ?? "Untitled" }, store);
+      return;
+    }
+  }
+}

--- a/src/lib/activity-redis.ts
+++ b/src/lib/activity-redis.ts
@@ -7,6 +7,7 @@ const STREAM_KEY = "activity:stream";
 const TOTALS_PREFIX = "activity:totals:";
 const IDEMP_PREFIX = "activity:idemp:";
 const VISIT_WINDOW_PREFIX = "activity:visit:window:";
+const COUNTRY_TOTALS_KEY = "activity:country:totals";
 
 export type ActivityRedisSource = "activity" | "likes";
 
@@ -125,10 +126,13 @@ function parseXrevrange(result: unknown): ActivityEvent[] {
 export function createRedisActivityStore(client: Redis): ActivityStore {
   return {
     async claimIdempotency(key: string, ttlSeconds: number): Promise<boolean> {
-      const result = await client.set(`${IDEMP_PREFIX}${key}`, "1", {
-        nx: true,
-        ex: ttlSeconds,
-      });
+      const result =
+        ttlSeconds > 0
+          ? await client.set(`${IDEMP_PREFIX}${key}`, "1", {
+              nx: true,
+              ex: ttlSeconds,
+            })
+          : await client.set(`${IDEMP_PREFIX}${key}`, "1", { nx: true });
       return result === "OK";
     },
 
@@ -200,6 +204,10 @@ export function createRedisActivityStore(client: Redis): ActivityStore {
         await client.expire(key, ttlSeconds);
       }
       return count;
+    },
+
+    async incrementCountryTotal(country: string): Promise<number> {
+      return (await client.hincrby(COUNTRY_TOTALS_KEY, country, 1)) ?? 0;
     },
   };
 }

--- a/src/lib/activity-schedule.ts
+++ b/src/lib/activity-schedule.ts
@@ -1,0 +1,15 @@
+import { after } from "next/server";
+
+import { type ActivityStore } from "./activity";
+import { getActivityStore } from "./activity-redis";
+
+export function afterActivity(record: (store: ActivityStore) => Promise<unknown>): void {
+  const store = getActivityStore();
+  if (!store) return;
+
+  after(() => {
+    void record(store).catch((error) => {
+      console.error("[activity] ingest failed", error);
+    });
+  });
+}

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -58,6 +58,8 @@ export type ActivityIngestInput = {
   meta?: Record<string, unknown>;
   /** When false, increment totals only (used for sampled visits). */
   writeToStream?: boolean;
+  /** Override idempotency TTL. `0` keeps the key forever (publish / first-seen events). */
+  idempotencyTtlSeconds?: number;
 };
 
 const ACTIVITY_PATH = /^\/activity(?:\/|$)/;
@@ -166,6 +168,28 @@ export function formatTotalLabel(type: string): string {
       return "Likes";
     case "visit":
       return "Visits";
+    case "visit_country_first":
+      return "New countries";
+    case "ama_asked":
+      return "AMA questions";
+    case "ama_answered":
+      return "AMA answers";
+    case "digest_subscribed":
+      return "Digest subscribers";
+    case "digest_sent":
+      return "Digests sent";
+    case "writing_published":
+      return "Writing";
+    case "til_published":
+      return "TILs";
+    case "stack_added":
+      return "Stack";
+    case "site_added":
+      return "Sites";
+    case "design_details_added":
+      return "Design Details";
+    case "app_dissection_published":
+      return "App dissections";
     default:
       return type.replace(/_/g, " ");
   }

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -5,8 +5,10 @@ import {
   findForbiddenPii,
   getActivityRow,
   getRequestCountry,
+  hashDigestSubscriber,
   ingestActivityEvent,
   likeMetaFromRequest,
+  recordDigestSubscribed,
   recordLike,
   recordVisit,
   shouldRecordVisit,
@@ -147,11 +149,81 @@ describe("recordVisit", () => {
     }
 
     const totals = await store.getTotals();
-    expect(totals).toEqual([
+    expect(totals).toContainEqual(
       expect.objectContaining({ source: "brios", type: "visit", count: burst }),
-    ]);
-    expect(await store.getStreamLength()).toBe(ACTIVITY_VISIT_STREAM_MAX_PER_SEC);
+    );
+    expect(totals).toContainEqual(
+      expect.objectContaining({ source: "brios", type: "visit_country_first", count: 1 }),
+    );
+    expect(await store.getStreamLength()).toBe(ACTIVITY_VISIT_STREAM_MAX_PER_SEC + 1);
     expect(await store.getStreamLength()).toBeLessThan(ACTIVITY_STREAM_MAXLEN);
+  });
+});
+
+describe("recordDigestSubscribed", () => {
+  test("does not leak the email in the event payload or meta", async () => {
+    const store = createMemoryActivityStore();
+    const email = "person@example.com";
+
+    const result = await recordDigestSubscribed({ email }, store);
+    expect(result.ok && !result.duplicate).toBe(true);
+
+    const [event] = await store.getTail(1);
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain(email);
+    expect(serialized).not.toContain("person");
+    expect(serialized.toLowerCase()).not.toContain("example.com");
+    expect(event?.type).toBe("digest_subscribed");
+    expect(event?.source).toBe("brios");
+    expect(event?.visibility).toBe("public");
+    expect(event?.meta).toBeUndefined();
+    expect(event?.idempotency_key).toBe(`brios:digest_subscribed:${hashDigestSubscriber(email)}`);
+  });
+
+  test("is idempotent per email hash, not the raw address", async () => {
+    const store = createMemoryActivityStore();
+    const first = await recordDigestSubscribed({ email: "Alex@Example.com" }, store);
+    const second = await recordDigestSubscribed({ email: "alex@example.com" }, store);
+    const other = await recordDigestSubscribed({ email: "other@example.org" }, store);
+
+    expect(first.ok && !first.duplicate).toBe(true);
+    expect(second.ok && second.duplicate).toBe(true);
+    expect(other.ok && !other.duplicate).toBe(true);
+    expect(await store.getStreamLength()).toBe(2);
+    expect(await store.getTotals()).toEqual([
+      expect.objectContaining({ source: "brios", type: "digest_subscribed", count: 2 }),
+    ]);
+  });
+});
+
+describe("visit_country_first", () => {
+  test("fires once per country when a visit increments 0→1", async () => {
+    const store = createMemoryActivityStore();
+
+    await recordVisit({ path: "/writing", country: "FR" }, store);
+    await recordVisit({ path: "/writing", country: "FR" }, store);
+    await recordVisit({ path: "/til", country: "JP" }, store);
+
+    const events = await store.getTail(20);
+    const firsts = events.filter((event) => event.type === "visit_country_first");
+    expect(firsts).toHaveLength(2);
+    expect(firsts.map((event) => event.meta?.country).sort()).toEqual(["FR", "JP"]);
+    expect(firsts.every((event) => event.source === "brios")).toBe(true);
+    expect(firsts.every((event) => event.visibility === "public")).toBe(true);
+    expect(JSON.stringify(firsts)).not.toMatch(/\d{1,3}(?:\.\d{1,3}){3}/);
+
+    expect(await store.incrementCountryTotal("FR")).toBe(3);
+    expect(await store.incrementCountryTotal("JP")).toBe(2);
+    expect(await store.getTotals()).toContainEqual(
+      expect.objectContaining({ source: "brios", type: "visit_country_first", count: 2 }),
+    );
+  });
+
+  test("does not record a first-country event for /activity", async () => {
+    const store = createMemoryActivityStore();
+    await recordVisit({ path: "/activity", country: "BR" }, store);
+    expect(await store.getTotals()).toEqual([]);
+    expect(await store.incrementCountryTotal("BR")).toBe(1);
   });
 });
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,3 +1,5 @@
+import { createHash } from "crypto";
+
 import {
   ACTIVITY_ENVELOPE_VERSION,
   ACTIVITY_IDEMPOTENCY_TTL_SECONDS,
@@ -7,11 +9,14 @@ import {
   ACTIVITY_VISIT_STREAM_MAX_PER_SEC,
   type ActivityEvent,
   type ActivityIngestInput,
+  type ActivityRef,
+  type ActivitySpeed,
   type ActivityTotal,
   findForbiddenPii,
   inferContentTypeFromPath,
   inferTitleFromPath,
   isActivityPath,
+  normalizeCountryCode,
   shouldRecordVisit,
 } from "./activity-shared";
 
@@ -50,6 +55,7 @@ export type ActivityStore = {
   getTotals(): Promise<ActivityTotal[]>;
   getStreamLength(): Promise<number>;
   incrementVisitWindow(windowKey: string, ttlSeconds: number): Promise<number>;
+  incrementCountryTotal(country: string): Promise<number>;
 };
 
 export function createMemoryActivityStore(options: { maxLen?: number } = {}): ActivityStore {
@@ -58,6 +64,7 @@ export function createMemoryActivityStore(options: { maxLen?: number } = {}): Ac
   const totals = new Map<string, ActivityTotal>();
   const claimed = new Set<string>();
   const visitWindows = new Map<string, number>();
+  const countryTotals = new Map<string, number>();
 
   return {
     async claimIdempotency(key: string): Promise<boolean> {
@@ -92,6 +99,11 @@ export function createMemoryActivityStore(options: { maxLen?: number } = {}): Ac
     async incrementVisitWindow(windowKey: string): Promise<number> {
       const next = (visitWindows.get(windowKey) ?? 0) + 1;
       visitWindows.set(windowKey, next);
+      return next;
+    },
+    async incrementCountryTotal(country: string): Promise<number> {
+      const next = (countryTotals.get(country) ?? 0) + 1;
+      countryTotals.set(country, next);
       return next;
     },
   };
@@ -173,7 +185,7 @@ export async function ingestActivityEvent(
 
   const claimed = await store.claimIdempotency(
     event.idempotency_key,
-    ACTIVITY_IDEMPOTENCY_TTL_SECONDS,
+    input.idempotencyTtlSeconds ?? ACTIVITY_IDEMPOTENCY_TTL_SECONDS,
   );
 
   if (!claimed) {
@@ -233,7 +245,7 @@ export async function recordVisit(
   const windowCount = await store.incrementVisitWindow(windowKey, 2);
   const writeToStream = windowCount <= ACTIVITY_VISIT_STREAM_MAX_PER_SEC;
 
-  return ingestActivityEvent(
+  const visitResult = await ingestActivityEvent(
     {
       source: ACTIVITY_SOURCE_BRIOS,
       type: "visit",
@@ -243,6 +255,238 @@ export async function recordVisit(
       idempotency_key: `brios:visit:${crypto.randomUUID()}`,
       meta: country ? { country } : undefined,
       writeToStream,
+    },
+    store,
+    now,
+  );
+
+  if (country) {
+    await recordVisitCountryFirst(country, store, now);
+  }
+
+  return visitResult;
+}
+
+async function recordVisitCountryFirst(
+  country: string,
+  store: ActivityStore,
+  now: Date,
+): Promise<void> {
+  const code = normalizeCountryCode(country);
+  if (!code) return;
+
+  const countryCount = await store.incrementCountryTotal(code);
+  if (countryCount !== 1) return;
+
+  await ingestActivityEvent(
+    {
+      source: ACTIVITY_SOURCE_BRIOS,
+      type: "visit_country_first",
+      speed: "event",
+      summary: `First visit from ${code}`,
+      visibility: "public",
+      idempotency_key: `brios:visit_country_first:${code}`,
+      meta: { country: code },
+      idempotencyTtlSeconds: 0,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordBriosEvent(
+  input: {
+    type: string;
+    summary: string;
+    idempotency_key: string;
+    subject?: ActivityRef;
+    meta?: Record<string, unknown>;
+    speed?: ActivitySpeed;
+    permanent?: boolean;
+  },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  return ingestActivityEvent(
+    {
+      source: ACTIVITY_SOURCE_BRIOS,
+      type: input.type,
+      speed: input.speed ?? "event",
+      summary: input.summary,
+      visibility: "public",
+      idempotency_key: input.idempotency_key,
+      ...(input.subject ? { subject: input.subject } : {}),
+      ...(input.meta ? { meta: input.meta } : {}),
+      ...(input.permanent ? { idempotencyTtlSeconds: 0 } : {}),
+    },
+    store,
+    now,
+  );
+}
+
+export function hashDigestSubscriber(email: string): string {
+  return createHash("sha256")
+    .update(`brios:digest_subscribed:${email.trim().toLowerCase()}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export async function recordAmaAsked(
+  input: { id: string; title: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const title = input.title.trim() || "a question";
+  const href = `/ama/${input.id}`;
+  return recordBriosEvent(
+    {
+      type: "ama_asked",
+      summary: "Someone asked a question",
+      idempotency_key: `brios:ama_asked:${input.id}`,
+      subject: { kind: "ama", label: title, href },
+      meta: { title, href },
+      permanent: true,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordAmaAnswered(
+  input: { id: string; title: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const title = input.title.trim() || "a question";
+  const href = `/ama/${input.id}`;
+  return recordBriosEvent(
+    {
+      type: "ama_answered",
+      summary: "A question was answered",
+      idempotency_key: `brios:ama_answered:${input.id}`,
+      subject: { kind: "ama", label: title, href },
+      meta: { title, href },
+      permanent: true,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordDigestSubscribed(
+  input: { email: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const subscriberHash = hashDigestSubscriber(input.email);
+  return recordBriosEvent(
+    {
+      type: "digest_subscribed",
+      summary: "Someone subscribed to the HN digest",
+      idempotency_key: `brios:digest_subscribed:${subscriberHash}`,
+      permanent: true,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordDigestSent(
+  input: { date: string; postCount?: number },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  return recordBriosEvent(
+    {
+      type: "digest_sent",
+      summary: "The HN digest was sent",
+      idempotency_key: `brios:digest_sent:${input.date}`,
+      meta: input.postCount === undefined ? undefined : { post_count: input.postCount },
+      permanent: true,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordWritingPublished(
+  input: { id: string; title: string; slug: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const title = input.title.trim() || "a post";
+  const href = `/writing/${input.slug}`;
+  return recordBriosEvent(
+    {
+      type: "writing_published",
+      summary: "A writing post was published",
+      idempotency_key: `brios:writing_published:${input.id}`,
+      subject: { kind: "writing", label: title, href },
+      meta: { title, href },
+      permanent: true,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordTilPublished(
+  input: { id: string; title: string; href: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const title = input.title.trim() || "a TIL";
+  const href = input.href;
+  return recordBriosEvent(
+    {
+      type: "til_published",
+      summary: "A TIL was published",
+      idempotency_key: `brios:til_published:${input.id}`,
+      subject: { kind: "til", label: title, href },
+      meta: { title, href },
+      permanent: true,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordStackAdded(
+  input: { id: string; title: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const title = input.title.trim() || "a stack item";
+  const href = "/stack";
+  return recordBriosEvent(
+    {
+      type: "stack_added",
+      summary: "A stack item was added",
+      idempotency_key: `brios:stack_added:${input.id}`,
+      subject: { kind: "stack", label: title, href },
+      meta: { title, href },
+      permanent: true,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordSiteAdded(
+  input: { id: string; title: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const title = input.title.trim() || "a site";
+  const href = "/sites";
+  return recordBriosEvent(
+    {
+      type: "site_added",
+      summary: "A good website was added",
+      idempotency_key: `brios:site_added:${input.id}`,
+      subject: { kind: "site", label: title, href },
+      meta: { title, href },
+      permanent: true,
     },
     store,
     now,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cut 2 of the activity feed: in-process `ingestActivityEvent` calls after existing briOS writes so `/activity` fills up. HMAC ingest is unchanged. No GitHub, Shiori, Spotify, Vercel, podcast, walk, or coffee events.

All events set `source: "brios"`, `visibility: "public"`, a stable `idempotency_key`, and `subject` when there is a page. `/activity` itself is never recorded. Emails, IPs, and cookies are rejected by ingest and are not written by these producers.

## Producers

| Type | Hooked | File |
| --- | --- | --- |
| `ama_asked` | After a successful AMA question create | `src/app/api/ama/route.ts` |
| `ama_answered` | Notion purge webhook (`POST /api/purge-cache?type=ama`) when `data.id` is Answered | `src/app/api/purge-cache/route.ts` |
| `digest_subscribed` | After a new HN digest signup. Idempotency is an email hash; raw email is not in payload or meta | `src/app/api/hn-digest/subscribe/route.ts` |
| `digest_sent` | After a nightly send with `successCount > 0`. Meta: `post_count`. No subscriber list | `src/app/api/hn-digest/send/route.ts` |
| `writing_published` | After a new writing Short ID is generated; also purge `type=writing` + `data.id` | `src/app/api/webhooks/generate-short-id/route.ts`, `src/app/api/purge-cache/route.ts` |
| `til_published` | Notion purge webhook (`POST /api/purge-cache?type=til`) with `data.id` | `src/app/api/purge-cache/route.ts` |
| `stack_added` | Existing stack-icon webhook (closest add signal; no create-stack route). Same idempotency key on purge `type=stack` | `src/app/api/webhooks/process-stack-icon/route.ts` |
| `site_added` | Site preview / favicon webhooks (new-site automations). Same idempotency key on purge `type=sites` | `src/app/api/webhooks/capture-site-preview/route.ts`, `src/app/api/webhooks/update-site-icon/route.ts` |
| `visit_country_first` | Derived: when a `visit` increments a country total from 0→1. One Redis hash field per country code. Never stores IP | `src/lib/activity.ts` (`recordVisit`) |

## Skipped

- `design_details_added` — no create webhook and not a purge-cache type
- `app_dissection_published` — no create webhook and not a purge-cache type
- No admin UI added for either

`createStackItem` exists in `src/lib/notion/mutations.ts` but has no API route. Stack events use the existing icon webhook instead of inventing a create endpoint.

## Redis

Country first-seen totals live in one hash, `activity:country:totals`, one field per ISO country code. Publish / subscribe / first-country idempotency keys do not expire so retries do not double-count after the short like/visit TTL.

Uses the existing activity Redis helper (`UPSTASH_ACTIVITY_*` preferred).

## Tests

- `digest_subscribed` does not leak the email and is idempotent per hash
- `visit_country_first` fires once per country and not for `/activity`
- `bun test`, lint, and `tsc --noEmit` clean

## Live smoke

Called `recordDigestSubscribed` and `recordAmaAsked` in-process against the activity Redis (not the subscribe route, so no real email was added to the HN list and no digest was sent). Both events showed up on the live tail and on https://brianlovin.com/activity. The subscribe payload did not contain the email.

[Live /activity feed after smoke ingest](https://cursor.com/agents/bc-a5ce1db6-eb59-47f1-8ac3-66dd144011d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_live_feed_smoke.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5ce1db6-eb59-47f1-8ac3-66dd144011d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5ce1db6-eb59-47f1-8ac3-66dd144011d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

