### PR TITLE
Remove first-visit-from-country activity events

### DIFF
--- a/src/lib/activity-redis.ts
+++ b/src/lib/activity-redis.ts
@@ -13,7 +13,6 @@ const STREAM_KEY = "activity:stream";
 const TOTALS_PREFIX = "activity:totals:";
 const IDEMP_PREFIX = "activity:idemp:";
 const VISIT_WINDOW_PREFIX = "activity:visit:window:";
-const COUNTRY_TOTALS_KEY = "activity:country:totals";
 
 export type ActivityRedisSource = "activity" | "likes";
 
@@ -210,10 +209,6 @@ export function createRedisActivityStore(client: Redis): ActivityStore {
         await client.expire(key, ttlSeconds);
       }
       return count;
-    },
-
-    async incrementCountryTotal(country: string): Promise<number> {
-      return (await client.hincrby(COUNTRY_TOTALS_KEY, country, 1)) ?? 0;
     },
   };
 }

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -236,8 +236,6 @@ export function formatTotalLabel(type: string): string {
       return "Likes";
     case "visit":
       return "Visits";
-    case "visit_country_first":
-      return "New countries";
     case "ama_asked":
       return "AMA questions";
     case "ama_answered":

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -253,7 +253,8 @@ describe("recordVisit", () => {
     );
     expect("ok" in result && result.ok).toBe(true);
 
-    const event = (await store.getTail(10)).find((item) => item.type === "visit");
+    const [event] = await store.getTail(1);
+    expect(event?.type).toBe("visit");
     expect(event?.summary).toBe("🇮🇳 Visit from India");
     expect(event?.subject).toEqual({
       kind: "writing",
@@ -288,7 +289,8 @@ describe("recordVisit", () => {
       },
       store,
     );
-    const event = (await store.getTail(10)).find((item) => item.type === "visit");
+    const [event] = await store.getTail(1);
+    expect(event?.type).toBe("visit");
     expect(event?.summary).toBe("🇺🇸 Visit from San Francisco, California, United States");
     expect(event?.meta).toEqual({
       country: "US",
@@ -330,6 +332,41 @@ describe("recordVisit", () => {
     });
   });
 
+  test("still flags leftover first-country stream rows", () => {
+    const row = getActivityRow({
+      v: 1,
+      id: "old-first",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "brios",
+      type: "visit_country_first",
+      speed: "event",
+      summary: "First visit from IN",
+      visibility: "public",
+      idempotency_key: "old-first",
+      meta: { country: "IN" },
+    });
+    expect(row).toEqual({
+      summary: "First visit from IN",
+      flag: "🇮🇳",
+    });
+  });
+
+  test("does not emit a first-country event", async () => {
+    const store = createMemoryActivityStore();
+    await recordVisit({ path: "/writing", country: "FR" }, store);
+    await recordVisit({ path: "/writing", country: "FR" }, store);
+    await recordVisit({ path: "/til", country: "JP" }, store);
+
+    const events = await store.getTail(20);
+    expect(events).toHaveLength(3);
+    expect(events.every((event) => event.type === "visit")).toBe(true);
+    expect(events.some((event) => event.type === "visit_country_first")).toBe(false);
+    expect(await store.getTotals()).toEqual([
+      expect.objectContaining({ source: "brios", type: "visit", count: 3 }),
+    ]);
+  });
+
   test("does not ingest a visit for /activity/nested", async () => {
     const store = createMemoryActivityStore();
     await recordVisit({ path: "/activity/nested" }, store);
@@ -351,7 +388,7 @@ describe("recordVisit", () => {
       expect.objectContaining({ source: "brios", type: "visit", count: burst }),
     );
     expect(totals.find((total) => total.type === "visit_country_first")).toBeUndefined();
-    expect(await store.getStreamLength()).toBe(ACTIVITY_VISIT_STREAM_MAX_PER_SEC + 1);
+    expect(await store.getStreamLength()).toBe(ACTIVITY_VISIT_STREAM_MAX_PER_SEC);
     expect(await store.getStreamLength()).toBeLessThan(ACTIVITY_STREAM_MAXLEN);
   });
 });
@@ -389,37 +426,6 @@ describe("recordDigestSubscribed", () => {
     expect(await store.getTotals()).toEqual([
       expect.objectContaining({ source: "brios", type: "digest_subscribed", count: 2 }),
     ]);
-  });
-});
-
-describe("visit_country_first", () => {
-  test("fires once per country when a visit increments 0→1", async () => {
-    const store = createMemoryActivityStore();
-
-    await recordVisit({ path: "/writing", country: "FR" }, store);
-    await recordVisit({ path: "/writing", country: "FR" }, store);
-    await recordVisit({ path: "/til", country: "JP" }, store);
-
-    const events = await store.getTail(20);
-    const firsts = events.filter((event) => event.type === "visit_country_first");
-    expect(firsts).toHaveLength(2);
-    expect(firsts.map((event) => event.meta?.country).sort()).toEqual(["FR", "JP"]);
-    expect(firsts.every((event) => event.source === "brios")).toBe(true);
-    expect(firsts.every((event) => event.visibility === "public")).toBe(true);
-    expect(JSON.stringify(firsts)).not.toMatch(/\d{1,3}(?:\.\d{1,3}){3}/);
-
-    expect(await store.incrementCountryTotal("FR")).toBe(3);
-    expect(await store.incrementCountryTotal("JP")).toBe(2);
-    expect(await store.getTotals().then((totals) => totals.map((total) => total.type))).toEqual([
-      "visit",
-    ]);
-  });
-
-  test("does not record a first-country event for /activity", async () => {
-    const store = createMemoryActivityStore();
-    await recordVisit({ path: "/activity", country: "BR" }, store);
-    expect(await store.getTotals()).toEqual([]);
-    expect(await store.incrementCountryTotal("BR")).toBe(1);
   });
 });
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -18,7 +18,6 @@ import {
   inferContentTypeFromPath,
   inferTitleFromPath,
   isActivityPath,
-  normalizeCountryCode,
   shouldCountLifetimeTotal,
   shouldRecordVisit,
   visibleLifetimeTotals,
@@ -70,7 +69,6 @@ export type ActivityStore = {
   getTotals(): Promise<ActivityTotal[]>;
   getStreamLength(): Promise<number>;
   incrementVisitWindow(windowKey: string, ttlSeconds: number): Promise<number>;
-  incrementCountryTotal(country: string): Promise<number>;
 };
 
 export async function buildActivityFeed(store: ActivityStore | null): Promise<ActivityFeedPayload> {
@@ -85,7 +83,6 @@ export function createMemoryActivityStore(options: { maxLen?: number } = {}): Ac
   const totals = new Map<string, ActivityTotal>();
   const claimed = new Set<string>();
   const visitWindows = new Map<string, number>();
-  const countryTotals = new Map<string, number>();
 
   return {
     async claimIdempotency(key: string): Promise<boolean> {
@@ -120,11 +117,6 @@ export function createMemoryActivityStore(options: { maxLen?: number } = {}): Ac
     async incrementVisitWindow(windowKey: string): Promise<number> {
       const next = (visitWindows.get(windowKey) ?? 0) + 1;
       visitWindows.set(windowKey, next);
-      return next;
-    },
-    async incrementCountryTotal(country: string): Promise<number> {
-      const next = (countryTotals.get(country) ?? 0) + 1;
-      countryTotals.set(country, next);
       return next;
     },
   };
@@ -275,7 +267,7 @@ export async function recordVisit(
   const windowCount = await store.incrementVisitWindow(windowKey, 2);
   const writeToStream = windowCount <= ACTIVITY_VISIT_STREAM_MAX_PER_SEC;
 
-  const visitResult = await ingestActivityEvent(
+  return ingestActivityEvent(
     {
       source: ACTIVITY_SOURCE_BRIOS,
       type: "visit",
@@ -298,39 +290,6 @@ export async function recordVisit(
         title,
       },
       writeToStream,
-    },
-    store,
-    now,
-  );
-
-  if (country) {
-    await recordVisitCountryFirst(country, store, now);
-  }
-
-  return visitResult;
-}
-
-async function recordVisitCountryFirst(
-  country: string,
-  store: ActivityStore,
-  now: Date,
-): Promise<void> {
-  const code = normalizeCountryCode(country);
-  if (!code) return;
-
-  const countryCount = await store.incrementCountryTotal(code);
-  if (countryCount !== 1) return;
-
-  await ingestActivityEvent(
-    {
-      source: ACTIVITY_SOURCE_BRIOS,
-      type: "visit_country_first",
-      speed: "event",
-      summary: `First visit from ${code}`,
-      visibility: "public",
-      idempotency_key: `brios:visit_country_first:${code}`,
-      meta: { country: code },
-      idempotencyTtlSeconds: 0,
     },
     store,
     now,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stop emitting `visit_country_first` (“First visit from …”). It rarely fires and is not interesting enough to keep.

## What changed

- `recordVisit` no longer writes a first-country event or increments the country-total Redis hash.
- `incrementCountryTotal` is gone from the activity store (memory + Redis).
- Lifetime still hides leftover `visit_country_first` totals so old Redis keys do not show as “visit country first”.
- Existing stream rows still get a flag until they age out of the tail.

Regular visit rows are unchanged: flag + city/region/country summary.

## Verification

- `bun test` — 50 pass (activity + feed tests)
- `bun run lint` — clean
- `bunx tsc --noEmit` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-700c3204-dd63-4a3c-ab2e-9c4c37c8343c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-700c3204-dd63-4a3c-ab2e-9c4c37c8343c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

