### PR TITLE
Ignore Safari extension sendMessage noise in Sentry

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,10 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import { initBotId } from "botid/client/core";
 
 import { HN_BOTID_PROTECTED_ROUTES } from "@/lib/botid";
-import {
-  SENTRY_DENY_URLS,
-  SENTRY_IGNORE_ERRORS,
-} from "@/lib/observability/client-filters";
+import { SENTRY_DENY_URLS, SENTRY_IGNORE_ERRORS } from "@/lib/observability/client-filters";
 
 initBotId({
   protect: [...HN_BOTID_PROTECTED_ROUTES],

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,6 +2,10 @@ import * as Sentry from "@sentry/nextjs";
 import { initBotId } from "botid/client/core";
 
 import { HN_BOTID_PROTECTED_ROUTES } from "@/lib/botid";
+import {
+  SENTRY_DENY_URLS,
+  SENTRY_IGNORE_ERRORS,
+} from "@/lib/observability/client-filters";
 
 initBotId({
   protect: [...HN_BOTID_PROTECTED_ROUTES],
@@ -12,6 +16,10 @@ Sentry.init({
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
+
+  // Drop browser-extension noise (e.g. BRIOS-1 Safari runtime.sendMessage).
+  ignoreErrors: SENTRY_IGNORE_ERRORS,
+  denyUrls: SENTRY_DENY_URLS,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/src/lib/observability/client-filters.test.ts
+++ b/src/lib/observability/client-filters.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { matchesIgnoreError, SENTRY_IGNORE_ERRORS } from "@/lib/observability/client-filters";
+
+describe("matchesIgnoreError", () => {
+  test("ignores the BRIOS-1 Safari extension message", () => {
+    expect(
+      matchesIgnoreError("Invalid call to runtime.sendMessage(). Tab not found."),
+    ).toBe(true);
+  });
+
+  test("ignores related browser-extension messaging failures", () => {
+    expect(matchesIgnoreError("Extension context invalidated.")).toBe(true);
+    expect(
+      matchesIgnoreError(
+        "The message port closed before a response was received.",
+      ),
+    ).toBe(true);
+    expect(
+      matchesIgnoreError(
+        "Could not establish connection. Receiving end does not exist.",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not ignore application errors", () => {
+    expect(matchesIgnoreError("TypeError: Cannot read properties of undefined")).toBe(
+      false,
+    );
+    expect(matchesIgnoreError("Failed to fetch")).toBe(false);
+    expect(matchesIgnoreError("")).toBe(false);
+  });
+
+  test("supports regex patterns the same way Sentry does", () => {
+    expect(matchesIgnoreError("Exact Match Message", [/^Exact Match Message$/])).toBe(
+      true,
+    );
+    expect(matchesIgnoreError("Exact Match Message extra", [/^Exact Match Message$/])).toBe(
+      false,
+    );
+  });
+
+  test("exports the patterns used by the client SDK", () => {
+    expect(SENTRY_IGNORE_ERRORS.length).toBeGreaterThan(0);
+    expect(SENTRY_IGNORE_ERRORS).toContain("Invalid call to runtime.sendMessage()");
+  });
+});

--- a/src/lib/observability/client-filters.test.ts
+++ b/src/lib/observability/client-filters.test.ts
@@ -4,40 +4,28 @@ import { matchesIgnoreError, SENTRY_IGNORE_ERRORS } from "@/lib/observability/cl
 
 describe("matchesIgnoreError", () => {
   test("ignores the BRIOS-1 Safari extension message", () => {
-    expect(
-      matchesIgnoreError("Invalid call to runtime.sendMessage(). Tab not found."),
-    ).toBe(true);
+    expect(matchesIgnoreError("Invalid call to runtime.sendMessage(). Tab not found.")).toBe(true);
   });
 
   test("ignores related browser-extension messaging failures", () => {
     expect(matchesIgnoreError("Extension context invalidated.")).toBe(true);
+    expect(matchesIgnoreError("The message port closed before a response was received.")).toBe(
+      true,
+    );
     expect(
-      matchesIgnoreError(
-        "The message port closed before a response was received.",
-      ),
-    ).toBe(true);
-    expect(
-      matchesIgnoreError(
-        "Could not establish connection. Receiving end does not exist.",
-      ),
+      matchesIgnoreError("Could not establish connection. Receiving end does not exist."),
     ).toBe(true);
   });
 
   test("does not ignore application errors", () => {
-    expect(matchesIgnoreError("TypeError: Cannot read properties of undefined")).toBe(
-      false,
-    );
+    expect(matchesIgnoreError("TypeError: Cannot read properties of undefined")).toBe(false);
     expect(matchesIgnoreError("Failed to fetch")).toBe(false);
     expect(matchesIgnoreError("")).toBe(false);
   });
 
   test("supports regex patterns the same way Sentry does", () => {
-    expect(matchesIgnoreError("Exact Match Message", [/^Exact Match Message$/])).toBe(
-      true,
-    );
-    expect(matchesIgnoreError("Exact Match Message extra", [/^Exact Match Message$/])).toBe(
-      false,
-    );
+    expect(matchesIgnoreError("Exact Match Message", [/^Exact Match Message$/])).toBe(true);
+    expect(matchesIgnoreError("Exact Match Message extra", [/^Exact Match Message$/])).toBe(false);
   });
 
   test("exports the patterns used by the client SDK", () => {

--- a/src/lib/observability/client-filters.ts
+++ b/src/lib/observability/client-filters.ts
@@ -1,0 +1,36 @@
+/**
+ * Client-side Sentry filters for noise that is not application code.
+ *
+ * BRIOS-1 is a Safari Web Extension error: a content script called
+ * `runtime.sendMessage()` after the tab was gone. That API is not used
+ * anywhere in this repo. The rejection has no stack frames, so denyUrls
+ * cannot catch it — ignoreErrors must match the message.
+ *
+ * Sentry treats string patterns as substring matches.
+ */
+
+export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
+  // Safari Web Extension: content script messages a missing tab.
+  "Invalid call to runtime.sendMessage()",
+  // Chrome / Firefox: extension was reloaded, updated, or its background page died.
+  "Extension context invalidated",
+  "message port closed before a response was received",
+  "Could not establish connection. Receiving end does not exist",
+];
+
+export const SENTRY_DENY_URLS: Array<string | RegExp> = [
+  /^chrome-extension:\/\//i,
+  /^moz-extension:\/\//i,
+  /^safari-extension:\/\//i,
+  /^safari-web-extension:\/\//i,
+  /^webkit-masked-url:\/\//i,
+];
+
+export function matchesIgnoreError(
+  message: string,
+  patterns: Array<string | RegExp> = SENTRY_IGNORE_ERRORS,
+): boolean {
+  return patterns.some((pattern) =>
+    typeof pattern === "string" ? message.includes(pattern) : pattern.test(message),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes BRIOS-1.

## Investigation

[BRIOS-1](https://brianlovin.sentry.io/issues/BRIOS-1) is not an application bug. The homepage loaded normally (~442ms pageload, visit beacon, writing prefetch) and then Safari reported an unhandled rejection:

`Invalid call to runtime.sendMessage(). Tab not found.`

- No stack frames
- Mobile Safari 26.6 / iOS 18.7
- Mechanism: `auto.browser.global_handlers.onunhandledrejection`
- `runtime.sendMessage()` is a WebExtensions API and is not used anywhere in this repo (or by BotID / Sentry client code)

This is a Safari Web Extension content script messaging a tab that no longer exists (password manager, ad blocker, translator, etc.). Sentry's global rejection handler captures it as if it came from the page.

## Fix

Drop this class of noise in the browser SDK before it is sent:

- `ignoreErrors` for the BRIOS-1 message and related Chrome/Firefox extension messaging failures
- `denyUrls` for extension script schemes (helps when a stack frame *is* present)

`denyUrls` alone cannot catch BRIOS-1 because there are no frames to match.

## Verification

- `bun test src/lib/observability/client-filters.test.ts` — 5 pass
- `bun run lint` — clean
- `bun run build` — compiled successfully

Optional follow-up in the Sentry project: enable the inbound filter **Filter out errors known to be caused by browser extensions**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9640893f-0f29-4734-9ee8-e68aa4fcd9e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9640893f-0f29-4734-9ee8-e68aa4fcd9e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

