### PR TITLE
Cheap CDN-cached /activity polling

### DIFF
--- a/src/app/api/activity/feed/route.ts
+++ b/src/app/api/activity/feed/route.ts
@@ -1,0 +1,10 @@
+import { activityCachedJson } from "@/lib/activity-feed";
+import { getActivityPageData } from "@/lib/activity-redis";
+
+/**
+ * Single public poll blob for /activity.
+ * Cookie-free and unauthenticated so Vercel can CDN-cache the JSON.
+ */
+export async function GET() {
+  return activityCachedJson(await getActivityPageData());
+}

--- a/src/app/api/activity/tail/route.ts
+++ b/src/app/api/activity/tail/route.ts
@@ -1,22 +1,8 @@
-import { NextResponse } from "next/server";
+import { activityCachedJson } from "@/lib/activity-feed";
+import { getActivityPageData } from "@/lib/activity-redis";
 
-import { getActivityStore } from "@/lib/activity-redis";
-import { errorResponse } from "@/lib/api-utils";
-
+/** Kept for mid-deploy clients. Prefer GET /api/activity/feed. */
 export async function GET() {
-  const store = getActivityStore();
-  if (!store) {
-    return NextResponse.json(
-      { events: [] },
-      { headers: { "Cache-Control": "public, s-maxage=1" } },
-    );
-  }
-
-  try {
-    const events = await store.getTail(100);
-    return NextResponse.json({ events }, { headers: { "Cache-Control": "public, s-maxage=1" } });
-  } catch (error) {
-    console.error("[activity] tail failed", error);
-    return errorResponse("Failed to load activity");
-  }
+  const { events } = await getActivityPageData();
+  return activityCachedJson({ events });
 }

--- a/src/app/api/activity/totals/route.ts
+++ b/src/app/api/activity/totals/route.ts
@@ -1,22 +1,8 @@
-import { NextResponse } from "next/server";
+import { activityCachedJson } from "@/lib/activity-feed";
+import { getActivityPageData } from "@/lib/activity-redis";
 
-import { getActivityStore } from "@/lib/activity-redis";
-import { errorResponse } from "@/lib/api-utils";
-
+/** Kept for mid-deploy clients. Prefer GET /api/activity/feed. */
 export async function GET() {
-  const store = getActivityStore();
-  if (!store) {
-    return NextResponse.json(
-      { totals: [] },
-      { headers: { "Cache-Control": "public, s-maxage=1" } },
-    );
-  }
-
-  try {
-    const totals = await store.getTotals();
-    return NextResponse.json({ totals }, { headers: { "Cache-Control": "public, s-maxage=1" } });
-  } catch (error) {
-    console.error("[activity] totals failed", error);
-    return errorResponse("Failed to load activity totals");
-  }
+  const { totals } = await getActivityPageData();
+  return activityCachedJson({ totals });
 }

--- a/src/lib/activity-feed.test.ts
+++ b/src/lib/activity-feed.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { GET as getFeed } from "@/app/api/activity/feed/route";
+import { GET as getTail } from "@/app/api/activity/tail/route";
+import { GET as getTotals } from "@/app/api/activity/totals/route";
+import {
+  buildActivityFeed,
+  createMemoryActivityStore,
+  ingestActivityEvent,
+  isActivityFeedPayload,
+} from "@/lib/activity";
+import { ACTIVITY_FEED_CACHE_HEADERS, activityCachedJson } from "@/lib/activity-feed";
+import {
+  ACTIVITY_FEED_CACHE_CONTROL,
+  ACTIVITY_FEED_DEDUPING_MS,
+  ACTIVITY_FEED_POLL_MS,
+  activityFeedRefreshInterval,
+} from "@/lib/activity-shared";
+
+describe("activity feed cache headers", () => {
+  test("uses a 2s shared max-age and 30s stale-while-revalidate", () => {
+    expect(ACTIVITY_FEED_CACHE_CONTROL).toBe("public, s-maxage=2, stale-while-revalidate=30");
+    expect(ACTIVITY_FEED_CACHE_HEADERS["Cache-Control"]).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+    expect(ACTIVITY_FEED_CACHE_HEADERS["CDN-Cache-Control"]).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+  });
+
+  test("JSON responses set both cache headers and no Vary or Set-Cookie", async () => {
+    const res = activityCachedJson({ events: [], totals: [] });
+    expect(res.headers.get("Cache-Control")).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+    expect(res.headers.get("CDN-Cache-Control")).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+    expect(res.headers.get("Vary")).toBeNull();
+    expect(res.headers.get("Set-Cookie")).toBeNull();
+    expect(await res.json()).toEqual({ events: [], totals: [] });
+  });
+});
+
+describe("activity feed payload", () => {
+  test("is { events, totals } and empty when the store is missing", async () => {
+    const empty = await buildActivityFeed(null);
+    expect(empty).toEqual({ events: [], totals: [] });
+    expect(isActivityFeedPayload(empty)).toBe(true);
+    expect(isActivityFeedPayload({ events: [] })).toBe(false);
+    expect(isActivityFeedPayload({ totals: [] })).toBe(false);
+  });
+
+  test("reads tail and lifetime totals from the store", async () => {
+    const store = createMemoryActivityStore();
+    await ingestActivityEvent(
+      {
+        source: "brios",
+        type: "like",
+        speed: "event",
+        summary: "Someone liked a page",
+        visibility: "public",
+        idempotency_key: "feed:like:1",
+      },
+      store,
+    );
+
+    const payload = await buildActivityFeed(store);
+    expect(isActivityFeedPayload(payload)).toBe(true);
+    expect(payload.events).toHaveLength(1);
+    expect(payload.events[0]).toEqual(
+      expect.objectContaining({ type: "like", summary: "Someone liked a page" }),
+    );
+    expect(payload.totals).toEqual([
+      expect.objectContaining({ source: "brios", type: "like", count: 1 }),
+    ]);
+  });
+});
+
+describe("activityFeedRefreshInterval", () => {
+  test("polls every 2s when visible and pauses when hidden", () => {
+    expect(ACTIVITY_FEED_POLL_MS).toBe(2000);
+    expect(ACTIVITY_FEED_DEDUPING_MS).toBeGreaterThanOrEqual(1000);
+    expect(activityFeedRefreshInterval("visible")).toBe(ACTIVITY_FEED_POLL_MS);
+    expect(activityFeedRefreshInterval("hidden")).toBe(0);
+    expect(activityFeedRefreshInterval("prerender")).toBe(0);
+    expect(activityFeedRefreshInterval(undefined)).toBe(0);
+  });
+});
+
+describe("activity poll routes", () => {
+  test("GET /api/activity/feed returns the combined payload and cache headers", async () => {
+    const res = await getFeed();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+    expect(res.headers.get("CDN-Cache-Control")).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+    expect(res.headers.get("Vary")).toBeNull();
+    const body = await res.json();
+    expect(isActivityFeedPayload(body)).toBe(true);
+  });
+
+  test("legacy tail and totals routes keep their payloads and stay cacheable", async () => {
+    const tail = await getTail();
+    const totals = await getTotals();
+    expect(tail.headers.get("Cache-Control")).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+    expect(totals.headers.get("CDN-Cache-Control")).toBe(ACTIVITY_FEED_CACHE_CONTROL);
+    expect(await tail.json()).toEqual({ events: expect.any(Array) });
+    expect(await totals.json()).toEqual({ totals: expect.any(Array) });
+  });
+});

--- a/src/lib/activity-feed.ts
+++ b/src/lib/activity-feed.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+import { ACTIVITY_FEED_CACHE_CONTROL } from "./activity-shared";
+
+/**
+ * Public, cookie-free cache headers for the activity poll blob.
+ * Do not read cookies/auth in handlers that use this — the response must
+ * stay CDN-cacheable with no per-user Vary.
+ */
+export const ACTIVITY_FEED_CACHE_HEADERS = {
+  "Cache-Control": ACTIVITY_FEED_CACHE_CONTROL,
+  "CDN-Cache-Control": ACTIVITY_FEED_CACHE_CONTROL,
+};
+
+export function activityCachedJson<T>(data: T): NextResponse<T> {
+  return NextResponse.json(data, { headers: ACTIVITY_FEED_CACHE_HEADERS });
+}

--- a/src/lib/activity-redis.ts
+++ b/src/lib/activity-redis.ts
@@ -1,6 +1,12 @@
 import { Redis } from "@upstash/redis";
 
-import { type ActivityEvent, type ActivityStore, type ActivityTotal } from "./activity";
+import {
+  type ActivityEvent,
+  type ActivityFeedPayload,
+  type ActivityStore,
+  type ActivityTotal,
+  buildActivityFeed,
+} from "./activity";
 import { ACTIVITY_STREAM_MAXLEN } from "./activity-shared";
 
 const STREAM_KEY = "activity:stream";
@@ -220,16 +226,9 @@ export function getActivityStore(): ActivityStore | null {
   return redisStore;
 }
 
-export async function getActivityPageData(): Promise<{
-  events: ActivityEvent[];
-  totals: ActivityTotal[];
-}> {
-  const store = getActivityStore();
-  if (!store) return { events: [], totals: [] };
-
+export async function getActivityPageData(): Promise<ActivityFeedPayload> {
   try {
-    const [events, totals] = await Promise.all([store.getTail(100), store.getTotals()]);
-    return { events, totals };
+    return await buildActivityFeed(getActivityStore());
   } catch (error) {
     console.error("[activity] failed to read feed", error);
     return { events: [], totals: [] };

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -11,6 +11,11 @@ export const ACTIVITY_META_MAX_BYTES = 2048;
 export const ACTIVITY_BODY_MAX_BYTES = 8192;
 export const ACTIVITY_SOURCE_BRIOS = "brios";
 
+/** CDN + browser cache for the public activity poll blob. */
+export const ACTIVITY_FEED_CACHE_CONTROL = "public, s-maxage=2, stale-while-revalidate=30";
+export const ACTIVITY_FEED_POLL_MS = 2000;
+export const ACTIVITY_FEED_DEDUPING_MS = 1000;
+
 export type ActivitySpeed = "event" | "signal";
 export type ActivityVisibility = "public" | "private";
 
@@ -42,6 +47,22 @@ export type ActivityTotal = {
   count: number;
   first_seen: string;
 };
+
+export type ActivityFeedPayload = {
+  events: ActivityEvent[];
+  totals: ActivityTotal[];
+};
+
+/** SWR refreshInterval: poll while the tab is visible, pause when hidden. */
+export function activityFeedRefreshInterval(visibilityState: string | null | undefined): number {
+  return visibilityState === "visible" ? ACTIVITY_FEED_POLL_MS : 0;
+}
+
+export function isActivityFeedPayload(value: unknown): value is ActivityFeedPayload {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return Array.isArray(record.events) && Array.isArray(record.totals);
+}
 
 export type ActivityIngestInput = {
   v?: number;

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -8,6 +8,7 @@ import {
   ACTIVITY_STREAM_MAXLEN,
   ACTIVITY_VISIT_STREAM_MAX_PER_SEC,
   type ActivityEvent,
+  type ActivityFeedPayload,
   type ActivityIngestInput,
   type ActivityRef,
   type ActivitySpeed,
@@ -22,6 +23,7 @@ import {
 
 export type {
   ActivityEvent,
+  ActivityFeedPayload,
   ActivityIngestInput,
   ActivityRef,
   ActivitySpeed,
@@ -30,15 +32,20 @@ export type {
 } from "./activity-shared";
 export {
   ACTIVITY_ENVELOPE_VERSION,
+  ACTIVITY_FEED_CACHE_CONTROL,
+  ACTIVITY_FEED_DEDUPING_MS,
+  ACTIVITY_FEED_POLL_MS,
   ACTIVITY_SOURCE_BRIOS,
   ACTIVITY_STREAM_MAXLEN,
   ACTIVITY_VISIT_STREAM_MAX_PER_SEC,
+  activityFeedRefreshInterval,
   findForbiddenPii,
   formatTotalLabel,
   getActivityRow,
   getRequestCountry,
   inferContentTypeFromPath,
   inferTitleFromPath,
+  isActivityFeedPayload,
   isActivityPath,
   shouldRecordVisit,
 } from "./activity-shared";
@@ -57,6 +64,12 @@ export type ActivityStore = {
   incrementVisitWindow(windowKey: string, ttlSeconds: number): Promise<number>;
   incrementCountryTotal(country: string): Promise<number>;
 };
+
+export async function buildActivityFeed(store: ActivityStore | null): Promise<ActivityFeedPayload> {
+  if (!store) return { events: [], totals: [] };
+  const [events, totals] = await Promise.all([store.getTail(100), store.getTotals()]);
+  return { events, totals };
+}
 
 export function createMemoryActivityStore(options: { maxLen?: number } = {}): ActivityStore {
   const maxLen = options.maxLen ?? ACTIVITY_STREAM_MAXLEN;

--- a/src/lib/hooks/useActivity.ts
+++ b/src/lib/hooks/useActivity.ts
@@ -1,30 +1,41 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import useSWR from "swr";
 
-import type { ActivityEvent, ActivityTotal } from "@/lib/activity";
+import type { ActivityEvent, ActivityFeedPayload, ActivityTotal } from "@/lib/activity";
+import { ACTIVITY_FEED_DEDUPING_MS, activityFeedRefreshInterval } from "@/lib/activity-shared";
 import { fetcher } from "@/lib/fetcher";
 
-type TailResponse = { events: ActivityEvent[] };
-type TotalsResponse = { totals: ActivityTotal[] };
+function subscribeVisibility(onChange: () => void): () => void {
+  document.addEventListener("visibilitychange", onChange);
+  return () => document.removeEventListener("visibilitychange", onChange);
+}
+
+function getVisibilitySnapshot(): DocumentVisibilityState {
+  return document.visibilityState;
+}
+
+function getServerVisibilitySnapshot(): DocumentVisibilityState {
+  return "visible";
+}
 
 export function useActivity(initialEvents: ActivityEvent[], initialTotals: ActivityTotal[]) {
-  const tail = useSWR<TailResponse>("/api/activity/tail", fetcher, {
-    fallbackData: { events: initialEvents },
-    refreshInterval: 1000,
-    revalidateOnFocus: false,
-    dedupingInterval: 500,
-  });
+  const visibilityState = useSyncExternalStore(
+    subscribeVisibility,
+    getVisibilitySnapshot,
+    getServerVisibilitySnapshot,
+  );
 
-  const totals = useSWR<TotalsResponse>("/api/activity/totals", fetcher, {
-    fallbackData: { totals: initialTotals },
-    refreshInterval: 1000,
+  const { data } = useSWR<ActivityFeedPayload>("/api/activity/feed", fetcher, {
+    fallbackData: { events: initialEvents, totals: initialTotals },
+    refreshInterval: activityFeedRefreshInterval(visibilityState),
     revalidateOnFocus: false,
-    dedupingInterval: 500,
+    dedupingInterval: ACTIVITY_FEED_DEDUPING_MS,
   });
 
   return {
-    events: tail.data?.events ?? initialEvents,
-    totals: totals.data?.totals ?? initialTotals,
+    events: data?.events ?? initialEvents,
+    totals: data?.totals ?? initialTotals,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/activity` from #2277 polls `GET /api/activity/tail` and `GET /api/activity/totals` every 1s. One idle tab is ~7200 requests/hour. This PR keeps the feed feeling live while making announce-scale cheap on Vercel.

Branched from current `main` (includes #2277 and #2280). Not stacked on #2279.

## What changed

- One client poll URL: `GET /api/activity/feed` returns `{ events, totals }`
- Cache-Control / CDN-Cache-Control: `public, s-maxage=2, stale-while-revalidate=30`
- Cookie-free handler (no auth, no `Vary` on user headers) so the blob is CDN-cacheable
- `useActivity` uses a single SWR key, `refreshInterval: 2000`, `dedupingInterval: 1000`, `revalidateOnFocus: false`
- Poll pauses when `document.visibilityState !== "visible"` and resumes on focus
- Legacy `/api/activity/tail` and `/api/activity/totals` stay as thin wrappers (same payloads, same cache headers) so nothing 404s mid-deploy

No SSE, websockets, UI redesign, producer changes, or Redis key changes.

## Math

**One visible tab**

| | Client → CDN | Origin Redis reads |
|---|---|---|
| Before | 2 URLs × 1/s = **7200 req/h** | ~2/s if CDN works (two 1s keys), or 2/s with no sharing |
| After | 1 URL × 0.5/s = **1800 req/h** | **~0.5/s** (`s-maxage=2`) |

**N visible tabs**

- Before: clients send `2N` req/s. Origin is ~2/s with a working 1s CDN cache, or `2N`/s if the cache is bypassed.
- After: clients send `0.5N` req/s to the CDN. Origin stays **~1 Redis read pair every 2s** no matter how large N is. After `s-maxage`, `stale-while-revalidate=30` keeps serving the last blob while one background refresh runs.

**Hidden tabs:** refresh interval is `0`, so a background `/activity` tab costs nothing until it is focused again.

Announce-scale (thousands of viewers) hits the Vercel CDN, not Upstash, at a handful of origin reads per second.

## Tests

- Cache header string (`Cache-Control` + `CDN-Cache-Control`)
- Payload shape `{ events, totals }`
- Hook interval is `0` when hidden (`activityFeedRefreshInterval`)
- Legacy tail/totals wrappers still return their original shapes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22a36b14-cc0e-4e05-bce7-24c4306a349a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22a36b14-cc0e-4e05-bce7-24c4306a349a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

