### PR TITLE
Allow Shiori link_clicked events on the activity feed

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -478,6 +478,27 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain("<a ");
   });
 
+  test("renders a Shiori link_clicked row like a save, without leaking a URL", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "shiori",
+          type: "link_clicked",
+          speed: "event",
+          summary: "Someone clicked a link on Shiori",
+          subject: { kind: "link", label: "A saved page", href: "https://example.com/secret" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("shiori-icon.png");
+    expect(markup).toContain("Someone clicked a link on Shiori");
+    expect(markup).not.toContain("A saved page");
+    expect(markup).not.toContain("example.com");
+    expect(markup).not.toContain("<a ");
+    expect(markup).not.toContain("https://");
+  });
+
   test("shows a tertiary count next to the title when a stack is larger than one", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow

--- a/src/lib/activity-registry.test.ts
+++ b/src/lib/activity-registry.test.ts
@@ -7,6 +7,7 @@ describe("activity registry", () => {
     expect(isRegisteredActivityEvent("brios", "visit")).toBe(true);
     expect(isRegisteredActivityEvent("brios", "like")).toBe(true);
     expect(isRegisteredActivityEvent("shiori", "link_saved")).toBe(true);
+    expect(isRegisteredActivityEvent("shiori", "link_clicked")).toBe(true);
     expect(isRegisteredActivityEvent("shiori", "download")).toBe(true);
     expect(isRegisteredActivityEvent("tax-ui", "visit")).toBe(true);
     expect(isRegisteredActivityEvent("tax-ui", "download")).toBe(true);

--- a/src/lib/activity-registry.ts
+++ b/src/lib/activity-registry.ts
@@ -22,7 +22,7 @@ export const ACTIVITY_REGISTRY = {
     "repo_starred",
     "caffeinated",
   ],
-  shiori: ["link_saved", "signed_up", "subscription_started", "download"],
+  shiori: ["link_saved", "link_clicked", "signed_up", "subscription_started", "download"],
   "tax-ui": ["visit", "download"],
   "staff-design": ["visit"],
   "design-details": ["visit"],

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -628,6 +628,10 @@ export function getActivityRow(event: ActivityEvent): {
     };
   }
 
+  if (event.source === "shiori" && (event.type === "link_saved" || event.type === "link_clicked")) {
+    return { summary: event.summary };
+  }
+
   return {
     summary: event.summary,
     href: event.subject?.href,

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -764,6 +764,51 @@ describe("HMAC download ingest", () => {
       label: "Shiori",
     });
   });
+
+  test("accepts HMAC Shiori link_clicked without subject, url, or meta", async () => {
+    const store = createMemoryActivityStore();
+    const result = await ingestActivityEvent(
+      {
+        source: "shiori",
+        type: "link_clicked",
+        idempotency_key: "hmac:shiori:link_clicked:1",
+      },
+      store,
+    );
+
+    expect(result.ok && !result.duplicate).toBe(true);
+    const [event] = await store.getTail(1);
+    expect(event?.source).toBe("shiori");
+    expect(event?.type).toBe("link_clicked");
+    expect(event?.speed).toBe("event");
+    expect(event?.summary).toBe("Someone clicked a link on Shiori");
+    expect(event?.subject).toBeUndefined();
+    expect(event?.meta).toBeUndefined();
+    expect(event?.actor).toBeUndefined();
+    expect(JSON.stringify(event)).not.toMatch(/https?:\/\//);
+    expect(getActivityRow(event!)).toEqual({
+      summary: "Someone clicked a link on Shiori",
+    });
+  });
+
+  test("does not leak a subject URL from a Shiori link_clicked row", async () => {
+    const store = createMemoryActivityStore();
+    const result = await ingestActivityEvent(
+      {
+        source: "shiori",
+        type: "link_clicked",
+        summary: "Someone clicked a link on Shiori",
+        idempotency_key: "hmac:shiori:link_clicked:url",
+        subject: { kind: "link", label: "A saved page", href: "https://example.com/secret" },
+      },
+      store,
+    );
+
+    expect(result.ok && !result.duplicate).toBe(true);
+    expect(getActivityRow((await store.getTail(1))[0]!)).toEqual({
+      summary: "Someone clicked a link on Shiori",
+    });
+  });
 });
 
 describe("activity source helpers", () => {
@@ -1490,6 +1535,29 @@ describe("rollupActivityEvents", () => {
     expect(stacks[0]?.latest.id).toBe("s1");
     expect(stacks[1]?.count).toBe(1);
     expect(stacks[1]?.key).toBe("like:/stack");
+  });
+
+  test("stacks consecutive Shiori link_clicked events separately from saves", () => {
+    const click = (id: string): ActivityEvent =>
+      feedEvent({
+        id,
+        source: "shiori",
+        type: "link_clicked",
+        summary: "Someone clicked a link on Shiori",
+      });
+    const save = feedEvent({
+      id: "save-1",
+      source: "shiori",
+      type: "link_saved",
+      summary: "Someone saved a link on Shiori",
+    });
+
+    const stacks = rollupActivityEvents([click("c1"), click("c2"), save]);
+    expect(stacks).toHaveLength(2);
+    expect(stacks[0]?.count).toBe(2);
+    expect(stacks[0]?.key).toBe("shiori:link_clicked");
+    expect(stacks[1]?.count).toBe(1);
+    expect(stacks[1]?.key).toBe("shiori:link_saved");
   });
 
   test("does not stack likes for different apps", () => {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -242,6 +242,18 @@ function applyIngestDefaults(input: ActivityIngestInput): ActivityIngestInput {
     };
   }
 
+  if (input.source === "shiori" && (input.type === "link_saved" || input.type === "link_clicked")) {
+    return {
+      ...input,
+      speed: input.speed ?? "event",
+      summary:
+        input.summary?.trim() ||
+        (input.type === "link_clicked"
+          ? "Someone clicked a link on Shiori"
+          : "Someone saved a link on Shiori"),
+    };
+  }
+
   return input;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Shiori is adding an anonymous HMAC ping when someone opens a saved link. Ingest rejected `(source: "shiori", type: "link_clicked")` with 400 because the pair was not in the activity registry.

## Changes
- Register `link_clicked` on the `shiori` source alongside `link_saved`, `signed_up`, `subscription_started`, and `download`.
- Default ingest summary is `Someone clicked a link on Shiori` when Shiori omits one. Subject, URL, and meta are not required and are not invented.
- `getActivityRow` treats `link_clicked` like `link_saved`: summary only, no link title, no leaked URL. The existing Shiori orb (`/img/shiori-icon.png`) already applies to any `shiori` source.
- Consecutive clicks roll up as `shiori:link_clicked`, separately from saves.

## Tests
- Registry accepts `(shiori, link_clicked)`.
- HMAC ingest without subject/url/meta stores the default summary and does not write a URL.
- A `link_clicked` row renders the Shiori summary and orb and does not leak a subject URL.
- Consecutive clicks stack; a following save is its own row.

Does not touch geo, lifetime sidebar, caffeine, or Spotify.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45b48ffe-c57b-4f6a-9dfe-7e0b9b9b727d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45b48ffe-c57b-4f6a-9dfe-7e0b9b9b727d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

