### PR TITLE
Add GitHub webhook producer for the public /activity feed

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -42,7 +42,7 @@
 
 Verify `X-Hub-Signature-256` (`sha256=<hex>`) against `GITHUB_ACTIVITY_WEBHOOK_SECRET` with `safeCompare`. Missing secret → 503. Bad signature → 401. Ignored events (ping, bots, star deletions, closed-unmerged PRs) return 200 so GitHub does not retry.
 
-Recorded types: `pr_opened`, `pr_merged`, `repo_starred`. Private repositories are recorded with generic copy — no repo name, title, or URL. Bot actors are skipped.
+Recorded types: `pr_opened`, `pr_merged`, `repo_starred`. Private repositories are recorded with generic copy — no repo name, title, or URL. Dependabot PRs are skipped; coding-agent PRs (e.g. `cursor[bot]`) are kept. Stars are humans only.
 
 **GitHub hook setup** (after `GITHUB_ACTIVITY_WEBHOOK_SECRET` is set in Vercel):
 

--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -36,6 +36,14 @@
 
 **Content rendering**: Notion blocks → React components via `renderBlocks.tsx`
 
+## GitHub Activity Webhook
+
+`POST /api/webhooks/github` receives GitHub `pull_request` and `star` events and writes them to the public `/activity` feed via in-process `ingestActivityEvent`. It does not use the HMAC ingest URL.
+
+Verify `X-Hub-Signature-256` (`sha256=<hex>`) against `GITHUB_ACTIVITY_WEBHOOK_SECRET` with `safeCompare`. Missing secret → 503. Bad signature → 401. Ignored events (ping, private repos, bots, star deletions, closed-unmerged PRs) return 200 so GitHub does not retry.
+
+Recorded types: `pr_opened`, `pr_merged`, `repo_starred`. Private repositories and bot actors are skipped.
+
 ## Notion Webhooks
 
 Webhook endpoints called by Notion database automations (button properties). All webhooks verify the `x-webhook-secret` header against `NOTION_WEBHOOK_VERIFICATION_SECRET` if configured.

--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -40,9 +40,20 @@
 
 `POST /api/webhooks/github` receives GitHub `pull_request` and `star` events and writes them to the public `/activity` feed via in-process `ingestActivityEvent`. It does not use the HMAC ingest URL.
 
-Verify `X-Hub-Signature-256` (`sha256=<hex>`) against `GITHUB_ACTIVITY_WEBHOOK_SECRET` with `safeCompare`. Missing secret → 503. Bad signature → 401. Ignored events (ping, private repos, bots, star deletions, closed-unmerged PRs) return 200 so GitHub does not retry.
+Verify `X-Hub-Signature-256` (`sha256=<hex>`) against `GITHUB_ACTIVITY_WEBHOOK_SECRET` with `safeCompare`. Missing secret → 503. Bad signature → 401. Ignored events (ping, bots, star deletions, closed-unmerged PRs) return 200 so GitHub does not retry.
 
-Recorded types: `pr_opened`, `pr_merged`, `repo_starred`. Private repositories and bot actors are skipped.
+Recorded types: `pr_opened`, `pr_merged`, `repo_starred`. Private repositories are recorded with generic copy — no repo name, title, or URL. Bot actors are skipped.
+
+**GitHub hook setup** (after `GITHUB_ACTIVITY_WEBHOOK_SECRET` is set in Vercel):
+
+1. Repo → **Settings → Webhooks → Add webhook**
+2. Payload URL: `https://brianlovin.com/api/webhooks/github`
+3. Content type: `application/json` (not form-encoded)
+4. Secret: the same value as `GITHUB_ACTIVITY_WEBHOOK_SECRET`
+5. Events: **Let me select individual events** → **Pull requests** and **Stars**
+6. Active → **Add webhook**. GitHub sends a `ping`; a 200 means the endpoint is up.
+
+Repeat per repo (including private). One hook does not cover a personal account. For every repo under one install, use a GitHub App webhook with the same URL, secret, and `pull_request` + `star` events.
 
 ## Notion Webhooks
 

--- a/.env.example
+++ b/.env.example
@@ -54,8 +54,9 @@ UPSTASH_ACTIVITY_REST_TOKEN=
 ACTIVITY_INGEST_HMAC_SECRET=
 
 # GitHub webhook secret for POST /api/webhooks/github (public /activity feed).
-# Configure in GitHub: Settings → Webhooks → Secret. Subscribe to pull_request and star.
-# Leave hook registration until after deploy. Do not commit a real value.
+# Same value as the GitHub webhook Secret. Subscribe to pull_request and star.
+# Payload URL: https://brianlovin.com/api/webhooks/github  Content type: application/json
+# Do not commit a real value.
 GITHUB_ACTIVITY_WEBHOOK_SECRET=
 
 # Likes system

--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,11 @@ UPSTASH_ACTIVITY_REST_TOKEN=
 # HMAC secret for POST /api/activity (later external producers)
 ACTIVITY_INGEST_HMAC_SECRET=
 
+# GitHub webhook secret for POST /api/webhooks/github (public /activity feed).
+# Configure in GitHub: Settings → Webhooks → Secret. Subscribe to pull_request and star.
+# Leave hook registration until after deploy. Do not commit a real value.
+GITHUB_ACTIVITY_WEBHOOK_SECRET=
+
 # Likes system
 LIKES_HASH_SALT=
 LIKES_SYNC_TOKEN=

--- a/src/app/api/webhooks/github/route.test.ts
+++ b/src/app/api/webhooks/github/route.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { createHmac } from "crypto";
+
+import { POST } from "@/app/api/webhooks/github/route";
+import { createMemoryActivityStore } from "@/lib/activity";
+import * as activityRedis from "@/lib/activity-redis";
+
+const TEST_SECRET = "unit-test-webhook-secret";
+
+function sign(body: string, secret = TEST_SECRET): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+function webhookRequest(
+  event: string,
+  payload: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  const raw = typeof payload === "string" ? payload : JSON.stringify(payload);
+  return new Request("http://localhost/api/webhooks/github", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-github-event": event,
+      "x-hub-signature-256": sign(raw),
+      ...headers,
+    },
+    body: raw,
+  });
+}
+
+const openedPr = {
+  action: "opened",
+  number: 7,
+  pull_request: {
+    number: 7,
+    title: "Webhook producer",
+    html_url: "https://github.com/brianlovin/briOS/pull/7",
+    merged: false,
+    user: { login: "octocat", type: "User", email: "octocat@example.com" },
+  },
+  repository: {
+    name: "briOS",
+    full_name: "brianlovin/briOS",
+    private: false,
+    html_url: "https://github.com/brianlovin/briOS",
+  },
+  sender: { login: "octocat", type: "User", email: "octocat@example.com" },
+};
+
+describe("POST /api/webhooks/github", () => {
+  const previousSecret = process.env.GITHUB_ACTIVITY_WEBHOOK_SECRET;
+  let store = createMemoryActivityStore();
+
+  beforeEach(() => {
+    process.env.GITHUB_ACTIVITY_WEBHOOK_SECRET = TEST_SECRET;
+    store = createMemoryActivityStore();
+    spyOn(activityRedis, "getActivityStore").mockReturnValue(store);
+  });
+
+  afterEach(() => {
+    if (previousSecret === undefined) {
+      delete process.env.GITHUB_ACTIVITY_WEBHOOK_SECRET;
+    } else {
+      process.env.GITHUB_ACTIVITY_WEBHOOK_SECRET = previousSecret;
+    }
+  });
+
+  test("returns 503 when the webhook secret is missing", async () => {
+    delete process.env.GITHUB_ACTIVITY_WEBHOOK_SECRET;
+    const res = await POST(webhookRequest("ping", { zen: "hi" }));
+    expect(res.status).toBe(503);
+    expect(await store.getStreamLength()).toBe(0);
+  });
+
+  test("returns 401 for a bad signature", async () => {
+    const res = await POST(
+      webhookRequest("pull_request", openedPr, {
+        "x-hub-signature-256":
+          "sha256=0000000000000000000000000000000000000000000000000000000000000000",
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(await store.getStreamLength()).toBe(0);
+  });
+
+  test("returns 200 for ping without ingesting", async () => {
+    const res = await POST(webhookRequest("ping", { zen: "Responsive is better than fast." }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, ignored: "ping" });
+    expect(await store.getStreamLength()).toBe(0);
+  });
+
+  test("ingests an opened pull request and strips email", async () => {
+    const res = await POST(webhookRequest("pull_request", openedPr));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.duplicate).toBe(false);
+
+    const [event] = await store.getTail(1);
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain("octocat@example.com");
+    expect(event?.type).toBe("pr_opened");
+    expect(event?.source).toBe("github");
+    expect(event?.summary).toBe("Opened a pull request on briOS");
+  });
+
+  test("returns 200 and skips private repos, bot PRs, unmerged closes, and deleted stars", async () => {
+    const privateRes = await POST(
+      webhookRequest("pull_request", {
+        ...openedPr,
+        repository: { ...openedPr.repository, private: true, name: "secrets" },
+      }),
+    );
+    const botRes = await POST(
+      webhookRequest("pull_request", {
+        ...openedPr,
+        sender: { login: "dependabot[bot]", type: "Bot" },
+        pull_request: {
+          ...openedPr.pull_request,
+          user: { login: "dependabot[bot]", type: "Bot" },
+        },
+      }),
+    );
+    const closedRes = await POST(
+      webhookRequest("pull_request", {
+        ...openedPr,
+        action: "closed",
+        pull_request: { ...openedPr.pull_request, merged: false },
+      }),
+    );
+    const deletedStar = await POST(
+      webhookRequest("star", {
+        action: "deleted",
+        repository: openedPr.repository,
+        sender: openedPr.sender,
+      }),
+    );
+
+    expect(privateRes.status).toBe(200);
+    expect(await privateRes.json()).toEqual({ ok: true, ignored: "private_repo" });
+    expect(botRes.status).toBe(200);
+    expect(await botRes.json()).toEqual({ ok: true, ignored: "bot_actor" });
+    expect(closedRes.status).toBe(200);
+    expect(await closedRes.json()).toEqual({ ok: true, ignored: "closed_unmerged" });
+    expect(deletedStar.status).toBe(200);
+    expect(await deletedStar.json()).toEqual({ ok: true, ignored: "ignored_star_action" });
+    expect(await store.getStreamLength()).toBe(0);
+  });
+});

--- a/src/app/api/webhooks/github/route.test.ts
+++ b/src/app/api/webhooks/github/route.test.ts
@@ -106,11 +106,22 @@ describe("POST /api/webhooks/github", () => {
     expect(event?.summary).toBe("Opened a pull request on briOS");
   });
 
-  test("returns 200 and skips private repos, bot PRs, unmerged closes, and deleted stars", async () => {
+  test("records private repos without the name, and skips bot PRs, unmerged closes, and deleted stars", async () => {
     const privateRes = await POST(
       webhookRequest("pull_request", {
         ...openedPr,
-        repository: { ...openedPr.repository, private: true, name: "secrets" },
+        repository: {
+          ...openedPr.repository,
+          private: true,
+          name: "secrets",
+          full_name: "brianlovin/secrets",
+          html_url: "https://github.com/brianlovin/secrets",
+        },
+        pull_request: {
+          ...openedPr.pull_request,
+          title: "private title must not leak",
+          html_url: "https://github.com/brianlovin/secrets/pull/7",
+        },
       }),
     );
     const botRes = await POST(
@@ -139,13 +150,20 @@ describe("POST /api/webhooks/github", () => {
     );
 
     expect(privateRes.status).toBe(200);
-    expect(await privateRes.json()).toEqual({ ok: true, ignored: "private_repo" });
+    const privateBody = await privateRes.json();
+    expect(privateBody.ok).toBe(true);
+    expect(privateBody.ignored).toBeUndefined();
+    const [privateEvent] = await store.getTail(1);
+    const privateSerialized = JSON.stringify(privateEvent);
+    expect(privateSerialized).not.toContain("secrets");
+    expect(privateSerialized).not.toContain("private title");
+    expect(privateEvent?.summary).toBe("Opened a pull request");
     expect(botRes.status).toBe(200);
     expect(await botRes.json()).toEqual({ ok: true, ignored: "bot_actor" });
     expect(closedRes.status).toBe(200);
     expect(await closedRes.json()).toEqual({ ok: true, ignored: "closed_unmerged" });
     expect(deletedStar.status).toBe(200);
     expect(await deletedStar.json()).toEqual({ ok: true, ignored: "ignored_star_action" });
-    expect(await store.getStreamLength()).toBe(0);
+    expect(await store.getStreamLength()).toBe(1);
   });
 });

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+import { recordGithubActivity, verifyGithubWebhookSignature } from "@/lib/activity";
+import { getActivityStore } from "@/lib/activity-redis";
+import { errorResponse } from "@/lib/api-utils";
+
+/**
+ * GitHub webhook producer for the public /activity feed.
+ * Verifies X-Hub-Signature-256 and calls ingestActivityEvent in-process.
+ * Does not go through POST /api/activity HMAC ingest.
+ */
+export async function POST(request: Request) {
+  const secret = process.env.GITHUB_ACTIVITY_WEBHOOK_SECRET;
+  if (!secret) {
+    return errorResponse("GitHub activity webhook is not configured", 503);
+  }
+
+  const raw = await request.text();
+  const signature = request.headers.get("x-hub-signature-256");
+  if (!verifyGithubWebhookSignature(raw, signature, secret)) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  const githubEvent = request.headers.get("x-github-event") ?? "";
+  if (githubEvent === "ping") {
+    return NextResponse.json({ ok: true, ignored: "ping" });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return NextResponse.json({ ok: true, ignored: "invalid_json" });
+  }
+
+  const store = getActivityStore();
+  if (!store) {
+    return errorResponse("Activity store is not configured", 503);
+  }
+
+  const result = await recordGithubActivity(githubEvent, payload, store);
+  if ("skipped" in result) {
+    return NextResponse.json({ ok: true, ignored: result.reason });
+  }
+  if (!result.ok) {
+    return NextResponse.json({ ok: true, ignored: result.error });
+  }
+
+  return NextResponse.json({ ok: true, id: result.id, duplicate: result.duplicate });
+}

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -101,4 +101,57 @@ describe("ActivityRow", () => {
     expect(markup).toContain("16.0041 19.25 12 19.25");
     expect(markup).not.toContain("text-red-500");
   });
+
+  test("shows merge diff stats in the metadata slot", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "github",
+          type: "pr_merged",
+          speed: "event",
+          summary: "Merged a pull request on briOS",
+          subject: {
+            kind: "pull_request",
+            label: "Add activity feed",
+            href: "https://github.com/brianlovin/briOS/pull/42",
+          },
+          meta: {
+            repo: "briOS",
+            title: "Add activity feed",
+            number: 42,
+            href: "https://github.com/brianlovin/briOS/pull/42",
+            additions: 311,
+            deletions: 211,
+            changed_files: 8,
+          },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Merged a pull request on briOS");
+    expect(markup).toContain("Add activity feed");
+    expect(markup).toContain("+311");
+    expect(markup).toContain("-211");
+    expect(markup).toContain("text-green-600");
+    expect(markup).toContain("text-red-500");
+    expect(markup).toContain("tabular-nums");
+    expect(markup).not.toContain("+311 -211");
+  });
+
+  test("still shows +0 and -0 when both diff fields are zero", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "github",
+          type: "pr_merged",
+          speed: "event",
+          summary: "Merged a pull request on briOS",
+          meta: { additions: 0, deletions: 0 },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("+0");
+    expect(markup).toContain("-0");
+  });
 });

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -78,4 +78,27 @@ describe("ActivityRow", () => {
     expect(visit).not.toContain("text-red-500");
     expect(visit).toContain("🇮🇳");
   });
+
+  test("uses the GitHub icon for github-sourced events", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "github",
+          type: "pr_opened",
+          speed: "event",
+          summary: "Opened a pull request on briOS",
+          subject: {
+            kind: "pull_request",
+            label: "Add activity feed",
+            href: "https://github.com/brianlovin/briOS/pull/42",
+          },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Opened a pull request on briOS");
+    expect(markup).toContain("Add activity feed");
+    expect(markup).toContain("16.0041 19.25 12 19.25");
+    expect(markup).not.toContain("text-red-500");
+  });
 });

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -14,7 +14,12 @@ import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { useTopBarActions } from "@/components/TopBarActions";
 import { IconButton } from "@/components/ui/IconButton";
 import type { ActivityEvent, ActivityTotal } from "@/lib/activity";
-import { formatTotalLabel, getActivityRow, visibleLifetimeTotals } from "@/lib/activity-shared";
+import {
+  formatTotalLabel,
+  getActivityRow,
+  getMergedPullRequestDiff,
+  visibleLifetimeTotals,
+} from "@/lib/activity-shared";
 import { useActivity } from "@/lib/hooks/useActivity";
 import { cn } from "@/lib/utils";
 
@@ -87,9 +92,19 @@ function ActivityRowIcon({ event, flag }: { event: ActivityEvent; flag?: string 
   return <Activity size={16} className="text-tertiary" aria-hidden />;
 }
 
+function PullRequestDiff({ additions, deletions }: { additions: number; deletions: number }) {
+  return (
+    <span className="shrink-0 text-sm tabular-nums">
+      <span className="text-green-600">+{additions}</span>{" "}
+      <span className="text-red-500">-{deletions}</span>
+    </span>
+  );
+}
+
 export function ActivityRow({ event }: { event: ActivityEvent }) {
   const row = getActivityRow(event);
   const href = row.href;
+  const diff = event.type === "pr_merged" ? getMergedPullRequestDiff(event.meta) : null;
 
   return (
     <div className="border-secondary hover:bg-secondary grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 border-b px-4 py-3 md:gap-4 md:py-2 md:dark:hover:bg-white/5">
@@ -98,13 +113,20 @@ export function ActivityRow({ event }: { event: ActivityEvent }) {
       </div>
       <div className="min-w-0">
         <p className="text-primary truncate text-pretty">{row.summary}</p>
-        {href ? (
-          <Link
-            href={href}
-            className="text-tertiary hover:text-primary block truncate text-sm underline-offset-2 hover:underline"
-          >
-            {row.label ?? href}
-          </Link>
+        {href || diff ? (
+          <div className="flex min-w-0 items-baseline gap-2">
+            {href ? (
+              <Link
+                href={href}
+                className="text-tertiary hover:text-primary min-w-0 truncate text-sm underline-offset-2 hover:underline"
+              >
+                {row.label ?? href}
+              </Link>
+            ) : null}
+            {diff ? (
+              <PullRequestDiff additions={diff.additions} deletions={diff.deletions} />
+            ) : null}
+          </div>
         ) : null}
       </div>
       <RelativeTime iso={event.received_at} />

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { activityLifetimeSidebarAtom } from "@/atoms/activityLifetimeSidebar";
 import { Activity } from "@/components/icons/Activity";
+import { Github } from "@/components/icons/Github";
 import { Heart } from "@/components/icons/Heart";
 import { Sidebar } from "@/components/icons/Sidebar";
 import { World } from "@/components/icons/World";
@@ -64,6 +65,10 @@ function RelativeTime({ iso }: { iso: string }) {
 }
 
 function ActivityRowIcon({ event, flag }: { event: ActivityEvent; flag?: string }) {
+  if (event.source === "github") {
+    return <Github size={16} className="text-tertiary" aria-hidden />;
+  }
+
   if (event.type === "like") {
     return <Heart size={16} className="fill-current text-red-500" aria-hidden />;
   }

--- a/src/lib/activity-github.test.ts
+++ b/src/lib/activity-github.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, test } from "bun:test";
+import { createHmac } from "crypto";
+
+import {
+  createMemoryActivityStore,
+  githubActivityFromWebhook,
+  isGithubBotActor,
+  recordGithubActivity,
+  verifyGithubWebhookSignature,
+} from "@/lib/activity";
+
+const EMAIL = "octocat@example.com";
+
+function publicRepo(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "briOS",
+    full_name: "brianlovin/briOS",
+    private: false,
+    html_url: "https://github.com/brianlovin/briOS",
+    ...overrides,
+  };
+}
+
+function human(overrides: Record<string, unknown> = {}) {
+  return {
+    login: "octocat",
+    type: "User",
+    email: EMAIL,
+    ...overrides,
+  };
+}
+
+function pullRequestPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: "opened",
+    number: 42,
+    pull_request: {
+      number: 42,
+      title: "Add activity feed",
+      html_url: "https://github.com/brianlovin/briOS/pull/42",
+      merged: false,
+      user: human(),
+    },
+    repository: publicRepo(),
+    sender: human(),
+    ...overrides,
+  };
+}
+
+function starPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: "created",
+    repository: publicRepo(),
+    sender: human(),
+    ...overrides,
+  };
+}
+
+describe("verifyGithubWebhookSignature", () => {
+  const secret = "unit-test-webhook-secret";
+  const body = `{"zen":"Responsive is better than fast."}`;
+  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+
+  test("accepts a matching sha256 signature", () => {
+    expect(verifyGithubWebhookSignature(body, signature, secret)).toBe(true);
+  });
+
+  test("rejects a missing, truncated, or wrong signature", () => {
+    expect(verifyGithubWebhookSignature(body, null, secret)).toBe(false);
+    expect(verifyGithubWebhookSignature(body, "sha256=deadbeef", secret)).toBe(false);
+    expect(verifyGithubWebhookSignature(body, signature.slice(0, 20), secret)).toBe(false);
+    expect(verifyGithubWebhookSignature(` ${body}`, signature, secret)).toBe(false);
+  });
+});
+
+describe("isGithubBotActor", () => {
+  test("treats type Bot and known bot logins as bots", () => {
+    expect(isGithubBotActor({ login: "octocat", type: "User" })).toBe(false);
+    expect(isGithubBotActor({ login: "cursor[bot]", type: "User" })).toBe(true);
+    expect(isGithubBotActor({ login: "dependabot[bot]", type: "User" })).toBe(true);
+    expect(isGithubBotActor({ login: "github-actions[bot]", type: "User" })).toBe(true);
+    expect(isGithubBotActor({ login: "some-app", type: "Bot" })).toBe(true);
+  });
+});
+
+describe("githubActivityFromWebhook", () => {
+  test("maps an opened pull request", () => {
+    const decision = githubActivityFromWebhook("pull_request", pullRequestPayload());
+    expect(decision).toEqual({
+      status: "ingest",
+      input: expect.objectContaining({
+        source: "github",
+        type: "pr_opened",
+        speed: "event",
+        visibility: "public",
+        summary: "Opened a pull request on briOS",
+        idempotency_key: "github:pr_opened:briOS:42",
+        subject: {
+          kind: "pull_request",
+          label: "Add activity feed",
+          href: "https://github.com/brianlovin/briOS/pull/42",
+        },
+        meta: {
+          repo: "briOS",
+          title: "Add activity feed",
+          number: 42,
+          href: "https://github.com/brianlovin/briOS/pull/42",
+        },
+      }),
+    });
+  });
+
+  test("maps a merged pull request and ignores closed-unmerged", () => {
+    const merged = githubActivityFromWebhook(
+      "pull_request",
+      pullRequestPayload({
+        action: "closed",
+        pull_request: {
+          number: 42,
+          title: "Add activity feed",
+          html_url: "https://github.com/brianlovin/briOS/pull/42",
+          merged: true,
+          user: human(),
+        },
+      }),
+    );
+    expect(merged.status).toBe("ingest");
+    if (merged.status === "ingest") {
+      expect(merged.input.type).toBe("pr_merged");
+      expect(merged.input.summary).toBe("Merged a pull request on briOS");
+      expect(merged.input.idempotency_key).toBe("github:pr_merged:briOS:42");
+    }
+
+    const closed = githubActivityFromWebhook(
+      "pull_request",
+      pullRequestPayload({
+        action: "closed",
+        pull_request: {
+          number: 42,
+          title: "Add activity feed",
+          html_url: "https://github.com/brianlovin/briOS/pull/42",
+          merged: false,
+          user: human(),
+        },
+      }),
+    );
+    expect(closed).toEqual({ status: "ignore", reason: "closed_unmerged" });
+  });
+
+  test("maps a created star and ignores deleted", () => {
+    const created = githubActivityFromWebhook("star", starPayload());
+    expect(created).toEqual({
+      status: "ingest",
+      input: expect.objectContaining({
+        source: "github",
+        type: "repo_starred",
+        speed: "event",
+        visibility: "public",
+        summary: "Someone starred briOS",
+        idempotency_key: "github:star:briOS:octocat",
+        subject: {
+          kind: "repo",
+          label: "brianlovin/briOS",
+          href: "https://github.com/brianlovin/briOS",
+        },
+        meta: {
+          repo: "briOS",
+          href: "https://github.com/brianlovin/briOS",
+        },
+      }),
+    });
+
+    expect(githubActivityFromWebhook("star", starPayload({ action: "deleted" }))).toEqual({
+      status: "ignore",
+      reason: "ignored_star_action",
+    });
+  });
+
+  test("ignores private repos before reading titles or urls", () => {
+    const decision = githubActivityFromWebhook(
+      "pull_request",
+      pullRequestPayload({
+        repository: {
+          name: "secrets",
+          full_name: "brianlovin/secrets",
+          private: true,
+          html_url: "https://github.com/brianlovin/secrets",
+        },
+        pull_request: {
+          number: 1,
+          title: "private title must not leak",
+          html_url: "https://github.com/brianlovin/secrets/pull/1",
+          merged: false,
+          user: human(),
+        },
+      }),
+    );
+    expect(decision).toEqual({ status: "ignore", reason: "private_repo" });
+    expect(JSON.stringify(decision)).not.toContain("private title");
+    expect(JSON.stringify(decision)).not.toContain("secrets");
+  });
+
+  test("ignores bot pull requests", () => {
+    expect(
+      githubActivityFromWebhook(
+        "pull_request",
+        pullRequestPayload({
+          sender: { login: "dependabot[bot]", type: "Bot" },
+          pull_request: {
+            number: 9,
+            title: "Bump lodash",
+            html_url: "https://github.com/brianlovin/briOS/pull/9",
+            merged: false,
+            user: { login: "dependabot[bot]", type: "Bot" },
+          },
+        }),
+      ),
+    ).toEqual({ status: "ignore", reason: "bot_actor" });
+
+    expect(
+      githubActivityFromWebhook(
+        "pull_request",
+        pullRequestPayload({
+          sender: { login: "cursor[bot]", type: "Bot" },
+          pull_request: {
+            number: 10,
+            title: "Agent PR",
+            html_url: "https://github.com/brianlovin/briOS/pull/10",
+            merged: false,
+            user: { login: "cursor[bot]", type: "Bot" },
+          },
+        }),
+      ),
+    ).toEqual({ status: "ignore", reason: "bot_actor" });
+  });
+
+  test("ignores stars from bots", () => {
+    expect(
+      githubActivityFromWebhook(
+        "star",
+        starPayload({ sender: { login: "github-actions[bot]", type: "Bot" } }),
+      ),
+    ).toEqual({ status: "ignore", reason: "bot_actor" });
+  });
+
+  test("ignores ping and unknown events", () => {
+    expect(githubActivityFromWebhook("ping", { zen: "nice" })).toEqual({
+      status: "ignore",
+      reason: "ping",
+    });
+    expect(githubActivityFromWebhook("issues", pullRequestPayload())).toEqual({
+      status: "ignore",
+      reason: "ignored_event",
+    });
+  });
+});
+
+describe("recordGithubActivity", () => {
+  test("writes a public event with no email", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordGithubActivity("pull_request", pullRequestPayload(), store);
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, duplicate: false }));
+    const [event] = await store.getTail(1);
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain(EMAIL);
+    expect(serialized).not.toContain("example.com");
+    expect(serialized.toLowerCase()).not.toMatch(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/);
+    expect(event?.source).toBe("github");
+    expect(event?.visibility).toBe("public");
+    expect(event?.actor).toBeUndefined();
+    expect(event?.meta).toEqual({
+      repo: "briOS",
+      title: "Add activity feed",
+      number: 42,
+      href: "https://github.com/brianlovin/briOS/pull/42",
+    });
+  });
+
+  test("does not record a private repo or a bot PR", async () => {
+    const store = createMemoryActivityStore();
+
+    const privateResult = await recordGithubActivity(
+      "pull_request",
+      pullRequestPayload({ repository: publicRepo({ private: true, name: "secrets" }) }),
+      store,
+    );
+    const botResult = await recordGithubActivity(
+      "pull_request",
+      pullRequestPayload({
+        sender: { login: "dependabot[bot]", type: "Bot" },
+        pull_request: {
+          number: 3,
+          title: "Bump",
+          html_url: "https://github.com/brianlovin/briOS/pull/3",
+          merged: false,
+          user: { login: "dependabot[bot]", type: "Bot" },
+        },
+      }),
+      store,
+    );
+
+    expect(privateResult).toEqual({ skipped: true, reason: "private_repo" });
+    expect(botResult).toEqual({ skipped: true, reason: "bot_actor" });
+    expect(await store.getStreamLength()).toBe(0);
+    expect(await store.getTotals()).toEqual([]);
+  });
+
+  test("treats the same person starring twice as one event", async () => {
+    const store = createMemoryActivityStore();
+    const first = await recordGithubActivity("star", starPayload(), store);
+    const second = await recordGithubActivity("star", starPayload(), store);
+    const other = await recordGithubActivity(
+      "star",
+      starPayload({ sender: human({ login: "other" }) }),
+      store,
+    );
+
+    expect(first).toEqual(expect.objectContaining({ ok: true, duplicate: false }));
+    expect(second).toEqual(expect.objectContaining({ ok: true, duplicate: true }));
+    expect(other).toEqual(expect.objectContaining({ ok: true, duplicate: false }));
+    expect(await store.getStreamLength()).toBe(2);
+    expect(await store.getTotals()).toEqual([
+      expect.objectContaining({ source: "github", type: "repo_starred", count: 2 }),
+    ]);
+  });
+});

--- a/src/lib/activity-github.test.ts
+++ b/src/lib/activity-github.test.ts
@@ -4,6 +4,7 @@ import { createHash, createHmac } from "crypto";
 import {
   createMemoryActivityStore,
   githubActivityFromWebhook,
+  isDependabotActor,
   isGithubBotActor,
   recordGithubActivity,
   verifyGithubWebhookSignature,
@@ -80,6 +81,16 @@ describe("isGithubBotActor", () => {
     expect(isGithubBotActor({ login: "dependabot[bot]", type: "User" })).toBe(true);
     expect(isGithubBotActor({ login: "github-actions[bot]", type: "User" })).toBe(true);
     expect(isGithubBotActor({ login: "some-app", type: "Bot" })).toBe(true);
+  });
+});
+
+describe("isDependabotActor", () => {
+  test("matches Dependabot only, not coding agents", () => {
+    expect(isDependabotActor({ login: "dependabot[bot]", type: "Bot" })).toBe(true);
+    expect(isDependabotActor({ login: "dependabot-preview[bot]", type: "Bot" })).toBe(true);
+    expect(isDependabotActor({ login: "cursor[bot]", type: "Bot" })).toBe(false);
+    expect(isDependabotActor({ login: "github-actions[bot]", type: "Bot" })).toBe(false);
+    expect(isDependabotActor({ login: "octocat", type: "User" })).toBe(false);
   });
 });
 
@@ -229,7 +240,7 @@ describe("githubActivityFromWebhook", () => {
     expect(serialized).not.toContain("brianlovin");
   });
 
-  test("ignores bot pull requests", () => {
+  test("ignores Dependabot pull requests but keeps coding-agent PRs", () => {
     expect(
       githubActivityFromWebhook(
         "pull_request",
@@ -246,21 +257,29 @@ describe("githubActivityFromWebhook", () => {
       ),
     ).toEqual({ status: "ignore", reason: "bot_actor" });
 
-    expect(
-      githubActivityFromWebhook(
-        "pull_request",
-        pullRequestPayload({
-          sender: { login: "cursor[bot]", type: "Bot" },
-          pull_request: {
-            number: 10,
-            title: "Agent PR",
-            html_url: "https://github.com/brianlovin/briOS/pull/10",
-            merged: false,
-            user: { login: "cursor[bot]", type: "Bot" },
-          },
-        }),
-      ),
-    ).toEqual({ status: "ignore", reason: "bot_actor" });
+    const agent = githubActivityFromWebhook(
+      "pull_request",
+      pullRequestPayload({
+        sender: { login: "cursor[bot]", type: "Bot" },
+        pull_request: {
+          number: 10,
+          title: "Agent PR",
+          html_url: "https://github.com/brianlovin/briOS/pull/10",
+          merged: false,
+          user: { login: "cursor[bot]", type: "Bot" },
+        },
+      }),
+    );
+    expect(agent.status).toBe("ingest");
+    if (agent.status === "ingest") {
+      expect(agent.input.type).toBe("pr_opened");
+      expect(agent.input.summary).toBe("Opened a pull request on briOS");
+      expect(agent.input.subject).toEqual({
+        kind: "pull_request",
+        label: "Agent PR",
+        href: "https://github.com/brianlovin/briOS/pull/10",
+      });
+    }
   });
 
   test("ignores stars from bots", () => {

--- a/src/lib/activity-github.test.ts
+++ b/src/lib/activity-github.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createHmac } from "crypto";
+import { createHash, createHmac } from "crypto";
 
 import {
   createMemoryActivityStore,
@@ -176,7 +176,7 @@ describe("githubActivityFromWebhook", () => {
     });
   });
 
-  test("ignores private repos before reading titles or urls", () => {
+  test("records private repos without passing through the name, title, or url", () => {
     const decision = githubActivityFromWebhook(
       "pull_request",
       pullRequestPayload({
@@ -195,9 +195,20 @@ describe("githubActivityFromWebhook", () => {
         },
       }),
     );
-    expect(decision).toEqual({ status: "ignore", reason: "private_repo" });
-    expect(JSON.stringify(decision)).not.toContain("private title");
-    expect(JSON.stringify(decision)).not.toContain("secrets");
+    const repoHash = createHash("sha256").update("brianlovin/secrets").digest("hex").slice(0, 16);
+
+    expect(decision.status).toBe("ingest");
+    if (decision.status === "ingest") {
+      expect(decision.input.summary).toBe("Opened a pull request");
+      expect(decision.input.subject).toEqual({ kind: "pull_request", label: "a pull request" });
+      expect(decision.input.meta).toEqual({ private: true, number: 1 });
+      expect(decision.input.idempotency_key).toBe(`github:pr_opened:private:${repoHash}:1`);
+    }
+
+    const serialized = JSON.stringify(decision);
+    expect(serialized).not.toContain("private title");
+    expect(serialized).not.toContain("secrets");
+    expect(serialized).not.toContain("brianlovin");
   });
 
   test("ignores bot pull requests", () => {
@@ -277,12 +288,19 @@ describe("recordGithubActivity", () => {
     });
   });
 
-  test("does not record a private repo or a bot PR", async () => {
+  test("records a private repo without leaking its name, and still skips bot PRs", async () => {
     const store = createMemoryActivityStore();
 
     const privateResult = await recordGithubActivity(
       "pull_request",
-      pullRequestPayload({ repository: publicRepo({ private: true, name: "secrets" }) }),
+      pullRequestPayload({
+        repository: publicRepo({
+          private: true,
+          name: "secrets",
+          full_name: "brianlovin/secrets",
+          html_url: "https://github.com/brianlovin/secrets",
+        }),
+      }),
       store,
     );
     const botResult = await recordGithubActivity(
@@ -300,10 +318,16 @@ describe("recordGithubActivity", () => {
       store,
     );
 
-    expect(privateResult).toEqual({ skipped: true, reason: "private_repo" });
+    expect(privateResult).toEqual(expect.objectContaining({ ok: true, duplicate: false }));
     expect(botResult).toEqual({ skipped: true, reason: "bot_actor" });
-    expect(await store.getStreamLength()).toBe(0);
-    expect(await store.getTotals()).toEqual([]);
+    expect(await store.getStreamLength()).toBe(1);
+
+    const [event] = await store.getTail(1);
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain("secrets");
+    expect(serialized).not.toContain("Add activity feed");
+    expect(event?.summary).toBe("Opened a pull request");
+    expect(event?.meta).toEqual({ private: true, number: 42 });
   });
 
   test("treats the same person starring twice as one event", async () => {

--- a/src/lib/activity-github.test.ts
+++ b/src/lib/activity-github.test.ts
@@ -120,6 +120,9 @@ describe("githubActivityFromWebhook", () => {
           title: "Add activity feed",
           html_url: "https://github.com/brianlovin/briOS/pull/42",
           merged: true,
+          additions: 311,
+          deletions: 211,
+          changed_files: 8,
           user: human(),
         },
       }),
@@ -129,6 +132,21 @@ describe("githubActivityFromWebhook", () => {
       expect(merged.input.type).toBe("pr_merged");
       expect(merged.input.summary).toBe("Merged a pull request on briOS");
       expect(merged.input.idempotency_key).toBe("github:pr_merged:briOS:42");
+      expect(merged.input.subject).toEqual({
+        kind: "pull_request",
+        label: "Add activity feed",
+        href: "https://github.com/brianlovin/briOS/pull/42",
+      });
+      expect(merged.input.meta).toEqual({
+        repo: "briOS",
+        title: "Add activity feed",
+        number: 42,
+        href: "https://github.com/brianlovin/briOS/pull/42",
+        additions: 311,
+        deletions: 211,
+        changed_files: 8,
+      });
+      expect(merged.input.summary).not.toContain("+311");
     }
 
     const closed = githubActivityFromWebhook(
@@ -267,6 +285,47 @@ describe("githubActivityFromWebhook", () => {
 });
 
 describe("recordGithubActivity", () => {
+  test("stores additions and deletions on a merged pull request", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordGithubActivity(
+      "pull_request",
+      pullRequestPayload({
+        action: "closed",
+        pull_request: {
+          number: 42,
+          title: "Add activity feed",
+          html_url: "https://github.com/brianlovin/briOS/pull/42",
+          merged: true,
+          additions: 311,
+          deletions: 211,
+          changed_files: 8,
+          user: human(),
+        },
+      }),
+      store,
+    );
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, duplicate: false }));
+    const [event] = await store.getTail(1);
+    expect(event?.type).toBe("pr_merged");
+    expect(event?.summary).toBe("Merged a pull request on briOS");
+    expect(event?.subject).toEqual({
+      kind: "pull_request",
+      label: "Add activity feed",
+      href: "https://github.com/brianlovin/briOS/pull/42",
+    });
+    expect(event?.meta).toEqual({
+      repo: "briOS",
+      title: "Add activity feed",
+      number: 42,
+      href: "https://github.com/brianlovin/briOS/pull/42",
+      additions: 311,
+      deletions: 211,
+      changed_files: 8,
+    });
+    expect(event?.summary).not.toMatch(/\+311|-211/);
+  });
+
   test("writes a public event with no email", async () => {
     const store = createMemoryActivityStore();
     const result = await recordGithubActivity("pull_request", pullRequestPayload(), store);

--- a/src/lib/activity-github.ts
+++ b/src/lib/activity-github.ts
@@ -48,6 +48,13 @@ export function isGithubBotActor(actor: unknown): boolean {
   return login !== undefined && GITHUB_BOT_LOGINS.has(login.toLowerCase());
 }
 
+/** Dependabot PRs only. Coding-agent bots (cursor[bot], etc.) are kept. */
+export function isDependabotActor(actor: unknown): boolean {
+  if (!isPlainObject(actor)) return false;
+  const login = asString(actor.login)?.toLowerCase();
+  return login !== undefined && (login === "dependabot[bot]" || login.startsWith("dependabot"));
+}
+
 export function verifyGithubWebhookSignature(
   rawBody: string,
   signatureHeader: string | null | undefined,
@@ -232,7 +239,7 @@ export function githubActivityFromWebhook(
     const prUser = pullRequest?.user;
 
     if (action === "opened") {
-      if (isGithubBotActor(prUser) || isGithubBotActor(sender)) {
+      if (isDependabotActor(prUser) || isDependabotActor(sender)) {
         return { status: "ignore", reason: "bot_actor" };
       }
       return pullRequestInput("pr_opened", payload, repository, isPrivate);
@@ -242,7 +249,7 @@ export function githubActivityFromWebhook(
       if (pullRequest?.merged !== true) {
         return { status: "ignore", reason: "closed_unmerged" };
       }
-      if (isGithubBotActor(sender)) {
+      if (isDependabotActor(sender) || isDependabotActor(prUser)) {
         return { status: "ignore", reason: "bot_actor" };
       }
       return pullRequestInput("pr_merged", payload, repository, isPrivate);

--- a/src/lib/activity-github.ts
+++ b/src/lib/activity-github.ts
@@ -48,10 +48,10 @@ function repoShortName(repository: Record<string, unknown>): string | undefined 
 
 function publicRepo(
   payload: Record<string, unknown>,
-): Record<string, unknown> | { ignore: string } {
-  if (!isPlainObject(payload.repository)) return { ignore: "missing_repo" };
-  if (payload.repository.private === true) return { ignore: "private_repo" };
-  return payload.repository;
+): { ok: true; repository: Record<string, unknown> } | { ok: false; reason: string } {
+  if (!isPlainObject(payload.repository)) return { ok: false, reason: "missing_repo" };
+  if (payload.repository.private === true) return { ok: false, reason: "private_repo" };
+  return { ok: true, repository: payload.repository };
 }
 
 function pullRequestInput(
@@ -137,8 +137,9 @@ export function githubActivityFromWebhook(
   if (githubEvent === "ping") return { status: "ignore", reason: "ping" };
   if (!isPlainObject(payload)) return { status: "ignore", reason: "invalid_payload" };
 
-  const repository = publicRepo(payload);
-  if ("ignore" in repository) return { status: "ignore", reason: repository.ignore };
+  const repoResult = publicRepo(payload);
+  if (!repoResult.ok) return { status: "ignore", reason: repoResult.reason };
+  const repository = repoResult.repository;
 
   if (githubEvent === "pull_request") {
     const action = asString(payload.action);

--- a/src/lib/activity-github.ts
+++ b/src/lib/activity-github.ts
@@ -1,0 +1,177 @@
+import { createHmac } from "crypto";
+
+import { ACTIVITY_SOURCE_GITHUB, type ActivityIngestInput } from "./activity-shared";
+import { safeCompare } from "./api-utils";
+
+const GITHUB_BOT_LOGINS = new Set(["dependabot[bot]", "cursor[bot]", "github-actions[bot]"]);
+
+export type GithubActivityDecision =
+  | { status: "ingest"; input: ActivityIngestInput }
+  | { status: "ignore"; reason: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function isGithubBotActor(actor: unknown): boolean {
+  if (!isPlainObject(actor)) return false;
+  if (actor.type === "Bot") return true;
+  const login = asString(actor.login);
+  return login !== undefined && GITHUB_BOT_LOGINS.has(login.toLowerCase());
+}
+
+export function verifyGithubWebhookSignature(
+  rawBody: string,
+  signatureHeader: string | null | undefined,
+  secret: string,
+): boolean {
+  const expected = `sha256=${createHmac("sha256", secret).update(rawBody).digest("hex")}`;
+  return safeCompare(signatureHeader, expected);
+}
+
+function repoShortName(repository: Record<string, unknown>): string | undefined {
+  const name = asString(repository.name);
+  if (name) return name;
+  const fullName = asString(repository.full_name);
+  if (!fullName) return undefined;
+  const short = fullName.split("/").pop();
+  return short || undefined;
+}
+
+function publicRepo(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | { ignore: string } {
+  if (!isPlainObject(payload.repository)) return { ignore: "missing_repo" };
+  if (payload.repository.private === true) return { ignore: "private_repo" };
+  return payload.repository;
+}
+
+function pullRequestInput(
+  type: "pr_opened" | "pr_merged",
+  payload: Record<string, unknown>,
+  repository: Record<string, unknown>,
+): GithubActivityDecision {
+  const pullRequest = isPlainObject(payload.pull_request) ? payload.pull_request : undefined;
+  const number = asNumber(pullRequest?.number) ?? asNumber(payload.number);
+  const repo = repoShortName(repository);
+  if (number === undefined || !repo) return { status: "ignore", reason: "incomplete_pr" };
+
+  const title = asString(pullRequest?.title) || "a pull request";
+  const href = asString(pullRequest?.html_url);
+  const summary =
+    type === "pr_opened" ? `Opened a pull request on ${repo}` : `Merged a pull request on ${repo}`;
+
+  return {
+    status: "ingest",
+    input: {
+      source: ACTIVITY_SOURCE_GITHUB,
+      type,
+      speed: "event",
+      summary,
+      visibility: "public",
+      idempotency_key: `github:${type}:${repo}:${number}`,
+      subject: {
+        kind: "pull_request",
+        label: title,
+        ...(href ? { href } : {}),
+      },
+      meta: {
+        repo,
+        title,
+        number,
+        ...(href ? { href } : {}),
+      },
+      idempotencyTtlSeconds: 0,
+    },
+  };
+}
+
+function starInput(
+  payload: Record<string, unknown>,
+  repository: Record<string, unknown>,
+): GithubActivityDecision {
+  const sender = isPlainObject(payload.sender) ? payload.sender : undefined;
+  const login = asString(sender?.login);
+  const repo = repoShortName(repository);
+  if (!login || !repo) return { status: "ignore", reason: "incomplete_star" };
+
+  const fullName = asString(repository.full_name);
+  const href = asString(repository.html_url);
+  const label = fullName || asString(repository.name) || repo;
+
+  return {
+    status: "ingest",
+    input: {
+      source: ACTIVITY_SOURCE_GITHUB,
+      type: "repo_starred",
+      speed: "event",
+      summary: `Someone starred ${repo}`,
+      visibility: "public",
+      idempotency_key: `github:star:${repo}:${login}`,
+      subject: {
+        kind: "repo",
+        label,
+        ...(href ? { href } : {}),
+      },
+      meta: {
+        repo,
+        ...(href ? { href } : {}),
+      },
+      idempotencyTtlSeconds: 0,
+    },
+  };
+}
+
+export function githubActivityFromWebhook(
+  githubEvent: string,
+  payload: unknown,
+): GithubActivityDecision {
+  if (githubEvent === "ping") return { status: "ignore", reason: "ping" };
+  if (!isPlainObject(payload)) return { status: "ignore", reason: "invalid_payload" };
+
+  const repository = publicRepo(payload);
+  if ("ignore" in repository) return { status: "ignore", reason: repository.ignore };
+
+  if (githubEvent === "pull_request") {
+    const action = asString(payload.action);
+    const pullRequest = isPlainObject(payload.pull_request) ? payload.pull_request : undefined;
+    const sender = isPlainObject(payload.sender) ? payload.sender : undefined;
+    const prUser = pullRequest?.user;
+
+    if (action === "opened") {
+      if (isGithubBotActor(prUser) || isGithubBotActor(sender)) {
+        return { status: "ignore", reason: "bot_actor" };
+      }
+      return pullRequestInput("pr_opened", payload, repository);
+    }
+
+    if (action === "closed") {
+      if (pullRequest?.merged !== true) {
+        return { status: "ignore", reason: "closed_unmerged" };
+      }
+      if (isGithubBotActor(sender)) {
+        return { status: "ignore", reason: "bot_actor" };
+      }
+      return pullRequestInput("pr_merged", payload, repository);
+    }
+
+    return { status: "ignore", reason: "ignored_pr_action" };
+  }
+
+  if (githubEvent === "star") {
+    const action = asString(payload.action);
+    if (action !== "created") return { status: "ignore", reason: "ignored_star_action" };
+    if (isGithubBotActor(payload.sender)) return { status: "ignore", reason: "bot_actor" };
+    return starInput(payload, repository);
+  }
+
+  return { status: "ignore", reason: "ignored_event" };
+}

--- a/src/lib/activity-github.ts
+++ b/src/lib/activity-github.ts
@@ -21,6 +21,26 @@ function asNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function asCount(value: unknown): number | undefined {
+  const n = asNumber(value);
+  return n !== undefined && n >= 0 ? n : undefined;
+}
+
+function pullRequestDiffMeta(pullRequest: Record<string, unknown> | undefined): {
+  additions?: number;
+  deletions?: number;
+  changed_files?: number;
+} {
+  const additions = asCount(pullRequest?.additions);
+  const deletions = asCount(pullRequest?.deletions);
+  const changedFiles = asCount(pullRequest?.changed_files);
+  return {
+    ...(additions !== undefined ? { additions } : {}),
+    ...(deletions !== undefined ? { deletions } : {}),
+    ...(changedFiles !== undefined ? { changed_files: changedFiles } : {}),
+  };
+}
+
 export function isGithubBotActor(actor: unknown): boolean {
   if (!isPlainObject(actor)) return false;
   if (actor.type === "Bot") return true;
@@ -91,6 +111,7 @@ function pullRequestInput(
         : `Merged a pull request on ${repoShortName(repository)}`;
 
   if (isPrivate) {
+    const diff = type === "pr_merged" ? pullRequestDiffMeta(pullRequest) : {};
     return {
       status: "ingest",
       input: {
@@ -101,7 +122,7 @@ function pullRequestInput(
         visibility: "public",
         idempotency_key: `github:${type}:${repoToken}:${number}`,
         subject: { kind: "pull_request", label: "a pull request" },
-        meta: { private: true, number },
+        meta: { private: true, number, ...diff },
         idempotencyTtlSeconds: 0,
       },
     };
@@ -110,6 +131,7 @@ function pullRequestInput(
   const title = asString(pullRequest?.title) || "a pull request";
   const href = asString(pullRequest?.html_url);
   const repo = repoShortName(repository);
+  const diff = type === "pr_merged" ? pullRequestDiffMeta(pullRequest) : {};
 
   return {
     status: "ingest",
@@ -130,6 +152,7 @@ function pullRequestInput(
         title,
         number,
         ...(href ? { href } : {}),
+        ...diff,
       },
       idempotencyTtlSeconds: 0,
     },

--- a/src/lib/activity-github.ts
+++ b/src/lib/activity-github.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "crypto";
+import { createHash, createHmac } from "crypto";
 
 import { ACTIVITY_SOURCE_GITHUB, type ActivityIngestInput } from "./activity-shared";
 import { safeCompare } from "./api-utils";
@@ -46,28 +46,70 @@ function repoShortName(repository: Record<string, unknown>): string | undefined 
   return short || undefined;
 }
 
-function publicRepo(
+function readRepository(
   payload: Record<string, unknown>,
-): { ok: true; repository: Record<string, unknown> } | { ok: false; reason: string } {
+):
+  | { ok: true; repository: Record<string, unknown>; isPrivate: boolean }
+  | { ok: false; reason: string } {
   if (!isPlainObject(payload.repository)) return { ok: false, reason: "missing_repo" };
-  if (payload.repository.private === true) return { ok: false, reason: "private_repo" };
-  return { ok: true, repository: payload.repository };
+  return {
+    ok: true,
+    repository: payload.repository,
+    isPrivate: payload.repository.private === true,
+  };
+}
+
+function repoIdempotencyToken(
+  repository: Record<string, unknown>,
+  isPrivate: boolean,
+): string | undefined {
+  const shortName = repoShortName(repository);
+  const raw = asString(repository.full_name) || shortName;
+  if (!raw) return undefined;
+  if (!isPrivate) return shortName ?? raw.split("/").pop();
+  return `private:${createHash("sha256").update(raw).digest("hex").slice(0, 16)}`;
 }
 
 function pullRequestInput(
   type: "pr_opened" | "pr_merged",
   payload: Record<string, unknown>,
   repository: Record<string, unknown>,
+  isPrivate: boolean,
 ): GithubActivityDecision {
   const pullRequest = isPlainObject(payload.pull_request) ? payload.pull_request : undefined;
   const number = asNumber(pullRequest?.number) ?? asNumber(payload.number);
-  const repo = repoShortName(repository);
-  if (number === undefined || !repo) return { status: "ignore", reason: "incomplete_pr" };
+  const repoToken = repoIdempotencyToken(repository, isPrivate);
+  if (number === undefined || !repoToken) return { status: "ignore", reason: "incomplete_pr" };
+
+  const summary =
+    type === "pr_opened"
+      ? isPrivate
+        ? "Opened a pull request"
+        : `Opened a pull request on ${repoShortName(repository)}`
+      : isPrivate
+        ? "Merged a pull request"
+        : `Merged a pull request on ${repoShortName(repository)}`;
+
+  if (isPrivate) {
+    return {
+      status: "ingest",
+      input: {
+        source: ACTIVITY_SOURCE_GITHUB,
+        type,
+        speed: "event",
+        summary,
+        visibility: "public",
+        idempotency_key: `github:${type}:${repoToken}:${number}`,
+        subject: { kind: "pull_request", label: "a pull request" },
+        meta: { private: true, number },
+        idempotencyTtlSeconds: 0,
+      },
+    };
+  }
 
   const title = asString(pullRequest?.title) || "a pull request";
   const href = asString(pullRequest?.html_url);
-  const summary =
-    type === "pr_opened" ? `Opened a pull request on ${repo}` : `Merged a pull request on ${repo}`;
+  const repo = repoShortName(repository);
 
   return {
     status: "ingest",
@@ -77,7 +119,7 @@ function pullRequestInput(
       speed: "event",
       summary,
       visibility: "public",
-      idempotency_key: `github:${type}:${repo}:${number}`,
+      idempotency_key: `github:${type}:${repoToken}:${number}`,
       subject: {
         kind: "pull_request",
         label: title,
@@ -97,15 +139,34 @@ function pullRequestInput(
 function starInput(
   payload: Record<string, unknown>,
   repository: Record<string, unknown>,
+  isPrivate: boolean,
 ): GithubActivityDecision {
   const sender = isPlainObject(payload.sender) ? payload.sender : undefined;
   const login = asString(sender?.login);
-  const repo = repoShortName(repository);
-  if (!login || !repo) return { status: "ignore", reason: "incomplete_star" };
+  const repoToken = repoIdempotencyToken(repository, isPrivate);
+  if (!login || !repoToken) return { status: "ignore", reason: "incomplete_star" };
 
+  if (isPrivate) {
+    return {
+      status: "ingest",
+      input: {
+        source: ACTIVITY_SOURCE_GITHUB,
+        type: "repo_starred",
+        speed: "event",
+        summary: "Someone starred a repository",
+        visibility: "public",
+        idempotency_key: `github:star:${repoToken}:${login}`,
+        subject: { kind: "repo", label: "a repository" },
+        meta: { private: true },
+        idempotencyTtlSeconds: 0,
+      },
+    };
+  }
+
+  const repo = repoShortName(repository);
   const fullName = asString(repository.full_name);
   const href = asString(repository.html_url);
-  const label = fullName || asString(repository.name) || repo;
+  const label = fullName || asString(repository.name) || repo || "a repository";
 
   return {
     status: "ingest",
@@ -115,7 +176,7 @@ function starInput(
       speed: "event",
       summary: `Someone starred ${repo}`,
       visibility: "public",
-      idempotency_key: `github:star:${repo}:${login}`,
+      idempotency_key: `github:star:${repoToken}:${login}`,
       subject: {
         kind: "repo",
         label,
@@ -137,9 +198,9 @@ export function githubActivityFromWebhook(
   if (githubEvent === "ping") return { status: "ignore", reason: "ping" };
   if (!isPlainObject(payload)) return { status: "ignore", reason: "invalid_payload" };
 
-  const repoResult = publicRepo(payload);
+  const repoResult = readRepository(payload);
   if (!repoResult.ok) return { status: "ignore", reason: repoResult.reason };
-  const repository = repoResult.repository;
+  const { repository, isPrivate } = repoResult;
 
   if (githubEvent === "pull_request") {
     const action = asString(payload.action);
@@ -151,7 +212,7 @@ export function githubActivityFromWebhook(
       if (isGithubBotActor(prUser) || isGithubBotActor(sender)) {
         return { status: "ignore", reason: "bot_actor" };
       }
-      return pullRequestInput("pr_opened", payload, repository);
+      return pullRequestInput("pr_opened", payload, repository, isPrivate);
     }
 
     if (action === "closed") {
@@ -161,7 +222,7 @@ export function githubActivityFromWebhook(
       if (isGithubBotActor(sender)) {
         return { status: "ignore", reason: "bot_actor" };
       }
-      return pullRequestInput("pr_merged", payload, repository);
+      return pullRequestInput("pr_merged", payload, repository, isPrivate);
     }
 
     return { status: "ignore", reason: "ignored_pr_action" };
@@ -171,7 +232,7 @@ export function githubActivityFromWebhook(
     const action = asString(payload.action);
     if (action !== "created") return { status: "ignore", reason: "ignored_star_action" };
     if (isGithubBotActor(payload.sender)) return { status: "ignore", reason: "bot_actor" };
-    return starInput(payload, repository);
+    return starInput(payload, repository, isPrivate);
   }
 
   return { status: "ignore", reason: "ignored_event" };

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -192,6 +192,15 @@ export function visibleLifetimeTotals(totals: ActivityTotal[]): ActivityTotal[] 
   return totals.filter((total) => shouldCountLifetimeTotal(total.type));
 }
 
+export function getMergedPullRequestDiff(
+  meta: Record<string, unknown> | undefined,
+): { additions: number; deletions: number } | null {
+  if (!meta) return null;
+  if (typeof meta.additions !== "number" || typeof meta.deletions !== "number") return null;
+  if (!Number.isFinite(meta.additions) || !Number.isFinite(meta.deletions)) return null;
+  return { additions: meta.additions, deletions: meta.deletions };
+}
+
 export function getActivityRow(event: ActivityEvent): {
   summary: string;
   flag?: string;

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -20,6 +20,7 @@ export const ACTIVITY_IDEMPOTENCY_TTL_SECONDS = 6 * 60 * 60;
 export const ACTIVITY_META_MAX_BYTES = 2048;
 export const ACTIVITY_BODY_MAX_BYTES = 8192;
 export const ACTIVITY_SOURCE_BRIOS = "brios";
+export const ACTIVITY_SOURCE_GITHUB = "github";
 
 /** CDN + browser cache for the public activity poll blob. */
 export const ACTIVITY_FEED_CACHE_CONTROL = "public, s-maxage=2, stale-while-revalidate=30";
@@ -256,6 +257,12 @@ export function formatTotalLabel(type: string): string {
       return "Design Details";
     case "app_dissection_published":
       return "App dissections";
+    case "pr_opened":
+      return "PRs opened";
+    case "pr_merged":
+      return "PRs merged";
+    case "repo_starred":
+      return "Stars";
     default:
       return type.replace(/_/g, " ");
   }

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -55,6 +55,7 @@ export {
   findForbiddenPii,
   formatTotalLabel,
   getActivityRow,
+  getMergedPullRequestDiff,
   getRequestCountry,
   inferContentTypeFromPath,
   inferTitleFromPath,

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -29,6 +29,7 @@ export { countryCodeToName, formatVisitSummary, getRequestGeo } from "./activity
 export type { GithubActivityDecision } from "./activity-github";
 export {
   githubActivityFromWebhook,
+  isDependabotActor,
   isGithubBotActor,
   verifyGithubWebhookSignature,
 } from "./activity-github";

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 
 import { type ActivityGeo, countryCodeToName, formatVisitSummary } from "./activity-geo";
+import { githubActivityFromWebhook } from "./activity-github";
 import {
   ACTIVITY_ENVELOPE_VERSION,
   ACTIVITY_IDEMPOTENCY_TTL_SECONDS,
@@ -25,6 +26,12 @@ import {
 
 export type { ActivityGeo } from "./activity-geo";
 export { countryCodeToName, formatVisitSummary, getRequestGeo } from "./activity-geo";
+export type { GithubActivityDecision } from "./activity-github";
+export {
+  githubActivityFromWebhook,
+  isGithubBotActor,
+  verifyGithubWebhookSignature,
+} from "./activity-github";
 export type {
   ActivityEvent,
   ActivityFeedPayload,
@@ -40,6 +47,7 @@ export {
   ACTIVITY_FEED_DEDUPING_MS,
   ACTIVITY_FEED_POLL_MS,
   ACTIVITY_SOURCE_BRIOS,
+  ACTIVITY_SOURCE_GITHUB,
   ACTIVITY_STREAM_MAXLEN,
   ACTIVITY_VISIT_STREAM_MAX_PER_SEC,
   activityFeedRefreshInterval,
@@ -294,6 +302,19 @@ export async function recordVisit(
     store,
     now,
   );
+}
+
+export async function recordGithubActivity(
+  githubEvent: string,
+  payload: unknown,
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult | { skipped: true; reason: string }> {
+  const decision = githubActivityFromWebhook(githubEvent, payload);
+  if (decision.status === "ignore") {
+    return { skipped: true, reason: decision.reason };
+  }
+  return ingestActivityEvent(decision.input, store, now);
 }
 
 export async function recordBriosEvent(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub can POST realtime events into the public `/activity` feed. This adds an in-process producer — it does **not** go through the HMAC ingest URL.

`main` was merged in to resolve conflicts with #2287 (caffeine activity). Both producers coexist.

## Endpoint

`POST /api/webhooks/github`

Verifies GitHub’s `X-Hub-Signature-256` (`sha256=`) against `GITHUB_ACTIVITY_WEBHOOK_SECRET` using `safeCompare`.

- Missing secret → 503
- Bad signature → 401
- Ignored events always return 200 so GitHub does not retry

Reads `X-GitHub-Event`. `ping` is acknowledged with 200 and not ingested. Everything else unknown is ignored.

## Events

| Type | GitHub event | Condition |
| --- | --- | --- |
| `pr_opened` | `pull_request` | action `opened` |
| `pr_merged` | `pull_request` | action `closed` AND `merged === true` |
| `repo_starred` | `star` | action `created` (`deleted` is ignored) |

`source: "github"`, `visibility: "public"`, `speed: "event"`.

`pr_merged` stores `additions`, `deletions`, and optional `changed_files` from the webhook payload. Summary stays `Merged a pull request on {repo}`. The activity row metadata slot shows `+N` in green and `-N` in red (`tabular-nums`) next to the PR title.

## Privacy

- Private repos are recorded. The public payload never includes the repo name, title, or URL (hrefs contain the name). Summaries are generic (`Opened a pull request`). Idempotency uses a hash of the full name.
- Dependabot PRs are skipped. Coding-agent PRs (`cursor[bot]` and other non-Dependabot bots) are kept.
- Stars from humans only.
- No emails. Login is used only for star idempotency.

## Hook setup

After `GITHUB_ACTIVITY_WEBHOOK_SECRET` is set in Vercel:

1. Repo → Settings → Webhooks → Add webhook
2. Payload URL: `https://brianlovin.com/api/webhooks/github`
3. Content type: `application/json`
4. Secret: same value as the env var
5. Events: Pull requests + Stars
6. GitHub sends a `ping`; 200 means the endpoint is up

Repeat per repo. A GitHub App webhook with the same URL/secret/events covers every repo on one install.

## UI

`ActivityFeed` uses the existing `Github` icon when `source === "github"`.

## Env

`GITHUB_ACTIVITY_WEBHOOK_SECRET` is documented in `.env.example` with no value.

## Tests

Signature verify, private repo recorded without name, Dependabot ignored, cursor[bot] PRs kept, merged vs closed-unmerged, merge stores additions/deletions, star created vs deleted, payload has no email.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d86cc182-5923-4b0b-b5fb-076850c04efe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d86cc182-5923-4b0b-b5fb-076850c04efe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

