### PR TITLE
Redirect legacy brianlovin.ai to brianlovin.com

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,20 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ["@sparticuz/chromium"],
   async redirects() {
     return [
+      // Legacy brianlovin.ai (formerly the brios-api project) now redirects
+      // to the main site. Both apex and www hosts, preserving the path.
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "brianlovin.ai" }],
+        destination: "https://brianlovin.com/:path*",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.brianlovin.ai" }],
+        destination: "https://brianlovin.com/:path*",
+        permanent: true,
+      },
       {
         source: "/writing/:path(rss|RSS|Rss|feed|Feed)",
         destination: "/writing/rss.xml",


### PR DESCRIPTION
## Why

`brios-api` (which serves `brianlovin.ai`) is being archived now that its Spotify sync has been migrated into this repo (#2278). Point the legacy `.ai` domain at the main site so any existing links/bookmarks keep resolving.

## What

Host-based `next.config` redirects for both `brianlovin.ai` and `www.brianlovin.ai` → `https://brianlovin.com/:path*` (permanent, path-preserving). These are dormant until the `.ai` domains are moved onto this Vercel project (next step of the archival).

## Test plan

- [x] Build passes (Vercel preview)
- [ ] After merge + domain move: `curl -sI https://brianlovin.ai` returns 301 → `https://brianlovin.com/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)