### PR TITLE
Omit placeholder region 00 from visit location summaries

### DIFF
--- a/src/lib/activity-geo.ts
+++ b/src/lib/activity-geo.ts
@@ -381,6 +381,8 @@ const REGION_NAMES: Record<string, Record<string, string>> = {
 };
 
 const REGION_RE = /^[A-Z0-9]{1,3}$/;
+const PLACEHOLDER_REGION_RE = /^0+$/;
+const ALL_DIGITS_SHORT_RE = /^\d{1,3}$/;
 
 export function countryCodeToName(value: string | null | undefined): string {
   const code = value?.trim().toUpperCase() ?? "";
@@ -392,6 +394,7 @@ export function normalizeRegionCode(value: string | null | undefined): string | 
   if (!value) return undefined;
   const code = value.trim().toUpperCase();
   if (!REGION_RE.test(code)) return undefined;
+  if (PLACEHOLDER_REGION_RE.test(code)) return undefined;
   return code;
 }
 
@@ -406,7 +409,21 @@ export function regionCodeToName(
     const mapped = REGION_NAMES[countryCode]?.[regionCode];
     if (mapped) return mapped;
   }
-  return regionCode;
+  return "";
+}
+
+/** Skip empty, all-zero, all-digit short codes, and unmapped 2-char ISO codes. */
+function isUsableRegionLabel(
+  label: string | undefined,
+  country: string | undefined,
+): label is string {
+  if (!label) return false;
+  const code = label.trim().toUpperCase();
+  if (!code) return false;
+  if (PLACEHOLDER_REGION_RE.test(code)) return false;
+  if (ALL_DIGITS_SHORT_RE.test(code)) return false;
+  if (code.length === 2 && !regionCodeToName(country, code)) return false;
+  return true;
 }
 
 export function decodeHeaderText(value: string | null | undefined): string | undefined {
@@ -437,8 +454,11 @@ export function getRequestGeo(headers: Headers): ActivityGeo {
     firstHeader(headers, ["cf-region-code", "x-vercel-ip-country-region"]),
   );
   const regionFromNameHeader = decodeHeaderText(firstHeader(headers, ["cf-region"]));
-  const regionName =
-    regionFromNameHeader || (country && region ? regionCodeToName(country, region) : undefined);
+  const mappedRegionName = country && region ? regionCodeToName(country, region) : "";
+  const regionNameCandidate = regionFromNameHeader || mappedRegionName || undefined;
+  const regionName = isUsableRegionLabel(regionNameCandidate, country)
+    ? regionNameCandidate
+    : undefined;
   const city = decodeHeaderText(firstHeader(headers, ["cf-ipcity", "x-vercel-ip-city"]));
 
   return {
@@ -463,7 +483,13 @@ export function formatVisitSummary(geo: {
     decodeHeaderText(geo.countryName) ||
     (country ? countryCodeToName(country) : undefined) ||
     rawCountry;
-  const regionLabel = decodeHeaderText(geo.regionName) || decodeHeaderText(geo.region);
+  const rawRegionName = decodeHeaderText(geo.regionName);
+  const rawRegion = decodeHeaderText(geo.region);
+  const mappedRegion = regionCodeToName(country, rawRegion);
+  const regionLabel =
+    (isUsableRegionLabel(rawRegionName, country) ? rawRegionName : undefined) ||
+    mappedRegion ||
+    (isUsableRegionLabel(rawRegion, country) ? rawRegion : undefined);
   const city = decodeHeaderText(geo.city);
 
   let location: string | undefined;
@@ -506,13 +532,19 @@ export function geoFromVisitMeta(meta: Record<string, unknown> | undefined): {
   city?: string;
 } {
   if (!meta) return {};
+  const country = typeof meta.country === "string" ? meta.country : undefined;
+  const region = normalizeRegionCode(
+    typeof meta.region === "string" ? decodeHeaderText(meta.region) : undefined,
+  );
+  const regionNameRaw =
+    typeof meta.region_name === "string" ? decodeHeaderText(meta.region_name) : undefined;
+  const regionName = isUsableRegionLabel(regionNameRaw, country) ? regionNameRaw : undefined;
   return {
-    country: typeof meta.country === "string" ? meta.country : undefined,
+    country,
     countryName:
       typeof meta.country_name === "string" ? decodeHeaderText(meta.country_name) : undefined,
-    region: typeof meta.region === "string" ? decodeHeaderText(meta.region) : undefined,
-    regionName:
-      typeof meta.region_name === "string" ? decodeHeaderText(meta.region_name) : undefined,
+    ...(region ? { region } : {}),
+    ...(regionName ? { regionName } : {}),
     city: typeof meta.city === "string" ? decodeHeaderText(meta.city) : undefined,
   };
 }

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -25,7 +25,7 @@ import {
   shouldRecordVisit,
   visibleLifetimeTotals,
 } from "@/lib/activity";
-import { geoFromVisitMeta } from "@/lib/activity-geo";
+import { geoFromVisitMeta, normalizeRegionCode } from "@/lib/activity-geo";
 import { parseActivityStreamFields } from "@/lib/activity-redis";
 import { ACTIVITY_STREAM_MAXLEN, ACTIVITY_VISIT_STREAM_MAX_PER_SEC } from "@/lib/activity-shared";
 
@@ -314,6 +314,53 @@ describe("formatVisitSummary", () => {
     );
     expect(summary).toContain("San Francisco");
     expect(summary).not.toContain("San%20Francisco");
+  });
+
+  test("omits placeholder region 00 so Belgrade is city + country", () => {
+    const summary = formatVisitSummary({
+      city: "Belgrade",
+      region: "00",
+      country: "RS",
+    });
+    expect(summary).toContain("Belgrade");
+    expect(summary).toContain("Serbia");
+    expect(summary).not.toContain("00");
+
+    const fromStoredMeta = formatVisitSummary(
+      geoFromVisitMeta({
+        city: "Belgrade",
+        region: "00",
+        region_name: "00",
+        country: "RS",
+      }),
+    );
+    expect(fromStoredMeta).toContain("Belgrade");
+    expect(fromStoredMeta).toContain("Serbia");
+    expect(fromStoredMeta).not.toContain("00");
+  });
+
+  test("still includes a mapped US region for San Francisco", () => {
+    const summary = formatVisitSummary({
+      city: "San Francisco",
+      region: "CA",
+      country: "US",
+    });
+    expect(summary).toContain("San Francisco");
+    expect(summary).toMatch(/California|\bCA\b/);
+    expect(summary).not.toContain("00");
+  });
+});
+
+describe("normalizeRegionCode", () => {
+  test("returns undefined for placeholder all-zero codes", () => {
+    expect(normalizeRegionCode("00")).toBeUndefined();
+    expect(normalizeRegionCode("0")).toBeUndefined();
+    expect(normalizeRegionCode("000")).toBeUndefined();
+  });
+
+  test("keeps a real ISO-3166-2 region code", () => {
+    expect(normalizeRegionCode("CA")).toBe("CA");
+    expect(normalizeRegionCode("nsw")).toBe("NSW");
   });
 });
 
@@ -723,6 +770,23 @@ describe("getRequestGeo", () => {
       city: "Bengaluru",
     });
     expect(JSON.stringify(geo)).not.toContain("203.0.113");
+  });
+
+  test("omits placeholder Vercel region 00", () => {
+    const geo = getRequestGeo(
+      new Headers({
+        "x-vercel-ip-country": "RS",
+        "x-vercel-ip-country-region": "00",
+        "x-vercel-ip-city": "Belgrade",
+      }),
+    );
+    expect(geo).toEqual({
+      country: "RS",
+      countryName: "Serbia",
+      city: "Belgrade",
+    });
+    expect(geo).not.toHaveProperty("region");
+    expect(geo).not.toHaveProperty("regionName");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Vercel and Cloudflare send `x-vercel-ip-country-region: 00` when a country has no ISO-3166-2 subdivision. Visit rows were rendering that placeholder as a state, e.g. “Belgrade, 00, Serbia”.

## Changes

In `src/lib/activity-geo.ts` only:

- `normalizeRegionCode` returns `undefined` for all-zero placeholders (`00`, `0`, `000`)
- `regionCodeToName` returns `""` when there is no mapped name instead of echoing the raw code
- `formatVisitSummary` skips empty / `00` / all-digit short codes / unmapped 2-char codes when choosing `regionLabel`, so the existing city + country branch produces “Belgrade, Serbia”
- `getRequestGeo` omits `region` / `regionName` when the code normalizes away
- `geoFromVisitMeta` applies the same skip so already-stored Redis events with `meta.region` / `meta.region_name` of `"00"` render correctly without a replay

US/`CA` still maps to California. Ingest HMAC, favicons, and the activity UI are untouched.

## Tests

- `{ city: "Belgrade", region: "00", country: "RS" }` → “Belgrade” + “Serbia”, no `00` (including stored meta)
- `{ city: "San Francisco", region: "CA", country: "US" }` still includes California
- `normalizeRegionCode("00")` is `undefined`
- `getRequestGeo` with Vercel `00` does not set `region` / `regionName`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-291faa9d-48ad-4295-b641-84947b40ff61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-291faa9d-48ad-4295-b641-84947b40ff61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

