### PR TITLE
Add shortcut-friendly caffeine activity events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,11 @@ UPSTASH_ACTIVITY_REST_TOKEN=
 # HMAC secret for POST /api/activity (later external producers)
 ACTIVITY_INGEST_HMAC_SECRET=
 
+# Shared token for POST /api/activity/caffeine (iOS Shortcut).
+# Send as `Authorization: Bearer <token>` or `x-activity-token`.
+# Set the same value in Vercel (Production + Preview). Do not commit a real token.
+ACTIVITY_CAFFEINE_TOKEN=
+
 # Likes system
 LIKES_HASH_SALT=
 LIKES_SYNC_TOKEN=

--- a/src/app/api/activity/caffeine/route.test.ts
+++ b/src/app/api/activity/caffeine/route.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { handleCaffeinePost } from "@/app/api/activity/caffeine/route";
+import { createMemoryActivityStore } from "@/lib/activity";
+
+const TEST_TOKEN = "test-caffeine-token";
+
+const originalToken = process.env.ACTIVITY_CAFFEINE_TOKEN;
+
+afterEach(() => {
+  if (originalToken === undefined) {
+    delete process.env.ACTIVITY_CAFFEINE_TOKEN;
+  } else {
+    process.env.ACTIVITY_CAFFEINE_TOKEN = originalToken;
+  }
+});
+
+function request(init: {
+  token?: string | null;
+  header?: "bearer" | "x-activity-token";
+  body?: unknown;
+}) {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (init.token) {
+    if (init.header === "x-activity-token") {
+      headers.set("x-activity-token", init.token);
+    } else {
+      headers.set("authorization", `Bearer ${init.token}`);
+    }
+  }
+
+  return new Request("https://brianlovin.com/api/activity/caffeine", {
+    method: "POST",
+    headers,
+    body:
+      init.body === undefined ? JSON.stringify({ drink: "cortado" }) : JSON.stringify(init.body),
+  });
+}
+
+describe("POST /api/activity/caffeine", () => {
+  test("returns 503 when ACTIVITY_CAFFEINE_TOKEN is missing", async () => {
+    delete process.env.ACTIVITY_CAFFEINE_TOKEN;
+    const res = await handleCaffeinePost(
+      request({ token: TEST_TOKEN }),
+      createMemoryActivityStore(),
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Caffeine ingest is not configured" });
+  });
+
+  test("returns 401 when the token is missing or wrong", async () => {
+    process.env.ACTIVITY_CAFFEINE_TOKEN = TEST_TOKEN;
+
+    const missing = await handleCaffeinePost(request({}), createMemoryActivityStore());
+    expect(missing.status).toBe(401);
+
+    const wrong = await handleCaffeinePost(request({ token: "nope" }), createMemoryActivityStore());
+    expect(wrong.status).toBe(401);
+    expect(await wrong.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  test("accepts Authorization Bearer or x-activity-token and records the drink", async () => {
+    process.env.ACTIVITY_CAFFEINE_TOKEN = TEST_TOKEN;
+    const store = createMemoryActivityStore();
+
+    const bearer = await handleCaffeinePost(request({ token: TEST_TOKEN }), store);
+    expect(bearer.status).toBe(200);
+    expect(await bearer.json()).toEqual({ ok: true });
+
+    const header = await handleCaffeinePost(
+      request({
+        token: TEST_TOKEN,
+        header: "x-activity-token",
+        body: { drink: "celsius", extra: "ignore" },
+      }),
+      store,
+    );
+    expect(header.status).toBe(200);
+    expect(await header.json()).toEqual({ ok: true });
+
+    const events = await store.getTail(10);
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.summary).sort()).toEqual([
+      "Caffeinated with Celsius",
+      "Caffeinated with Cortado",
+    ]);
+    expect(events.every((event) => event.meta && Object.keys(event.meta).join() === "drink")).toBe(
+      true,
+    );
+    expect(JSON.stringify(events)).not.toContain("@");
+    expect(JSON.stringify(events)).not.toContain("email");
+  });
+
+  test("returns 200 without writing when the store is missing", async () => {
+    process.env.ACTIVITY_CAFFEINE_TOKEN = TEST_TOKEN;
+    const res = await handleCaffeinePost(request({ token: TEST_TOKEN }), null);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("returns 200 when ingest throws so Redis failures fail open", async () => {
+    process.env.ACTIVITY_CAFFEINE_TOKEN = TEST_TOKEN;
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      const res = await handleCaffeinePost(request({ token: TEST_TOKEN }), {
+        claimIdempotency: async () => {
+          throw new Error("redis down");
+        },
+        incrementTotal: async () => {},
+        addToStream: async () => {},
+        getTail: async () => [],
+        getTotals: async () => [],
+        getStreamLength: async () => 0,
+        incrementVisitWindow: async () => 0,
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/src/app/api/activity/caffeine/route.ts
+++ b/src/app/api/activity/caffeine/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+
+import { type ActivityStore, recordCaffeine } from "@/lib/activity";
+import { getActivityStore } from "@/lib/activity-redis";
+import { ACTIVITY_BODY_MAX_BYTES, CAFFEINE_DRINK_MAX_LENGTH } from "@/lib/activity-shared";
+import { errorResponse, safeCompare } from "@/lib/api-utils";
+
+function providedToken(request: Request): string | null {
+  const headerToken = request.headers.get("x-activity-token");
+  if (headerToken) return headerToken;
+
+  const authorization = request.headers.get("authorization");
+  if (authorization?.toLowerCase().startsWith("bearer ")) {
+    return authorization.slice(7).trim();
+  }
+
+  return null;
+}
+
+/**
+ * Shortcut-friendly caffeine ingest.
+ * Auth is a shared bearer / x-activity-token — HMAC is painful inside Shortcuts.
+ */
+export async function handleCaffeinePost(
+  request: Request,
+  store: ActivityStore | null,
+): Promise<NextResponse> {
+  const expected = process.env.ACTIVITY_CAFFEINE_TOKEN;
+  if (!expected) {
+    return errorResponse("Caffeine ingest is not configured", 503);
+  }
+
+  if (!safeCompare(providedToken(request), expected)) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  const raw = await request.text();
+  if (raw.length > ACTIVITY_BODY_MAX_BYTES) {
+    return errorResponse("Payload too large", 413);
+  }
+
+  let drink: unknown;
+  try {
+    const body = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    drink = body.drink;
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+
+  if (typeof drink !== "string") {
+    return errorResponse("drink is required", 400);
+  }
+
+  const trimmed = drink.trim();
+  if (!trimmed || trimmed.length > CAFFEINE_DRINK_MAX_LENGTH) {
+    return errorResponse("drink is required", 400);
+  }
+
+  if (!store) {
+    return NextResponse.json({ ok: true });
+  }
+
+  try {
+    const result = await recordCaffeine({ drink: trimmed }, store);
+    if (!result.ok) {
+      return errorResponse(result.error, result.status);
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[activity] caffeine ingest failed", error);
+    return NextResponse.json({ ok: true });
+  }
+}
+
+export async function POST(request: Request) {
+  return handleCaffeinePost(request, getActivityStore());
+}

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -78,4 +78,40 @@ describe("ActivityRow", () => {
     expect(visit).not.toContain("text-red-500");
     expect(visit).toContain("🇮🇳");
   });
+
+  test("shows a coffee cup for coffee-family caffeine events", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "caffeinated",
+          speed: "event",
+          summary: "Caffeinated with Cortado",
+          subject: { kind: "drink", label: "Cortado" },
+          meta: { drink: "Cortado" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("☕");
+    expect(markup).toContain("Caffeinated with Cortado");
+    expect(markup).not.toContain("🥤");
+  });
+
+  test("shows a cup for celsius, tea, and unknown caffeine events", () => {
+    for (const drink of ["Celsius", "Tea", "Mystery Juice"]) {
+      const markup = renderToStaticMarkup(
+        <ActivityRow
+          event={event({
+            type: "caffeinated",
+            speed: "event",
+            summary: `Caffeinated with ${drink}`,
+            subject: { kind: "drink", label: drink },
+            meta: { drink },
+          })}
+        />,
+      );
+      expect(markup).toContain("🥤");
+      expect(markup).not.toContain("☕");
+    }
+  });
 });

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -63,7 +63,15 @@ function RelativeTime({ iso }: { iso: string }) {
   );
 }
 
-function ActivityRowIcon({ event, flag }: { event: ActivityEvent; flag?: string }) {
+function ActivityRowIcon({
+  event,
+  flag,
+  icon,
+}: {
+  event: ActivityEvent;
+  flag?: string;
+  icon?: string;
+}) {
   if (event.type === "like") {
     return <Heart size={16} className="fill-current text-red-500" aria-hidden />;
   }
@@ -79,6 +87,14 @@ function ActivityRowIcon({ event, flag }: { event: ActivityEvent; flag?: string 
     return <World size={16} className="text-tertiary" aria-hidden />;
   }
 
+  if (event.type === "caffeinated") {
+    return (
+      <span className="text-base leading-none" aria-hidden>
+        {icon ?? "🥤"}
+      </span>
+    );
+  }
+
   return <Activity size={16} className="text-tertiary" aria-hidden />;
 }
 
@@ -89,7 +105,7 @@ export function ActivityRow({ event }: { event: ActivityEvent }) {
   return (
     <div className="border-secondary hover:bg-secondary grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 border-b px-4 py-3 md:gap-4 md:py-2 md:dark:hover:bg-white/5">
       <div className="flex size-8 items-center justify-center">
-        <ActivityRowIcon event={event} flag={row.flag} />
+        <ActivityRowIcon event={event} flag={row.flag} icon={row.icon} />
       </div>
       <div className="min-w-0">
         <p className="text-primary truncate text-pretty">{row.summary}</p>

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -191,12 +191,77 @@ export function visibleLifetimeTotals(totals: ActivityTotal[]): ActivityTotal[] 
   return totals.filter((total) => shouldCountLifetimeTotal(total.type));
 }
 
+export const CAFFEINE_DRINK_MAX_LENGTH = 40;
+export const CAFFEINE_COFFEE_ICON = "☕";
+export const CAFFEINE_OTHER_ICON = "🥤";
+
+/** Coffee-family drinks render ☕; everything else caffeinated is 🥤. */
+const COFFEE_FAMILY_TERMS = [
+  "pour over",
+  "cold brew",
+  "flat white",
+  "cappuccino",
+  "cappucino",
+  "americano",
+  "macchiato",
+  "gibraltar",
+  "affogato",
+  "espresso",
+  "cortado",
+  "coffee",
+  "mocha",
+  "latte",
+  "nitro",
+  "drip",
+];
+
+export function titleCaseWords(value: string): string {
+  return value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export function normalizeCaffeineDrink(drink: string): string | null {
+  const collapsed = drink.trim().replace(/\s+/g, " ");
+  if (!collapsed || collapsed.length > CAFFEINE_DRINK_MAX_LENGTH) return null;
+  return titleCaseWords(collapsed);
+}
+
+export function isCoffeeFamilyDrink(drink: string): boolean {
+  const normalized = drink.toLowerCase().trim();
+  if (!normalized) return false;
+  return COFFEE_FAMILY_TERMS.some((term) => normalized === term || normalized.includes(term));
+}
+
+export function getCaffeineIcon(drink: string | null | undefined): string {
+  return drink && isCoffeeFamilyDrink(drink) ? CAFFEINE_COFFEE_ICON : CAFFEINE_OTHER_ICON;
+}
+
+export function caffeineDrinkFromEvent(event: ActivityEvent): string {
+  if (typeof event.meta?.drink === "string") return event.meta.drink;
+  if (event.subject?.kind === "drink") return event.subject.label;
+  return "";
+}
+
 export function getActivityRow(event: ActivityEvent): {
   summary: string;
   flag?: string;
+  icon?: string;
   href?: string;
   label?: string;
 } {
+  if (event.type === "caffeinated") {
+    return {
+      summary: event.summary,
+      icon: getCaffeineIcon(caffeineDrinkFromEvent(event)),
+      href: event.subject?.href,
+      label: event.subject?.label,
+    };
+  }
+
   if (event.type === "visit") {
     const geo = geoFromVisitMeta(event.meta);
     const full =
@@ -256,6 +321,8 @@ export function formatTotalLabel(type: string): string {
       return "Design Details";
     case "app_dissection_published":
       return "App dissections";
+    case "caffeinated":
+      return "Caffeinated";
     default:
       return type.replace(/_/g, " ");
   }

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -7,11 +7,13 @@ import {
   findForbiddenPii,
   formatVisitSummary,
   getActivityRow,
+  getCaffeineIcon,
   getRequestCountry,
   getRequestGeo,
   hashDigestSubscriber,
   ingestActivityEvent,
   likeMetaFromRequest,
+  recordCaffeine,
   recordDigestSubscribed,
   recordLike,
   recordVisit,
@@ -574,5 +576,104 @@ describe("shouldRecordVisit / likeMetaFromRequest", () => {
       }),
     );
     expect(activity).toBeNull();
+  });
+});
+
+describe("recordCaffeine", () => {
+  test("writes a public caffeinated event with title-cased summary and drink-only meta", async () => {
+    const store = createMemoryActivityStore();
+    const now = new Date("2026-08-16T15:04:05.000Z");
+    const result = await recordCaffeine({ drink: "cortado" }, store, now);
+
+    expect(result.ok && !result.duplicate).toBe(true);
+    const [event] = await store.getTail(1);
+    expect(event?.source).toBe("brios");
+    expect(event?.type).toBe("caffeinated");
+    expect(event?.speed).toBe("event");
+    expect(event?.visibility).toBe("public");
+    expect(event?.summary).toBe("Caffeinated with Cortado");
+    expect(event?.subject).toEqual({ kind: "drink", label: "Cortado" });
+    expect(event?.meta).toEqual({ drink: "Cortado" });
+    expect(event?.idempotency_key).toMatch(/^brios:caffeinated:2026-08-16:cortado:[0-9a-f-]{36}$/);
+    expect(getActivityRow(event!)).toEqual({
+      summary: "Caffeinated with Cortado",
+      icon: "☕",
+      label: "Cortado",
+    });
+    expect(findForbiddenPii(event)).toBeNull();
+    expect(JSON.stringify(event)).not.toContain("@");
+    expect(event?.meta).not.toHaveProperty("email");
+    expect(event?.meta).not.toHaveProperty("authorization");
+    expect(event?.actor).toBeUndefined();
+  });
+
+  test("counts two of the same drink on the same day as separate events", async () => {
+    const store = createMemoryActivityStore();
+    const now = new Date("2026-08-16T15:04:05.000Z");
+    const first = await recordCaffeine({ drink: "coffee" }, store, now);
+    const second = await recordCaffeine({ drink: "coffee" }, store, now);
+
+    expect(first.ok && !first.duplicate).toBe(true);
+    expect(second.ok && !second.duplicate).toBe(true);
+    expect(await store.getStreamLength()).toBe(2);
+    expect(await store.getTotals()).toEqual([
+      expect.objectContaining({ source: "brios", type: "caffeinated", count: 2 }),
+    ]);
+  });
+
+  test("rejects an empty drink and an email drink before writing", async () => {
+    const store = createMemoryActivityStore();
+    expect(await recordCaffeine({ drink: "   " }, store)).toEqual({
+      ok: false,
+      error: "drink is required",
+      status: 400,
+    });
+
+    const pii = await recordCaffeine({ drink: "hi@example.com" }, store);
+    expect(pii.ok).toBe(false);
+    if (!pii.ok) expect(pii.error).toContain("forbidden");
+    expect(await store.getStreamLength()).toBe(0);
+  });
+});
+
+describe("getCaffeineIcon", () => {
+  test("uses a coffee cup for coffee-family drinks", () => {
+    for (const drink of [
+      "coffee",
+      "Espresso",
+      "latte",
+      "cappuccino",
+      "cappucino",
+      "cortado",
+      "macchiato",
+      "mocha",
+      "americano",
+      "flat white",
+      "drip",
+      "pour over",
+      "cold brew",
+      "nitro",
+      "affogato",
+      "gibraltar",
+      "iced latte",
+    ]) {
+      expect(getCaffeineIcon(drink)).toBe("☕");
+    }
+  });
+
+  test("uses a cup for other caffeinated drinks and unknowns", () => {
+    for (const drink of [
+      "celsius",
+      "tea",
+      "matcha",
+      "energy",
+      "soda",
+      "coke",
+      "yerba",
+      "preworkout",
+      "unknown",
+    ]) {
+      expect(getCaffeineIcon(drink)).toBe("🥤");
+    }
   });
 });

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -18,6 +18,7 @@ import {
   inferContentTypeFromPath,
   inferTitleFromPath,
   isActivityPath,
+  normalizeCaffeineDrink,
   shouldCountLifetimeTotal,
   shouldRecordVisit,
   visibleLifetimeTotals,
@@ -47,11 +48,14 @@ export {
   findForbiddenPii,
   formatTotalLabel,
   getActivityRow,
+  getCaffeineIcon,
   getRequestCountry,
   inferContentTypeFromPath,
   inferTitleFromPath,
   isActivityFeedPayload,
   isActivityPath,
+  isCoffeeFamilyDrink,
+  normalizeCaffeineDrink,
   shouldCountLifetimeTotal,
   shouldRecordVisit,
   visibleLifetimeTotals,
@@ -290,6 +294,35 @@ export async function recordVisit(
         title,
       },
       writeToStream,
+    },
+    store,
+    now,
+  );
+}
+
+export async function recordCaffeine(
+  input: { drink: string },
+  store: ActivityStore,
+  now: Date = new Date(),
+): Promise<IngestResult> {
+  const drink = normalizeCaffeineDrink(input.drink);
+  if (!drink) {
+    return { ok: false, error: "drink is required", status: 400 };
+  }
+
+  const day = now.toISOString().slice(0, 10);
+  const slug = drink.toLowerCase().replace(/\s+/g, "-");
+
+  return ingestActivityEvent(
+    {
+      source: ACTIVITY_SOURCE_BRIOS,
+      type: "caffeinated",
+      speed: "event",
+      summary: `Caffeinated with ${drink}`,
+      visibility: "public",
+      idempotency_key: `brios:caffeinated:${day}:${slug}:${crypto.randomUUID()}`,
+      subject: { kind: "drink", label: drink },
+      meta: { drink },
     },
     store,
     now,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HMAC ingest (`POST /api/activity`) is painful inside iOS Shortcuts. This adds a tiny dedicated endpoint so an NFC tap can record a drink on the public `/activity` feed.

## Endpoint

`POST https://brianlovin.com/api/activity/caffeine`

- Auth: `Authorization: Bearer <token>` or `x-activity-token`, compared with `safeCompare` against `ACTIVITY_CAFFEINE_TOKEN`
- Missing env token → `503`
- Bad / missing request token → `401`
- Body: `{ "drink": "cortado" }` (extra keys ignored; drink is a short string)
- Returns `{ "ok": true }` quickly
- Redis / store failures fail open (same idea as visit ingest) — never throw to the Shortcut

Event written via `recordCaffeine({ drink })` → `ingestActivityEvent`:

- source: `brios`
- type: `caffeinated`
- speed: `event`
- visibility: `public`
- summary: `Caffeinated with {Drink}` (title case)
- idempotency: `brios:caffeinated:{yyyy-mm-dd}:{drink}:{uuid}` so two coffees the same day both count
- meta: `{ drink }` only
- subject: `{ kind: "drink", label: drink }`

## Icons

- Coffee-family (coffee, espresso, latte, cappuccino / cappucino, cortado, macchiato, mocha, americano, flat white, drip, pour over, cold brew, nitro, affogato, gibraltar) → ☕
- Everything else (celsius, tea, matcha, unknown, …) → 🥤

## Vercel

Set `ACTIVITY_CAFFEINE_TOKEN` in the Vercel project (Production + Preview). Do not commit a token. Put the same value in the Shortcut header.

## iOS Shortcut recipe

1. **Receive/ask for input.** Add a List or Ask for Input action: “What did you have?” with presets **Coffee**, **Latte**, **Cortado**, **Cappuccino**, **Tea**, **Celsius**, plus **Ask Each Time**.
2. **Get Contents of URL**
   - Method: `POST`
   - URL: `https://brianlovin.com/api/activity/caffeine`
   - Headers: `Authorization` = `Bearer ` + your token (the one you set as `ACTIVITY_CAFFEINE_TOKEN` in Vercel — do not put a real token in git)
   - Request body: JSON
     ```json
     {"drink":"<Shortcut input>"}
     ```
     Map `<Shortcut input>` to the List / Ask result from step 1.
3. That’s it. Point the NFC tag at this Shortcut.

## Tests

- Auth missing / wrong / unconfigured
- Coffee-family → ☕, celsius / tea / unknown → 🥤
- Summary `Caffeinated with Cortado`
- No PII in the stored payload
- Same drink twice in one day both count
- Redis throw → `200 { ok: true }`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a80cce6-244b-4441-a2bb-f5be5fecdf94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a80cce6-244b-4441-a2bb-f5be5fecdf94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

