### PR TITLE
Polish /activity feed row layout and chrome

### DIFF
--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -27,13 +27,6 @@ function ActivityFallback() {
     <ListDetailWrapper>
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div data-scrollable className="relative min-w-0 flex-1 overflow-auto">
-          <div className="bg-secondary border-secondary sticky top-0 z-10 hidden border-b md:block dark:bg-neutral-950">
-            <div className="grid grid-cols-[2rem_minmax(0,1fr)_auto] gap-3 px-4 py-2 md:gap-4">
-              <LoadingSkeleton className="h-4 w-6" />
-              <LoadingSkeleton className="h-4 w-20" />
-              <LoadingSkeleton className="ml-auto h-4 w-12" />
-            </div>
-          </div>
           <div className="divide-secondary divide-y">
             {Array.from({ length: 8 }, (_, index) => (
               <div

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -234,6 +234,23 @@
       opacity: 0;
     }
   }
+  @keyframes activity-rollup-pulse {
+    0%,
+    55% {
+      background-color: var(--background-color-secondary);
+    }
+    100% {
+      background-color: transparent;
+    }
+  }
+  .activity-rollup-pulse {
+    animation: activity-rollup-pulse 550ms ease-out forwards;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .activity-rollup-pulse {
+      animation: none;
+    }
+  }
   @keyframes zoom-in {
     from {
       transform: scale(0.95);

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -574,6 +574,7 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("🇮🇳 Visit from India");
     expect(markup).toContain("divide-y");
     expect(markup).toContain("divide-secondary");
+    expect(markup).toContain("overflow-hidden");
     expect(markup).not.toContain(">Event<");
     expect(markup).not.toContain(">Time<");
     expect(markup).not.toContain("sticky top-0");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -213,7 +213,9 @@ describe("ActivityRow", () => {
     );
 
     expect(like).toContain("text-red-500");
-    expect(like).toContain("Someone liked Grok Bot first impressions");
+    expect(like).toContain("Someone liked");
+    expect(like).toContain(">Grok Bot first impressions<");
+    expect(like).not.toContain("Someone liked Grok Bot first impressions");
     expect(like).toContain('href="/writing/grok-bot-first-impressions"');
     expect(visit).not.toContain("text-red-500");
     expect(visit).toContain("🇮🇳 Visit from India");
@@ -461,7 +463,9 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone liked Cursor");
+    expect(markup).toContain("Someone liked");
+    expect(markup).toContain(">Cursor<");
+    expect(markup).not.toContain("Someone liked Cursor");
     expect(markup).toContain('href="https://cursor.com"');
     expect(markup).toContain("text-red-500");
     expect(markup).not.toContain(">Stack<");
@@ -481,9 +485,73 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone liked Cursor");
+    expect(markup).toContain("Someone liked");
     expect(markup).toContain(">Cursor<");
+    expect(markup).not.toContain("Someone liked Cursor");
     expect(markup).not.toContain(">Stack<");
+  });
+
+  test("renders a stored Home like as Someone liked plus a Home link", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "like",
+          speed: "event",
+          summary: "Someone liked a page",
+          subject: { kind: "home", label: "a page", href: "/" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Someone liked");
+    expect(markup).toContain(">Home<");
+    expect(markup).toContain('href="/"');
+    expect(markup).not.toContain("Someone liked a page");
+    expect(markup).not.toContain("Someone liked Home");
+    expect(markup).not.toContain("a page");
+  });
+
+  test("keeps a like title as tertiary text when there is no href", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "like",
+          speed: "event",
+          summary: "Someone liked How to give a great product design portfolio presentation",
+          subject: {
+            kind: "writing",
+            label: "How to give a great product design portfolio presentation",
+          },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Someone liked");
+    expect(markup).toContain("text-tertiary");
+    expect(markup).toContain("How to give a great product design portfolio presentation");
+    expect(markup).not.toContain("<a ");
+    expect(markup).not.toContain("Someone liked How to give");
+    expect(markup).not.toMatch(/Someone liked\s{2,}/);
+  });
+
+  test("keeps the like title once and the count chip after it", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "like",
+          speed: "event",
+          summary: "Someone liked Cursor",
+          subject: { kind: "stack", label: "Cursor", href: "https://cursor.com" },
+        })}
+        count={2}
+      />,
+    );
+
+    expect(markup).toMatch(
+      /text-primary[^>]*>Someone liked[\s\S]*href="https:\/\/cursor.com"[^>]*>Cursor[\s\S]*font-mono[^>]*>2</,
+    );
+    expect(markup).not.toContain("Someone liked Cursor");
+    expect(markup).not.toContain("> 2<");
   });
 
   test("uses the Shiori orb for any shiori-sourced event", () => {

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -755,6 +755,9 @@ describe("ActivityRow", () => {
     expect(markup).toMatch(
       /text-primary[^>]*>🇺🇸 Visit from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*data-count="6"/,
     );
+    const title = markup.match(/<p class="relative z-10[\s\S]*?<\/p>/)?.[0] ?? "";
+    expect(title).toContain("data-count");
+    expect(title).not.toContain("<div");
 
     const single = renderToStaticMarkup(
       <ActivityRow

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -534,6 +534,7 @@ describe("ActivityRow", () => {
     expect(markup).toContain("text-tertiary");
     expect(markup).toContain("font-mono");
     expect(markup).toContain("rounded-sm");
+    expect(markup).toContain("border-secondary");
     expect(markup).toContain("tabular-nums");
     expect(markup).toContain("an AMA question");
     expect(markup).toContain('href="/ama"');

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -781,10 +781,13 @@ describe("ActivityRow", () => {
 
     expect(pulsed).toContain("data-rollup-pulse");
     expect(pulsed).toContain("bg-secondary");
-    expect(pulsed).toContain("duration-500");
+    expect(pulsed).not.toContain("transition-colors");
+    expect(pulsed).not.toContain("duration-500");
     expect(quiet).not.toContain("data-rollup-pulse");
     expect(quiet).not.toContain("border-b");
     expect(quiet).not.toContain("border-secondary");
+    expect(quiet).not.toContain("transition-colors");
+    expect(quiet).not.toContain("duration-500");
   });
 
   test("keeps the title on one line and sticks time to the right on mobile", () => {
@@ -817,6 +820,9 @@ describe("ActivityRow", () => {
     expect(markup).toContain("group-data-[rollup-pulse]:bg-inherit");
     expect(markup).toContain("md:static");
     expect(markup).toContain("md:grid-cols-[2rem_minmax(0,1fr)_auto]");
+    expect(markup).toContain("hover:bg-secondary");
+    expect(markup).not.toContain("transition-colors");
+    expect(markup).not.toContain("duration-500");
     expect(markup).toMatch(/Merged some-fix[\s\S]*brianlovin\/briOS#12[\s\S]*\+18[\s\S]*-3/);
   });
 });
@@ -840,6 +846,7 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("divide-y");
     expect(markup).toContain("divide-secondary");
     expect(markup).toContain("overflow-hidden");
+    expect(markup).toContain("clip-path:inset(0)");
     expect(markup).toContain("min-w-max");
     expect(markup).toContain("min-w-full");
     expect(markup).toContain("w-max");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -570,7 +570,6 @@ describe("ActivityRow", () => {
           },
           meta: { additions: 18, deletions: 3 },
         })}
-        showStickyEdge
       />,
     );
 
@@ -578,7 +577,12 @@ describe("ActivityRow", () => {
     expect(markup).toContain("md:truncate");
     expect(markup).toContain("sticky");
     expect(markup).toContain("right-0");
+    expect(markup).toContain("ml-auto");
+    expect(markup).toContain("w-max");
+    expect(markup).toContain("min-w-full");
     expect(markup).toContain("inset_1px_0_0");
+    expect(markup).toContain("group-hover:bg-inherit");
+    expect(markup).toContain("group-data-[rollup-pulse]:bg-inherit");
     expect(markup).toContain("md:static");
     expect(markup).toContain("md:grid-cols-[2rem_minmax(0,1fr)_auto]");
     expect(markup).toMatch(/Merged some-fix[\s\S]*brianlovin\/briOS#12[\s\S]*\+18[\s\S]*-3/);
@@ -604,7 +608,8 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("divide-y");
     expect(markup).toContain("divide-secondary");
     expect(markup).toContain("overflow-hidden");
-    expect(markup).toContain("min-w-max");
+    expect(markup).toContain("min-w-full");
+    expect(markup).toContain("w-max");
     expect(markup).toContain("overscroll-contain");
     expect(markup).toContain("whitespace-nowrap");
     expect(markup).toContain("sticky");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -352,7 +352,7 @@ describe("ActivityRow", () => {
     expect(markup).toContain("tabular-nums");
     expect(markup).not.toContain("+18 -3");
     expect(markup).toMatch(
-      /text-primary[^>]*>Merged some-fix[\s\S]*text-tertiary[^>]*> 2<[\s\S]*href="https:\/\/github.com\/brianlovin\/briOS\/pull\/12"[^>]*>brianlovin\/briOS#12[\s\S]*\+18[\s\S]*-3/,
+      /text-primary[^>]*>Merged some-fix[\s\S]*href="https:\/\/github.com\/brianlovin\/briOS\/pull\/12"[^>]*>brianlovin\/briOS#12[\s\S]*font-mono[^>]*>2<[\s\S]*\+18[\s\S]*-3/,
     );
   });
 
@@ -503,7 +503,7 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain("<a ");
   });
 
-  test("shows a tertiary count next to the title when a stack is larger than one", () => {
+  test("shows a quiet count chip after the metadata when a stack is larger than one", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow
         event={event({
@@ -529,14 +529,32 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("Visit from Spring Lake, North Carolina, United States");
-    expect(markup).toContain("> 6<");
+    expect(markup).toContain(">6<");
+    expect(markup).not.toContain("> 6<");
     expect(markup).toContain("text-tertiary");
+    expect(markup).toContain("font-mono");
+    expect(markup).toContain("rounded-sm");
+    expect(markup).toContain("tabular-nums");
     expect(markup).toContain("an AMA question");
     expect(markup).toContain('href="/ama"');
     expect(markup).not.toContain("2f2c711c-0ceb-810d-899d-e5feb99e70f4");
     expect(markup).toMatch(
-      /text-primary[^>]*>🇺🇸 Visit from Spring Lake[\s\S]*text-tertiary[^>]*> 6<[\s\S]*href="\/ama"[^>]*>an AMA question/,
+      /text-primary[^>]*>🇺🇸 Visit from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*font-mono[^>]*>6</,
     );
+
+    const single = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          summary: "Visit from Spring Lake, North Carolina, United States",
+          meta: { country: "US", path: "/ama" },
+        })}
+        count={1}
+        sectionLabel="an AMA question"
+        href="/ama"
+      />,
+    );
+    expect(single).not.toContain("font-mono");
+    expect(single).not.toContain(">1<");
   });
 
   test("pulses the row background only when asked", () => {

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -608,6 +608,7 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("divide-y");
     expect(markup).toContain("divide-secondary");
     expect(markup).toContain("overflow-hidden");
+    expect(markup).toContain("min-w-max");
     expect(markup).toContain("min-w-full");
     expect(markup).toContain("w-max");
     expect(markup).toContain("overscroll-contain");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -23,7 +23,7 @@ function event(overrides: Partial<ActivityEvent>): ActivityEvent {
 }
 
 describe("ActivityRow", () => {
-  test("shows the site favicon and keeps the flag in the title", () => {
+  test("shows the site favicon and omits the flag from the title", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow
         event={event({
@@ -34,7 +34,8 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("🇮🇳 Visit from India");
+    expect(markup).toContain("Visit from India");
+    expect(markup).not.toContain("🇮🇳");
     expect(markup).toContain("/activity/favicons/brios.png");
     expect(markup).toContain('href="/"');
     expect(markup).toContain("Home");
@@ -132,7 +133,8 @@ describe("ActivityRow", () => {
     );
 
     expect(visit).toContain("/activity/favicons/tax-ui.png");
-    expect(visit).toContain("🇺🇸 Visit from United States");
+    expect(visit).toContain("Visit from United States");
+    expect(visit).not.toContain("🇺🇸");
     expect(visit).toContain('width="16"');
     expect(visit).toContain('height="16"');
     expect(visit).toContain("size-4");
@@ -144,7 +146,8 @@ describe("ActivityRow", () => {
     expect(download).toContain('target="_blank"');
     expect(download).toContain("noopener noreferrer");
     expect(unknown).not.toContain("/activity/favicons/");
-    expect(unknown).toContain("🇺🇸 Visit from United States");
+    expect(unknown).toContain("Visit from United States");
+    expect(unknown).not.toContain("🇺🇸");
   });
 
   test("renders the staff.design favicon at 20px so it matches the GitHub mark", () => {
@@ -165,11 +168,11 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain("size-4");
   });
 
-  test("rebuilds a country name and flag for older visits that only have a code", () => {
+  test("rebuilds a country name without a flag emoji for older visits that only have a code", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow event={event({ summary: "Visit from TW", meta: { country: "TW" } })} />,
     );
-    expect(markup).toContain("🇹🇼");
+    expect(markup).not.toContain("🇹🇼");
     expect(markup).toContain("Visit from Taiwan");
   });
 
@@ -221,7 +224,8 @@ describe("ActivityRow", () => {
     expect(like).not.toContain("Someone liked Grok Bot first impressions");
     expect(like).toContain('href="/writing/grok-bot-first-impressions"');
     expect(visit).not.toContain("text-red-500");
-    expect(visit).toContain("🇮🇳 Visit from India");
+    expect(visit).toContain("Visit from India");
+    expect(visit).not.toContain("🇮🇳");
     expect(visit).toContain("/activity/favicons/brios.png");
     expect(like).not.toContain("/activity/favicons/");
   });
@@ -647,7 +651,8 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(staff).toContain("🇺🇸 Visit from United States");
+    expect(staff).toContain("Visit from United States");
+    expect(staff).not.toContain("🇺🇸");
     expect(staff).toContain(">Staff Design<");
     expect(staff).toContain('href="https://staff.design"');
     expect(staff).toContain('target="_blank"');
@@ -674,7 +679,8 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("🇩🇪 Visit from Germany");
+    expect(markup).toContain("Visit from Germany");
+    expect(markup).not.toContain("🇩🇪");
     expect(markup).toContain(">Karla Mickens Cole<");
     expect(markup).toContain('href="https://staff.design/karla-mickens-cole"');
     expect(markup).toContain('target="_blank"');
@@ -753,7 +759,7 @@ describe("ActivityRow", () => {
     expect(markup).toContain('href="/ama"');
     expect(markup).not.toContain("2f2c711c-0ceb-810d-899d-e5feb99e70f4");
     expect(markup).toMatch(
-      /text-primary[^>]*>🇺🇸 Visit from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*data-count="6"/,
+      /text-primary[^>]*>Visit from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*data-count="6"/,
     );
     const title = markup.match(/<p class="relative z-10[\s\S]*?<\/p>/)?.[0] ?? "";
     expect(title).toContain("data-count");
@@ -847,7 +853,8 @@ describe("ActivityFeed", () => {
       />,
     );
 
-    expect(markup).toContain("🇮🇳 Visit from India");
+    expect(markup).toContain("Visit from India");
+    expect(markup).not.toContain("🇮🇳");
     expect(markup).toContain("divide-y");
     expect(markup).toContain("divide-secondary");
     expect(markup).toContain("overflow-hidden");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -361,7 +361,7 @@ describe("ActivityRow", () => {
     expect(markup).toContain("tabular-nums");
     expect(markup).not.toContain("+18 -3");
     expect(markup).toMatch(
-      /text-primary[^>]*>Merged some-fix[\s\S]*href="https:\/\/github.com\/brianlovin\/briOS\/pull\/12"[^>]*>brianlovin\/briOS#12[\s\S]*font-mono[^>]*>2<[\s\S]*\+18[\s\S]*-3/,
+      /text-primary[^>]*>Merged some-fix[\s\S]*href="https:\/\/github.com\/brianlovin\/briOS\/pull\/12"[^>]*>brianlovin\/briOS#12[\s\S]*data-count="2"[\s\S]*\+18[\s\S]*-3/,
     );
   });
 
@@ -555,10 +555,10 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toMatch(
-      /text-primary[^>]*>Someone liked[\s\S]*href="https:\/\/cursor.com"[^>]*>Cursor[\s\S]*font-mono[^>]*>2</,
+      /text-primary[^>]*>Someone liked[\s\S]*href="https:\/\/cursor.com"[^>]*>Cursor[\s\S]*data-count="2"/,
     );
     expect(markup).not.toContain("Someone liked Cursor");
-    expect(markup).not.toContain("> 2<");
+    expect(markup).not.toContain('data-count="1"');
   });
 
   test("uses the Shiori orb for any shiori-sourced event", () => {
@@ -742,18 +742,18 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("Visit from Spring Lake, North Carolina, United States");
-    expect(markup).toContain(">6<");
-    expect(markup).not.toContain("> 6<");
+    expect(markup).toContain('data-count="6"');
     expect(markup).toContain("text-tertiary");
     expect(markup).toContain("font-mono");
     expect(markup).toContain("rounded-sm");
     expect(markup).toContain("border-secondary");
     expect(markup).toContain("tabular-nums");
+    expect(markup).toContain("inline-flex");
     expect(markup).toContain("an AMA question");
     expect(markup).toContain('href="/ama"');
     expect(markup).not.toContain("2f2c711c-0ceb-810d-899d-e5feb99e70f4");
     expect(markup).toMatch(
-      /text-primary[^>]*>🇺🇸 Visit from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*font-mono[^>]*>6</,
+      /text-primary[^>]*>🇺🇸 Visit from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*data-count="6"/,
     );
 
     const single = renderToStaticMarkup(
@@ -780,10 +780,12 @@ describe("ActivityRow", () => {
     );
 
     expect(pulsed).toContain("data-rollup-pulse");
+    expect(pulsed).toContain("activity-rollup-pulse");
     expect(pulsed).toContain("bg-secondary");
     expect(pulsed).not.toContain("transition-colors");
     expect(pulsed).not.toContain("duration-500");
     expect(quiet).not.toContain("data-rollup-pulse");
+    expect(quiet).not.toContain("activity-rollup-pulse");
     expect(quiet).not.toContain("border-b");
     expect(quiet).not.toContain("border-secondary");
     expect(quiet).not.toContain("transition-colors");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { ActivityRow, ActivityTrackedCount } from "@/components/ActivityFeed";
+import { ActivityFeed, ActivityRow, ActivityTrackedCount } from "@/components/ActivityFeed";
 import { ActivityLiveBadge, TopBarTrail } from "@/components/GlobalTopBar";
 import type { ActivityEvent } from "@/lib/activity";
 import { ACTIVITY_TRACKED_SINCE_TOOLTIP, formatTrackedEventsLabel } from "@/lib/activity-shared";
@@ -133,12 +133,33 @@ describe("ActivityRow", () => {
 
     expect(visit).toContain("/activity/favicons/tax-ui.png");
     expect(visit).toContain("🇺🇸 Visit from United States");
+    expect(visit).toContain('width="16"');
+    expect(visit).toContain('height="16"');
+    expect(visit).toContain("size-4");
     expect(download).toContain("/activity/favicons/design-details.png");
     expect(download).toContain("Someone downloaded ");
     expect(download).toContain("Design Details");
     expect(download).toContain('href="https://designdetails.fm"');
     expect(unknown).not.toContain("/activity/favicons/");
     expect(unknown).toContain("🇺🇸 Visit from United States");
+  });
+
+  test("renders the staff.design favicon at 20px so it matches the GitHub mark", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "staff-design",
+          summary: "🇺🇸 Visit from United States",
+          meta: { country: "US" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("/activity/favicons/staff-design.png");
+    expect(markup).toContain('width="20"');
+    expect(markup).toContain('height="20"');
+    expect(markup).toContain("size-5");
+    expect(markup).not.toContain("size-4");
   });
 
   test("rebuilds a country name and flag for older visits that only have a code", () => {
@@ -244,8 +265,8 @@ describe("ActivityRow", () => {
     for (const markup of [prOpened, prMerged, starred]) {
       expect(markup).not.toContain(pulsePath);
       expect(markup).toContain("text-primary");
-      expect(markup).toContain('width="16"');
-      expect(markup).toContain('height="16"');
+      expect(markup).toContain('width="20"');
+      expect(markup).toContain('height="20"');
       expect(markup).not.toContain("#000");
       expect(markup).not.toContain("#fff");
       expect(markup).not.toContain('fill="black"');
@@ -295,40 +316,44 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain("text-red-500");
   });
 
-  test("shows merge diff stats in the metadata slot", () => {
+  test("puts merge diff stats after the repo/PR context", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow
         event={event({
           source: "github",
           type: "pr_merged",
           speed: "event",
-          summary: "Merged a pull request on briOS",
+          summary: "Merged some-fix",
           subject: {
             kind: "pull_request",
-            label: "Add activity feed",
-            href: "https://github.com/brianlovin/briOS/pull/42",
+            label: "brianlovin/briOS#12",
+            href: "https://github.com/brianlovin/briOS/pull/12",
           },
           meta: {
             repo: "briOS",
-            title: "Add activity feed",
-            number: 42,
-            href: "https://github.com/brianlovin/briOS/pull/42",
-            additions: 311,
-            deletions: 211,
-            changed_files: 8,
+            title: "some-fix",
+            number: 12,
+            href: "https://github.com/brianlovin/briOS/pull/12",
+            additions: 18,
+            deletions: 3,
+            changed_files: 2,
           },
         })}
+        count={2}
       />,
     );
 
-    expect(markup).toContain("Merged a pull request on briOS");
-    expect(markup).toContain("Add activity feed");
-    expect(markup).toContain("+311");
-    expect(markup).toContain("-211");
+    expect(markup).toContain("Merged some-fix");
+    expect(markup).toContain("brianlovin/briOS#12");
+    expect(markup).toContain("+18");
+    expect(markup).toContain("-3");
     expect(markup).toContain("text-green-600");
     expect(markup).toContain("text-red-500");
     expect(markup).toContain("tabular-nums");
-    expect(markup).not.toContain("+311 -211");
+    expect(markup).not.toContain("+18 -3");
+    expect(markup).toMatch(
+      /text-primary[^>]*>Merged some-fix[\s\S]*text-tertiary[^>]*> 2<[\s\S]*href="https:\/\/github.com\/brianlovin\/briOS\/pull\/12"[^>]*>brianlovin\/briOS#12[\s\S]*\+18[\s\S]*-3/,
+    );
   });
 
   test("still shows +0 and -0 when both diff fields are zero", () => {
@@ -526,6 +551,32 @@ describe("ActivityRow", () => {
     expect(pulsed).toContain("bg-secondary");
     expect(pulsed).toContain("duration-500");
     expect(quiet).not.toContain("data-rollup-pulse");
+    expect(quiet).not.toContain("border-b");
+    expect(quiet).not.toContain("border-secondary");
+  });
+});
+
+describe("ActivityFeed", () => {
+  test("is a raw stream without Event / Time column headers", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityFeed
+        initialEvents={[
+          event({
+            id: "visit-1",
+            summary: "🇮🇳 Visit from India",
+            meta: { country: "IN" },
+          }),
+        ]}
+        initialCount={1}
+      />,
+    );
+
+    expect(markup).toContain("🇮🇳 Visit from India");
+    expect(markup).toContain("divide-y");
+    expect(markup).toContain("divide-secondary");
+    expect(markup).not.toContain(">Event<");
+    expect(markup).not.toContain(">Time<");
+    expect(markup).not.toContain("sticky top-0");
   });
 });
 

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -137,9 +137,12 @@ describe("ActivityRow", () => {
     expect(visit).toContain('height="16"');
     expect(visit).toContain("size-4");
     expect(download).toContain("/activity/favicons/design-details.png");
-    expect(download).toContain("Someone downloaded ");
-    expect(download).toContain("Design Details");
+    expect(download).toContain("Someone downloaded");
+    expect(download).not.toContain("Someone downloaded Design Details");
+    expect(download).toContain(">Design Details<");
     expect(download).toContain('href="https://designdetails.fm"');
+    expect(download).toContain('target="_blank"');
+    expect(download).toContain("noopener noreferrer");
     expect(unknown).not.toContain("/activity/favicons/");
     expect(unknown).toContain("🇺🇸 Visit from United States");
   });
@@ -288,8 +291,9 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone downloaded ");
-    expect(markup).toContain("Tax UI");
+    expect(markup).toContain("Someone downloaded");
+    expect(markup).not.toContain("Someone downloaded Tax UI");
+    expect(markup).toContain(">Tax UI<");
     expect(markup).toContain('href="https://tax-ui.brianlovin.com/"');
     expect(markup).toContain('target="_blank"');
     expect(markup).toContain("noopener noreferrer");
@@ -313,7 +317,10 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("Opened a pull request on briOS");
-    expect(markup).toContain("Add activity feed");
+    expect(markup).toContain(">Add activity feed<");
+    expect(markup).toContain('href="https://github.com/brianlovin/briOS/pull/42"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).not.toContain(">GitHub<");
     expect(markup).toContain("M12 2C6.477 2 2 6.477 2 12c0 4.42");
     expect(markup).not.toContain("text-red-500");
   });
@@ -567,8 +574,146 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("shiori-icon.png");
-    expect(markup).toContain("Someone saved a link on Shiori");
-    expect(markup).not.toContain("<a ");
+    expect(markup).toContain("Someone saved a link");
+    expect(markup).not.toContain("Someone saved a link on Shiori");
+    expect(markup).toContain(">Shiori<");
+    expect(markup).toContain('href="https://www.shiori.sh"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain("noopener noreferrer");
+  });
+
+  test("lifts Shiori out of click, signup, subscribe, and download copy", () => {
+    const cases = [
+      {
+        type: "link_clicked" as const,
+        summary: "Someone clicked a link on Shiori",
+        stripped: "Someone clicked a link",
+      },
+      {
+        type: "signed_up" as const,
+        summary: "Someone signed up for Shiori",
+        stripped: "Someone signed up",
+      },
+      {
+        type: "subscription_started" as const,
+        summary: "Someone subscribed on Shiori",
+        stripped: "Someone subscribed",
+      },
+      {
+        type: "download" as const,
+        summary: "Someone downloaded Shiori",
+        stripped: "Someone downloaded",
+      },
+    ];
+
+    for (const { type, summary, stripped } of cases) {
+      const markup = renderToStaticMarkup(
+        <ActivityRow
+          event={event({
+            source: "shiori",
+            type,
+            speed: "event",
+            summary,
+          })}
+        />,
+      );
+
+      expect(markup).toContain(stripped);
+      expect(markup).not.toContain(summary);
+      expect(markup).toContain(">Shiori<");
+      expect(markup).toContain('href="https://www.shiori.sh"');
+      expect(markup).toContain('target="_blank"');
+    }
+  });
+
+  test("links staff.design and Design Details visits to the product home", () => {
+    const staff = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "staff-design",
+          summary: "🇺🇸 Visit from United States",
+          meta: { country: "US" },
+        })}
+      />,
+    );
+    const details = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "design-details",
+          summary: "🇺🇸 Visit from San Francisco, California, United States",
+          subject: { kind: "home", label: "Home", href: "/" },
+          meta: { country: "US", city: "San Francisco", path: "/" },
+        })}
+      />,
+    );
+
+    expect(staff).toContain("🇺🇸 Visit from United States");
+    expect(staff).toContain(">Staff Design<");
+    expect(staff).toContain('href="https://staff.design"');
+    expect(staff).toContain('target="_blank"');
+    expect(details).toContain("Visit from San Francisco");
+    expect(details).toContain(">Design Details<");
+    expect(details).toContain('href="https://designdetails.fm"');
+    expect(details).toContain('target="_blank"');
+    expect(details).not.toContain(">Home<");
+  });
+
+  test("keeps a specific staff.design page as the new-tab link", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "staff-design",
+          summary: "🇩🇪 Visit from Germany",
+          subject: {
+            kind: "page",
+            label: "Karla Mickens Cole",
+            href: "/karla-mickens-cole",
+          },
+          meta: { country: "DE", path: "/karla-mickens-cole", title: "Karla Mickens Cole" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("🇩🇪 Visit from Germany");
+    expect(markup).toContain(">Karla Mickens Cole<");
+    expect(markup).toContain('href="https://staff.design/karla-mickens-cole"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).not.toContain(">Staff Design<");
+  });
+
+  test("keeps first-party likes and visits on the page, not briOS", () => {
+    const like = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "like",
+          speed: "event",
+          summary: "Someone liked Grok Bot first impressions",
+          subject: {
+            kind: "writing",
+            label: "Grok Bot first impressions",
+            href: "/writing/grok-bot-first-impressions",
+          },
+        })}
+      />,
+    );
+    const visit = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          summary: "🇮🇳 Visit from India",
+          subject: { kind: "home", label: "a page", href: "/" },
+          meta: { country: "IN", path: "/", title: "a page" },
+        })}
+      />,
+    );
+
+    expect(like).toContain(">Grok Bot first impressions<");
+    expect(like).toContain('href="/writing/grok-bot-first-impressions"');
+    expect(like).not.toContain(">briOS<");
+    expect(like).not.toContain('target="_blank"');
+    expect(visit).toContain(">Home<");
+    expect(visit).toContain('href="/"');
+    expect(visit).not.toContain(">briOS<");
+    expect(visit).not.toContain('target="_blank"');
   });
 
   test("shows a quiet count chip after the metadata when a stack is larger than one", () => {

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -869,6 +869,45 @@ describe("ActivityFeed", () => {
     expect(markup).not.toContain(">Event<");
     expect(markup).not.toContain(">Time<");
     expect(markup).not.toContain("sticky top-0");
+    expect(markup).not.toMatch(/opacity:\s*0/);
+    expect(markup).not.toContain("translateY(-8");
+    expect(markup).not.toContain("y: -8");
+  });
+
+  test("first paint of several stacks is static, not an enter cascade", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityFeed
+        initialEvents={[
+          event({
+            id: "visit-in",
+            summary: "Visit from India",
+            meta: { country: "IN", path: "/" },
+          }),
+          event({
+            id: "visit-us",
+            summary: "Visit from United States",
+            meta: { country: "US", city: "San Francisco", path: "/writing" },
+          }),
+          event({
+            id: "like-1",
+            type: "like",
+            speed: "event",
+            summary: "Someone liked Home",
+            subject: { kind: "home", label: "Home", href: "/" },
+          }),
+        ]}
+        initialCount={3}
+      />,
+    );
+
+    expect(markup).toContain("Visit from India");
+    expect(markup).toContain("Visit from San Francisco");
+    expect(markup).toContain("Someone liked");
+    expect(markup).not.toMatch(/opacity:\s*0/);
+    expect(markup).not.toContain("height: 0");
+    expect(markup).not.toContain("height:0px");
+    expect(markup).not.toContain("translateY(-8");
+    expect(markup).toContain("clip-path:inset(0)");
   });
 });
 

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -554,6 +554,35 @@ describe("ActivityRow", () => {
     expect(quiet).not.toContain("border-b");
     expect(quiet).not.toContain("border-secondary");
   });
+
+  test("keeps the title on one line and sticks time to the right on mobile", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "github",
+          type: "pr_merged",
+          speed: "event",
+          summary: "Merged some-fix",
+          subject: {
+            kind: "pull_request",
+            label: "brianlovin/briOS#12",
+            href: "https://github.com/brianlovin/briOS/pull/12",
+          },
+          meta: { additions: 18, deletions: 3 },
+        })}
+        showStickyEdge
+      />,
+    );
+
+    expect(markup).toContain("whitespace-nowrap");
+    expect(markup).toContain("md:truncate");
+    expect(markup).toContain("sticky");
+    expect(markup).toContain("right-0");
+    expect(markup).toContain("inset_1px_0_0");
+    expect(markup).toContain("md:static");
+    expect(markup).toContain("md:grid-cols-[2rem_minmax(0,1fr)_auto]");
+    expect(markup).toMatch(/Merged some-fix[\s\S]*brianlovin\/briOS#12[\s\S]*\+18[\s\S]*-3/);
+  });
 });
 
 describe("ActivityFeed", () => {
@@ -575,6 +604,11 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("divide-y");
     expect(markup).toContain("divide-secondary");
     expect(markup).toContain("overflow-hidden");
+    expect(markup).toContain("min-w-max");
+    expect(markup).toContain("overscroll-contain");
+    expect(markup).toContain("whitespace-nowrap");
+    expect(markup).toContain("sticky");
+    expect(markup).toContain("right-0");
     expect(markup).not.toContain(">Event<");
     expect(markup).not.toContain(">Time<");
     expect(markup).not.toContain("sticky top-0");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -617,6 +617,8 @@ describe("ActivityTrackedCount", () => {
     expect(one).toContain("1 event tracked");
     expect(one).toContain("text-tertiary");
     expect(one).toContain("text-sm");
+    expect(one).toContain("hidden");
+    expect(one).toContain("md:inline");
     expect(many).toContain("12 events tracked");
     expect(many).not.toContain("Live");
   });

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -175,10 +175,10 @@ export function ActivityRow({
   const isLike = event.type === "like";
   const likeTitle = isLike ? row.label || "Home" : "";
   const label = isLike ? likeTitle : (sectionLabel ?? row.label);
+  const rawHref = hrefOverride ?? row.href;
   const href =
-    hrefOverride ??
-    resolveActivitySourceHref(event.source, row.href) ??
-    row.href ??
+    resolveActivitySourceHref(event.source, rawHref) ??
+    rawHref ??
     (isLike
       ? likeTitle === "Home"
         ? (homeUrl ?? "/")

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -2,7 +2,15 @@
 
 import { AnimatePresence, LayoutGroup, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
-import { type ReactNode, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import {
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { Activity } from "@/components/icons/Activity";
 import { Github } from "@/components/icons/Github";
@@ -46,7 +54,7 @@ function formatRelativeTime(iso: string): string {
   return `${days}d ago`;
 }
 
-function RelativeTime({ iso }: { iso: string }) {
+function RelativeTime({ iso, className }: { iso: string; className?: string }) {
   const [label, setLabel] = useState("");
 
   useEffect(() => {
@@ -58,7 +66,7 @@ function RelativeTime({ iso }: { iso: string }) {
 
   return (
     <time
-      className="text-quaternary shrink-0 text-right text-sm tabular-nums"
+      className={cn("text-quaternary shrink-0 text-right text-sm tabular-nums", className)}
       dateTime={iso}
       title={iso}
     >
@@ -156,12 +164,14 @@ export function ActivityRow({
   sectionLabel,
   href: hrefOverride,
   pulse = false,
+  showStickyEdge = false,
 }: {
   event: ActivityEvent;
   count?: number;
   sectionLabel?: string;
   href?: string;
   pulse?: boolean;
+  showStickyEdge?: boolean;
 }) {
   const row = getActivityRow(event);
   const homeUrl = activitySourceUrl(event.source);
@@ -188,14 +198,14 @@ export function ActivityRow({
     <div
       data-rollup-pulse={pulse ? "" : undefined}
       className={cn(
-        "hover:bg-secondary grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 transition-colors duration-500 md:gap-4 md:py-2 md:dark:hover:bg-white/5",
+        "group hover:bg-secondary flex items-center gap-3 py-3 pl-4 transition-colors duration-500 md:grid md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5",
         pulse && "bg-secondary",
       )}
     >
-      <div className="flex size-8 items-center justify-center">
+      <div className="flex size-8 shrink-0 items-center justify-center">
         <ActivityRowIcon event={event} icon={row.icon} />
       </div>
-      <p className="min-w-0 truncate">
+      <p className="whitespace-nowrap md:min-w-0 md:truncate">
         <span className="text-primary">{row.summary}</span>
         {count > 1 ? <span className="text-tertiary"> {count}</span> : null}
         {href && context ? (
@@ -214,7 +224,16 @@ export function ActivityRow({
           </span>
         ) : null}
       </p>
-      <RelativeTime iso={event.received_at} />
+      <RelativeTime
+        iso={event.received_at}
+        className={cn(
+          "group-hover:bg-secondary sticky right-0 z-10 bg-white px-4 dark:bg-black",
+          pulse && "bg-secondary",
+          "md:static md:bg-transparent md:px-0 md:dark:bg-transparent md:dark:group-hover:bg-white/5",
+          showStickyEdge &&
+            "[box-shadow:inset_1px_0_0_var(--border-color-secondary)] md:shadow-none",
+        )}
+      />
     </div>
   );
 }
@@ -257,12 +276,99 @@ function useHydrated(): boolean {
   );
 }
 
+function useIsMobile(): boolean {
+  return useSyncExternalStore(
+    (onChange) => {
+      const media = window.matchMedia("(max-width: 767px)");
+      media.addEventListener("change", onChange);
+      return () => media.removeEventListener("change", onChange);
+    },
+    () => window.matchMedia("(max-width: 767px)").matches,
+    () => false,
+  );
+}
+
+function useHorizontalScrollEdge(ref: RefObject<HTMLElement | null>): boolean {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const update = () => setIsScrolled(container.scrollLeft > 0);
+    update();
+    container.addEventListener("scroll", update, { passive: true });
+    return () => container.removeEventListener("scroll", update);
+  }, [ref]);
+
+  return isScrolled;
+}
+
+function useMobileAxisLock(ref: RefObject<HTMLElement | null>, enabled: boolean) {
+  useEffect(() => {
+    const container = ref.current;
+    if (!container || !enabled) return;
+
+    let touchStartPos: { x: number; y: number } | null = null;
+    let lockedAxis: "x" | "y" | null = null;
+    let lockedScrollValue: number | null = null;
+    const threshold = 5;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!touch) return;
+      touchStartPos = { x: touch.clientX, y: touch.clientY };
+      lockedAxis = null;
+      lockedScrollValue = null;
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (!touchStartPos) return;
+      const touch = event.touches[0];
+      if (!touch || lockedAxis !== null) return;
+
+      const deltaX = Math.abs(touch.clientX - touchStartPos.x);
+      const deltaY = Math.abs(touch.clientY - touchStartPos.y);
+      if (deltaX <= threshold && deltaY <= threshold) return;
+
+      lockedAxis = deltaX > deltaY ? "x" : "y";
+      lockedScrollValue = lockedAxis === "x" ? container.scrollTop : container.scrollLeft;
+    };
+
+    const handleScroll = () => {
+      if (lockedAxis === null || lockedScrollValue === null) return;
+      if (lockedAxis === "x" && container.scrollTop !== lockedScrollValue) {
+        container.scrollTop = lockedScrollValue;
+      } else if (lockedAxis === "y" && container.scrollLeft !== lockedScrollValue) {
+        container.scrollLeft = lockedScrollValue;
+      }
+    };
+
+    const handleTouchEnd = () => {
+      touchStartPos = null;
+    };
+
+    container.addEventListener("touchstart", handleTouchStart, { passive: true });
+    container.addEventListener("touchmove", handleTouchMove, { passive: true });
+    container.addEventListener("touchend", handleTouchEnd);
+    container.addEventListener("scroll", handleScroll);
+    return () => {
+      container.removeEventListener("touchstart", handleTouchStart);
+      container.removeEventListener("touchmove", handleTouchMove);
+      container.removeEventListener("touchend", handleTouchEnd);
+      container.removeEventListener("scroll", handleScroll);
+    };
+  }, [enabled, ref]);
+}
+
 function ActivityStackList({
   stacks,
   pulseKey,
+  showStickyEdge,
 }: {
   stacks: ActivityRollup[];
   pulseKey: string | null;
+  showStickyEdge: boolean;
 }) {
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
@@ -270,7 +376,7 @@ function ActivityStackList({
 
   return (
     <LayoutGroup>
-      <div className="divide-secondary divide-y">
+      <div className="divide-secondary min-w-max divide-y md:min-w-0">
         <AnimatePresence initial={false}>
           {stacks.map((stack) => {
             const reactKey = activityStackReactKey(stack);
@@ -281,7 +387,7 @@ function ActivityStackList({
                 initial={shouldAnimate ? { height: 0, opacity: 0 } : false}
                 animate={{ height: "auto", opacity: 1 }}
                 exit={shouldAnimate ? { height: 0, opacity: 0 } : undefined}
-                className="overflow-hidden"
+                className="min-w-full [clip-path:inset(0)]"
                 transition={shouldAnimate ? LIST_MOTION : { duration: 0 }}
               >
                 <ActivityRow
@@ -290,6 +396,7 @@ function ActivityStackList({
                   sectionLabel={stack.sectionLabel}
                   href={stack.href}
                   pulse={pulseKey === stack.key}
+                  showStickyEdge={showStickyEdge}
                 />
               </motion.div>
             );
@@ -336,6 +443,10 @@ export function ActivityFeed({
   const { events, count } = useActivity(initialEvents, initialCount);
   const stacks = useMemo(() => rollupActivityEvents(events), [events]);
   const pulseKey = useRollupPulse(stacks);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
+  const isScrolled = useHorizontalScrollEdge(scrollRef);
+  useMobileAxisLock(scrollRef, isMobile);
 
   const topBarContent = useMemo(() => <ActivityTrackedCount count={count} />, [count]);
   useTopBarActions(topBarContent);
@@ -343,13 +454,22 @@ export function ActivityFeed({
   return (
     <ListDetailWrapper>
       <div className="relative flex min-h-0 flex-1 overflow-hidden">
-        <motion.div data-scrollable layoutScroll className="relative min-w-0 flex-1 overflow-auto">
+        <motion.div
+          ref={scrollRef}
+          data-scrollable
+          layoutScroll
+          className="relative min-w-0 flex-1 overflow-auto overscroll-contain [-webkit-overflow-scrolling:touch]"
+        >
           {events.length === 0 ? (
             <p className="text-tertiary px-4 py-10">
               Nothing yet. Likes and visits will show up here.
             </p>
           ) : (
-            <ActivityStackList stacks={stacks} pulseKey={pulseKey} />
+            <ActivityStackList
+              stacks={stacks}
+              pulseKey={pulseKey}
+              showStickyEdge={isScrolled || isMobile}
+            />
           )}
         </motion.div>
       </div>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -33,7 +33,6 @@ import {
   formatTrackedEventsLabel,
   getActivityRow,
   getMergedPullRequestDiff,
-  isKnownActivityTitle,
   resolveActivitySourceHref,
 } from "@/lib/activity-shared";
 import { useActivity } from "@/lib/hooks/useActivity";
@@ -173,23 +172,21 @@ export function ActivityRow({
 }) {
   const row = getActivityRow(event);
   const homeUrl = activitySourceUrl(event.source);
-  const label = sectionLabel ?? row.label;
+  const isLike = event.type === "like";
+  const likeTitle = isLike ? row.label || "Home" : "";
+  const label = isLike ? likeTitle : (sectionLabel ?? row.label);
   const href =
     hrefOverride ??
     resolveActivitySourceHref(event.source, row.href) ??
     row.href ??
-    (label || event.type === "download" ? homeUrl : undefined);
-  const likedName =
-    event.type === "like" ? row.summary.replace(/^Someone liked\s+/i, "").trim() : "";
-  const rawContext = label ?? (href || undefined);
-  const context =
-    event.type === "like" &&
-    rawContext &&
-    likedName &&
-    rawContext !== likedName &&
-    isKnownActivityTitle(rawContext)
-      ? likedName
-      : rawContext;
+    (isLike
+      ? likeTitle === "Home"
+        ? (homeUrl ?? "/")
+        : undefined
+      : label || event.type === "download"
+        ? homeUrl
+        : undefined);
+  const context = isLike ? likeTitle : (label ?? (href || undefined));
   const diff = event.type === "pr_merged" ? getMergedPullRequestDiff(event.meta) : null;
 
   return (

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, LayoutGroup, motion, useReducedMotion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import {
   type ReactNode,
@@ -22,6 +22,9 @@ import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import type { ActivityEvent, ActivityRollup } from "@/lib/activity";
 import {
+  ACTIVITY_ENTER_STAGGER_MAX,
+  ACTIVITY_ENTER_STAGGER_STEP,
+  activityEnterStaggerDelays,
   activityStackReactKey,
   rollupActivityEvents,
   shouldPulseActivityRollup,
@@ -193,7 +196,7 @@ export function ActivityRow({
     <div
       data-rollup-pulse={pulse ? "" : undefined}
       className={cn(
-        "group hover:bg-secondary flex w-max min-w-full items-center gap-3 py-3 pl-4 transition-colors duration-500 md:grid md:w-auto md:min-w-0 md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5",
+        "group hover:bg-secondary flex w-max min-w-full items-center gap-3 py-3 pl-4 md:grid md:w-auto md:min-w-0 md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5",
         pulse && "bg-secondary",
       )}
     >
@@ -262,7 +265,7 @@ export function ActivityTrackedCount({ count }: { count: number }) {
 }
 
 const ROLLUP_PULSE_MS = 550;
-const LIST_MOTION = { duration: 0.16, ease: [0.2, 0, 0, 1] } as const;
+const LIST_MOTION = { duration: 0.14, ease: [0.2, 0, 0, 1] } as const;
 
 function subscribeNoop(): () => void {
   return () => {};
@@ -345,6 +348,16 @@ function useMobileAxisLock(ref: RefObject<HTMLElement | null>, enabled: boolean)
   }, [enabled, ref]);
 }
 
+function pruneEnterDelays(delays: Map<string, number>, liveKeys: Set<string>): Map<string, number> {
+  let changed = false;
+  const next = new Map<string, number>();
+  for (const [key, delay] of delays) {
+    if (liveKeys.has(key)) next.set(key, delay);
+    else changed = true;
+  }
+  return changed ? next : delays;
+}
+
 function ActivityStackList({
   stacks,
   pulseKey,
@@ -355,36 +368,81 @@ function ActivityStackList({
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
   const shouldAnimate = hydrated && prefersReducedMotion !== true;
+  const keys = stacks.map(activityStackReactKey);
+  const liveKeys = new Set(keys);
+  const [seenKeys, setSeenKeys] = useState<Set<string> | null>(null);
+  const [enterDelays, setEnterDelays] = useState<Map<string, number>>(() => new Map());
+
+  let nextSeen = seenKeys;
+  let nextDelays = enterDelays;
+
+  if (seenKeys === null) {
+    nextSeen = liveKeys;
+  } else {
+    const pending = activityEnterStaggerDelays(
+      keys,
+      seenKeys,
+      ACTIVITY_ENTER_STAGGER_STEP,
+      ACTIVITY_ENTER_STAGGER_MAX,
+    );
+    if (pending.size > 0) {
+      nextDelays = new Map(enterDelays);
+      for (const [key, delay] of pending) nextDelays.set(key, delay);
+      nextSeen = new Set([...seenKeys, ...keys]);
+    }
+  }
+
+  if (nextSeen) {
+    const prunedSeen = new Set([...nextSeen].filter((key) => liveKeys.has(key)));
+    if (prunedSeen.size !== nextSeen.size) nextSeen = prunedSeen;
+  }
+  nextDelays = pruneEnterDelays(nextDelays, liveKeys);
+
+  if (nextSeen !== seenKeys) setSeenKeys(nextSeen);
+  if (nextDelays !== enterDelays) setEnterDelays(nextDelays);
 
   return (
-    <LayoutGroup>
-      <div className="divide-secondary min-w-max divide-y md:min-w-0">
-        <AnimatePresence initial={false}>
-          {stacks.map((stack) => {
-            const reactKey = activityStackReactKey(stack);
-            return (
-              <motion.div
-                key={reactKey}
-                layout={shouldAnimate ? "position" : false}
-                initial={shouldAnimate ? { height: 0, opacity: 0 } : false}
-                animate={{ height: "auto", opacity: 1 }}
-                exit={shouldAnimate ? { height: 0, opacity: 0 } : undefined}
-                className="w-max min-w-full [clip-path:inset(0)] md:w-auto md:min-w-0"
-                transition={shouldAnimate ? LIST_MOTION : { duration: 0 }}
-              >
-                <ActivityRow
-                  event={stack.latest}
-                  count={stack.count}
-                  sectionLabel={stack.sectionLabel}
-                  href={stack.href}
-                  pulse={pulseKey === stack.key}
-                />
-              </motion.div>
-            );
-          })}
-        </AnimatePresence>
-      </div>
-    </LayoutGroup>
+    <div className="divide-secondary min-w-max divide-y md:min-w-0">
+      <AnimatePresence initial={false}>
+        {stacks.map((stack) => {
+          const reactKey = activityStackReactKey(stack);
+          const delay = nextDelays.get(reactKey);
+          const isEntering = shouldAnimate && delay !== undefined;
+
+          return (
+            <motion.div
+              key={reactKey}
+              initial={isEntering ? { height: 0, opacity: 0 } : false}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={shouldAnimate ? { height: 0, opacity: 0 } : undefined}
+              transition={
+                shouldAnimate ? { ...LIST_MOTION, delay: isEntering ? delay : 0 } : { duration: 0 }
+              }
+              onAnimationComplete={() => {
+                setEnterDelays((current) => {
+                  if (!current.has(reactKey)) return current;
+                  const remaining = new Map(current);
+                  remaining.delete(reactKey);
+                  return remaining;
+                });
+              }}
+              className={cn(
+                "w-max min-w-full md:w-auto md:min-w-0",
+                isEntering ? "overflow-hidden" : "[clip-path:inset(0)]",
+              )}
+            >
+              <ActivityRow
+                event={stack.latest}
+                count={stack.count}
+                sectionLabel={stack.sectionLabel}
+                href={stack.href}
+                pulse={pulseKey === stack.key}
+              />
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+    </div>
   );
 }
 
@@ -434,10 +492,9 @@ export function ActivityFeed({
   return (
     <ListDetailWrapper>
       <div className="relative flex min-h-0 flex-1 overflow-hidden">
-        <motion.div
+        <div
           ref={scrollRef}
           data-scrollable
-          layoutScroll
           className="relative min-w-0 flex-1 overflow-auto overscroll-contain [-webkit-overflow-scrolling:touch]"
         >
           {events.length === 0 ? (
@@ -447,7 +504,7 @@ export function ActivityFeed({
           ) : (
             <ActivityStackList stacks={stacks} pulseKey={pulseKey} />
           )}
-        </motion.div>
+        </div>
       </div>
     </ListDetailWrapper>
   );

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -216,7 +216,7 @@ export function ActivityRow({
           ) : null}
         </span>
         {count > 1 ? (
-          <span className="text-tertiary shrink-0 rounded-sm px-1 font-mono text-[11px] leading-4 tabular-nums">
+          <span className="text-tertiary border-secondary shrink-0 rounded-sm border px-1 font-mono text-[11px] leading-4 tabular-nums">
             {count}
           </span>
         ) : null}

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -225,7 +225,7 @@ export function ActivityTrackedCount({ count }: { count: number }) {
       <TooltipTrigger
         delay={0}
         closeDelay={0}
-        className="text-tertiary cursor-default bg-transparent p-0 text-sm tabular-nums"
+        className="text-tertiary hidden cursor-default bg-transparent p-0 text-sm tabular-nums md:inline"
       >
         {formatTrackedEventsLabel(count)}
       </TooltipTrigger>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -203,20 +203,25 @@ export function ActivityRow({
       <div className="flex size-8 shrink-0 items-center justify-center">
         <ActivityRowIcon event={event} icon={row.icon} />
       </div>
-      <p className="whitespace-nowrap md:min-w-0 md:truncate">
-        <span className="text-primary">{row.summary}</span>
-        {count > 1 ? <span className="text-tertiary"> {count}</span> : null}
-        {href && context ? (
-          <>
-            {" "}
-            <ActivityContextLink href={href}>{context}</ActivityContextLink>
-          </>
-        ) : context ? (
-          <span className="text-tertiary"> {context}</span>
+      <p className="flex items-baseline gap-1.5 whitespace-nowrap md:min-w-0">
+        <span className="md:min-w-0 md:truncate">
+          <span className="text-primary">{row.summary}</span>
+          {href && context ? (
+            <>
+              {" "}
+              <ActivityContextLink href={href}>{context}</ActivityContextLink>
+            </>
+          ) : context ? (
+            <span className="text-tertiary"> {context}</span>
+          ) : null}
+        </span>
+        {count > 1 ? (
+          <span className="text-tertiary shrink-0 rounded-sm px-1 font-mono text-[11px] leading-4 tabular-nums">
+            {count}
+          </span>
         ) : null}
         {diff ? (
           <span className="shrink-0 text-sm tabular-nums">
-            {" "}
             <span className="text-green-600">+{diff.additions}</span>{" "}
             <span className="text-red-500">-{diff.deletions}</span>
           </span>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -68,8 +68,9 @@ function RelativeTime({ iso }: { iso: string }) {
   );
 }
 
-function ActivitySourceFavicon({ src }: { src: string }) {
+function ActivitySourceFavicon({ src, source }: { src: string; source: string }) {
   const [failed, setFailed] = useState(false);
+  const size = source === "staff-design" ? 20 : 16;
   if (failed) {
     return <World size={16} className="text-tertiary" aria-hidden />;
   }
@@ -79,9 +80,9 @@ function ActivitySourceFavicon({ src }: { src: string }) {
     <img
       src={src}
       alt=""
-      width={16}
-      height={16}
-      className="block size-4 rounded-[3px]"
+      width={size}
+      height={size}
+      className={cn("block rounded-[3px]", size === 20 ? "size-5" : "size-4")}
       aria-hidden
       onError={() => setFailed(true)}
     />
@@ -107,13 +108,13 @@ function ActivityRowIcon({ event, icon }: { event: ActivityEvent; icon?: string 
   }
 
   if (isGithubActivity(event)) {
-    return <Github size={16} className="text-primary" aria-hidden />;
+    return <Github size={20} className="text-primary" aria-hidden />;
   }
 
   if (event.type === "visit" || event.type === "visit_country_first" || event.type === "download") {
     const faviconSrc = activitySourceFaviconSrc(event.source);
     if (faviconSrc) {
-      return <ActivitySourceFavicon src={faviconSrc} />;
+      return <ActivitySourceFavicon src={faviconSrc} source={event.source} />;
     }
     return <World size={16} className="text-tertiary" aria-hidden />;
   }
@@ -188,7 +189,7 @@ export function ActivityRow({
     <div
       data-rollup-pulse={pulse ? "" : undefined}
       className={cn(
-        "border-secondary hover:bg-secondary grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 border-b px-4 py-3 transition-colors duration-500 md:gap-4 md:py-2 md:dark:hover:bg-white/5",
+        "hover:bg-secondary grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 transition-colors duration-500 md:gap-4 md:py-2 md:dark:hover:bg-white/5",
         pulse && "bg-secondary",
       )}
     >
@@ -198,13 +199,6 @@ export function ActivityRow({
       <p className="min-w-0 truncate">
         <span className="text-primary">{row.summary}</span>
         {count > 1 ? <span className="text-tertiary"> {count}</span> : null}
-        {diff ? (
-          <span className="shrink-0 text-sm tabular-nums">
-            {" "}
-            <span className="text-green-600">+{diff.additions}</span>{" "}
-            <span className="text-red-500">-{diff.deletions}</span>
-          </span>
-        ) : null}
         {href && context ? (
           <>
             {" "}
@@ -212,6 +206,13 @@ export function ActivityRow({
           </>
         ) : context ? (
           <span className="text-tertiary"> {context}</span>
+        ) : null}
+        {diff ? (
+          <span className="shrink-0 text-sm tabular-nums">
+            {" "}
+            <span className="text-green-600">+{diff.additions}</span>{" "}
+            <span className="text-red-500">-{diff.deletions}</span>
+          </span>
         ) : null}
       </p>
       <RelativeTime iso={event.received_at} />
@@ -355,13 +356,6 @@ export function ActivityFeed({
     <ListDetailWrapper>
       <div className="relative flex min-h-0 flex-1 overflow-hidden">
         <motion.div data-scrollable layoutScroll className="relative min-w-0 flex-1 overflow-auto">
-          <div className="bg-secondary border-secondary sticky top-0 z-10 hidden border-b md:block dark:bg-neutral-950">
-            <div className="grid grid-cols-[2rem_minmax(0,1fr)_auto] gap-3 px-4 py-2 text-sm font-medium md:gap-4">
-              <div />
-              <div>Event</div>
-              <div className="text-right">Time</div>
-            </div>
-          </div>
           {events.length === 0 ? (
             <p className="text-tertiary px-4 py-10">
               Nothing yet. Likes and visits will show up here.

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -23,10 +23,8 @@ import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import type { ActivityEvent, ActivityRollup } from "@/lib/activity";
 import {
-  ACTIVITY_ENTER_STAGGER_MAX,
-  ACTIVITY_ENTER_STAGGER_STEP,
-  activityEnterStaggerDelays,
   activityStackReactKey,
+  nextActivityEnterState,
   rollupActivityEvents,
   shouldPulseActivityRollup,
 } from "@/lib/activity-rollup";
@@ -375,35 +373,23 @@ function ActivityStackList({
 }) {
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
-  const shouldAnimate = hydrated && prefersReducedMotion !== true;
+  const canAnimate = hydrated && prefersReducedMotion !== true;
   const keys = stacks.map(activityStackReactKey);
   const liveKeys = new Set(keys);
   const [seenKeys, setSeenKeys] = useState<Set<string> | null>(null);
   const [enterDelays, setEnterDelays] = useState<Map<string, number>>(() => new Map());
 
-  let nextSeen = seenKeys;
+  const { seen, delays: pending } = nextActivityEnterState(keys, seenKeys);
+  let nextSeen = seen;
   let nextDelays = enterDelays;
 
-  if (seenKeys === null) {
-    nextSeen = liveKeys;
-  } else {
-    const pending = activityEnterStaggerDelays(
-      keys,
-      seenKeys,
-      ACTIVITY_ENTER_STAGGER_STEP,
-      ACTIVITY_ENTER_STAGGER_MAX,
-    );
-    if (pending.size > 0) {
-      nextDelays = new Map(enterDelays);
-      for (const [key, delay] of pending) nextDelays.set(key, delay);
-      nextSeen = new Set([...seenKeys, ...keys]);
-    }
+  if (pending.size > 0) {
+    nextDelays = new Map(enterDelays);
+    for (const [key, delay] of pending) nextDelays.set(key, delay);
   }
 
-  if (nextSeen) {
-    const prunedSeen = new Set([...nextSeen].filter((key) => liveKeys.has(key)));
-    if (prunedSeen.size !== nextSeen.size) nextSeen = prunedSeen;
-  }
+  const prunedSeen = new Set([...nextSeen].filter((key) => liveKeys.has(key)));
+  if (prunedSeen.size !== nextSeen.size) nextSeen = prunedSeen;
   nextDelays = pruneEnterDelays(nextDelays, liveKeys);
 
   if (nextSeen !== seenKeys) setSeenKeys(nextSeen);
@@ -415,17 +401,15 @@ function ActivityStackList({
         {stacks.map((stack) => {
           const reactKey = activityStackReactKey(stack);
           const delay = nextDelays.get(reactKey);
-          const isEntering = shouldAnimate && delay !== undefined;
+          const isEntering = canAnimate && delay !== undefined;
 
           return (
             <motion.div
               key={reactKey}
               initial={isEntering ? { height: 0, opacity: 0 } : false}
-              animate={{ height: "auto", opacity: 1 }}
-              exit={shouldAnimate ? { height: 0, opacity: 0 } : undefined}
-              transition={
-                shouldAnimate ? { ...LIST_MOTION, delay: isEntering ? delay : 0 } : { duration: 0 }
-              }
+              animate={isEntering ? { height: "auto", opacity: 1 } : false}
+              exit={canAnimate ? { height: 0, opacity: 0 } : undefined}
+              transition={isEntering ? { ...LIST_MOTION, delay } : { duration: 0 }}
               onAnimationComplete={() => {
                 setEnterDelays((current) => {
                   if (!current.has(reactKey)) return current;

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -18,6 +18,7 @@ import { Heart } from "@/components/icons/Heart";
 import { Shiori } from "@/components/icons/Shiori";
 import { World } from "@/components/icons/World";
 import { ListDetailWrapper } from "@/components/ListDetailWrapper";
+import { RollingDigits } from "@/components/RollingDigits";
 import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import type { ActivityEvent, ActivityRollup } from "@/lib/activity";
@@ -195,15 +196,19 @@ export function ActivityRow({
   return (
     <div
       data-rollup-pulse={pulse ? "" : undefined}
-      className={cn(
-        "group hover:bg-secondary flex w-max min-w-full items-center gap-3 py-3 pl-4 md:grid md:w-auto md:min-w-0 md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5",
-        pulse && "bg-secondary",
-      )}
+      className="group hover:bg-secondary relative isolate flex w-max min-w-full items-center gap-3 py-3 pl-4 md:grid md:w-auto md:min-w-0 md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5"
     >
-      <div className="flex size-8 shrink-0 items-center justify-center">
+      {pulse ? (
+        <span
+          key={event.id}
+          aria-hidden
+          className="activity-rollup-pulse pointer-events-none absolute inset-0 z-0"
+        />
+      ) : null}
+      <div className="relative z-10 flex size-8 shrink-0 items-center justify-center">
         <ActivityRowIcon event={event} icon={row.icon} />
       </div>
-      <p className="flex items-baseline gap-1.5 whitespace-nowrap md:min-w-0">
+      <p className="relative z-10 flex items-baseline gap-1.5 whitespace-nowrap md:min-w-0">
         <span className="md:min-w-0 md:truncate">
           <span className="text-primary">{row.summary}</span>
           {href && context ? (
@@ -216,8 +221,11 @@ export function ActivityRow({
           ) : null}
         </span>
         {count > 1 ? (
-          <span className="text-tertiary border-secondary shrink-0 rounded-sm border px-1 font-mono text-[11px] leading-4 tabular-nums">
-            {count}
+          <span
+            data-count={count}
+            className="text-tertiary border-secondary shrink-0 rounded-sm border px-1 font-mono text-[11px] leading-4 tabular-nums"
+          >
+            <RollingDigits value={count} />
           </span>
         ) : null}
         {diff ? (
@@ -436,7 +444,7 @@ function ActivityStackList({
                 count={stack.count}
                 sectionLabel={stack.sectionLabel}
                 href={stack.href}
-                pulse={pulseKey === stack.key}
+                pulse={pulseKey === reactKey}
               />
             </motion.div>
           );
@@ -447,17 +455,20 @@ function ActivityStackList({
 }
 
 function useRollupPulse(stacks: ActivityRollup[]): string | null {
+  const prefersReducedMotion = useReducedMotion();
   const top = stacks[0];
+  const topReactKey = top ? activityStackReactKey(top) : null;
   const [seenTop, setSeenTop] = useState<{ key: string; count: number } | null>(null);
   const [pulseKey, setPulseKey] = useState<string | null>(null);
-  const shouldPulse = shouldPulseActivityRollup(seenTop, top);
-  const nextSeen = top ? { key: top.key, count: top.count } : null;
+  const nextSeen = topReactKey && top ? { key: topReactKey, count: top.count } : null;
+  const shouldPulse =
+    prefersReducedMotion !== true && shouldPulseActivityRollup(seenTop, nextSeen ?? undefined);
   const seenChanged = seenTop?.key !== nextSeen?.key || seenTop?.count !== nextSeen?.count;
 
   if (seenChanged) {
     setSeenTop(nextSeen);
-    if (shouldPulse) {
-      setPulseKey(top.key);
+    if (shouldPulse && topReactKey) {
+      setPulseKey(topReactKey);
     } else if (pulseKey && nextSeen?.key !== pulseKey) {
       setPulseKey(null);
     }
@@ -469,7 +480,7 @@ function useRollupPulse(stacks: ActivityRollup[]): string | null {
     return () => window.clearTimeout(timeout);
   }, [pulseKey, top?.count]);
 
-  return shouldPulse && top ? top.key : pulseKey;
+  return shouldPulse && topReactKey ? topReactKey : pulseKey;
 }
 
 export function ActivityFeed({

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -164,14 +164,12 @@ export function ActivityRow({
   sectionLabel,
   href: hrefOverride,
   pulse = false,
-  showStickyEdge = false,
 }: {
   event: ActivityEvent;
   count?: number;
   sectionLabel?: string;
   href?: string;
   pulse?: boolean;
-  showStickyEdge?: boolean;
 }) {
   const row = getActivityRow(event);
   const homeUrl = activitySourceUrl(event.source);
@@ -198,7 +196,7 @@ export function ActivityRow({
     <div
       data-rollup-pulse={pulse ? "" : undefined}
       className={cn(
-        "group hover:bg-secondary flex items-center gap-3 py-3 pl-4 transition-colors duration-500 md:grid md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5",
+        "group hover:bg-secondary flex w-max min-w-full items-center gap-3 py-3 pl-4 transition-colors duration-500 md:grid md:w-auto md:min-w-0 md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5",
         pulse && "bg-secondary",
       )}
     >
@@ -227,11 +225,11 @@ export function ActivityRow({
       <RelativeTime
         iso={event.received_at}
         className={cn(
-          "group-hover:bg-secondary sticky right-0 z-10 bg-white px-4 dark:bg-black",
-          pulse && "bg-secondary",
-          "md:static md:bg-transparent md:px-0 md:dark:bg-transparent md:dark:group-hover:bg-white/5",
-          showStickyEdge &&
-            "[box-shadow:inset_1px_0_0_var(--border-color-secondary)] md:shadow-none",
+          "sticky right-0 z-10 ml-auto bg-white px-4 dark:bg-black",
+          "group-hover:bg-inherit group-data-[rollup-pulse]:bg-inherit",
+          "max-md:[box-shadow:inset_1px_0_0_var(--border-color-secondary)]",
+          "md:static md:ml-0 md:bg-transparent md:px-0 md:shadow-none md:dark:bg-transparent",
+          "md:group-hover:bg-inherit md:group-data-[rollup-pulse]:bg-inherit md:dark:group-hover:bg-white/5",
         )}
       />
     </div>
@@ -286,22 +284,6 @@ function useIsMobile(): boolean {
     () => window.matchMedia("(max-width: 767px)").matches,
     () => false,
   );
-}
-
-function useHorizontalScrollEdge(ref: RefObject<HTMLElement | null>): boolean {
-  const [isScrolled, setIsScrolled] = useState(false);
-
-  useEffect(() => {
-    const container = ref.current;
-    if (!container) return;
-
-    const update = () => setIsScrolled(container.scrollLeft > 0);
-    update();
-    container.addEventListener("scroll", update, { passive: true });
-    return () => container.removeEventListener("scroll", update);
-  }, [ref]);
-
-  return isScrolled;
 }
 
 function useMobileAxisLock(ref: RefObject<HTMLElement | null>, enabled: boolean) {
@@ -364,11 +346,9 @@ function useMobileAxisLock(ref: RefObject<HTMLElement | null>, enabled: boolean)
 function ActivityStackList({
   stacks,
   pulseKey,
-  showStickyEdge,
 }: {
   stacks: ActivityRollup[];
   pulseKey: string | null;
-  showStickyEdge: boolean;
 }) {
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
@@ -376,7 +356,7 @@ function ActivityStackList({
 
   return (
     <LayoutGroup>
-      <div className="divide-secondary min-w-max divide-y md:min-w-0">
+      <div className="divide-secondary divide-y">
         <AnimatePresence initial={false}>
           {stacks.map((stack) => {
             const reactKey = activityStackReactKey(stack);
@@ -387,7 +367,7 @@ function ActivityStackList({
                 initial={shouldAnimate ? { height: 0, opacity: 0 } : false}
                 animate={{ height: "auto", opacity: 1 }}
                 exit={shouldAnimate ? { height: 0, opacity: 0 } : undefined}
-                className="min-w-full [clip-path:inset(0)]"
+                className="w-max min-w-full [clip-path:inset(0)] md:w-auto md:min-w-0"
                 transition={shouldAnimate ? LIST_MOTION : { duration: 0 }}
               >
                 <ActivityRow
@@ -396,7 +376,6 @@ function ActivityStackList({
                   sectionLabel={stack.sectionLabel}
                   href={stack.href}
                   pulse={pulseKey === stack.key}
-                  showStickyEdge={showStickyEdge}
                 />
               </motion.div>
             );
@@ -445,7 +424,6 @@ export function ActivityFeed({
   const pulseKey = useRollupPulse(stacks);
   const scrollRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
-  const isScrolled = useHorizontalScrollEdge(scrollRef);
   useMobileAxisLock(scrollRef, isMobile);
 
   const topBarContent = useMemo(() => <ActivityTrackedCount count={count} />, [count]);
@@ -465,11 +443,7 @@ export function ActivityFeed({
               Nothing yet. Likes and visits will show up here.
             </p>
           ) : (
-            <ActivityStackList
-              stacks={stacks}
-              pulseKey={pulseKey}
-              showStickyEdge={isScrolled || isMobile}
-            />
+            <ActivityStackList stacks={stacks} pulseKey={pulseKey} />
           )}
         </motion.div>
       </div>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, LayoutGroup, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
-import { type ReactNode, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { type ReactNode, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 
 import { Activity } from "@/components/icons/Activity";
 import { Github } from "@/components/icons/Github";
@@ -14,7 +14,6 @@ import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import type { ActivityEvent, ActivityRollup } from "@/lib/activity";
 import {
-  activityEnterStaggerDelays,
   activityStackReactKey,
   rollupActivityEvents,
   shouldPulseActivityRollup,
@@ -222,17 +221,28 @@ export function ActivityRow({
 
 export function ActivityTrackedCount({ count }: { count: number }) {
   return (
-    <Tooltip>
-      <TooltipTrigger className="text-tertiary cursor-default bg-transparent p-0 text-sm tabular-nums">
+    <Tooltip delay={0} closeDelay={0}>
+      <TooltipTrigger
+        delay={0}
+        closeDelay={0}
+        className="text-tertiary cursor-default bg-transparent p-0 text-sm tabular-nums"
+      >
         {formatTrackedEventsLabel(count)}
       </TooltipTrigger>
-      <TooltipContent>{ACTIVITY_TRACKED_SINCE_TOOLTIP}</TooltipContent>
+      <TooltipContent
+        side="bottom"
+        align="end"
+        collisionPadding={8}
+        container={typeof document === "undefined" ? undefined : document.body}
+      >
+        {ACTIVITY_TRACKED_SINCE_TOOLTIP}
+      </TooltipContent>
     </Tooltip>
   );
 }
 
 const ROLLUP_PULSE_MS = 550;
-const LIST_MOTION = { duration: 0.25, ease: "easeOut" } as const;
+const LIST_MOTION = { duration: 0.16, ease: [0.2, 0, 0, 1] } as const;
 
 function subscribeNoop(): () => void {
   return () => {};
@@ -246,16 +256,6 @@ function useHydrated(): boolean {
   );
 }
 
-function usePreviousKeys(keys: string[]): string[] | null {
-  const previousRef = useRef<string[] | null>(null);
-  useEffect(() => {
-    previousRef.current = keys;
-  }, [keys]);
-  // Last committed key list — new rows must read this on the insert render to get stagger.
-  // eslint-disable-next-line react-hooks/refs -- usePrevious
-  return previousRef.current;
-}
-
 function ActivityStackList({
   stacks,
   pulseKey,
@@ -266,12 +266,6 @@ function ActivityStackList({
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
   const shouldAnimate = hydrated && prefersReducedMotion !== true;
-  const keys = useMemo(() => stacks.map(activityStackReactKey), [stacks]);
-  const previousKeys = usePreviousKeys(keys);
-  const enterDelays =
-    shouldAnimate && previousKeys
-      ? activityEnterStaggerDelays(keys, new Set(previousKeys))
-      : new Map<string, number>();
 
   return (
     <LayoutGroup>
@@ -279,22 +273,15 @@ function ActivityStackList({
         <AnimatePresence initial={false}>
           {stacks.map((stack) => {
             const reactKey = activityStackReactKey(stack);
-            const delay = enterDelays.get(reactKey) ?? 0;
             return (
               <motion.div
                 key={reactKey}
-                layout={shouldAnimate}
-                initial={shouldAnimate ? { opacity: 0, y: -8 } : false}
-                animate={{ opacity: 1, y: 0 }}
-                transition={
-                  shouldAnimate
-                    ? {
-                        opacity: { ...LIST_MOTION, delay },
-                        y: { ...LIST_MOTION, delay },
-                        layout: LIST_MOTION,
-                      }
-                    : { duration: 0 }
-                }
+                layout={shouldAnimate ? "position" : false}
+                initial={shouldAnimate ? { height: 0, opacity: 0 } : false}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={shouldAnimate ? { height: 0, opacity: 0 } : undefined}
+                className="overflow-hidden"
+                transition={shouldAnimate ? LIST_MOTION : { duration: 0 }}
               >
                 <ActivityRow
                   event={stack.latest}

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -356,7 +356,7 @@ function ActivityStackList({
 
   return (
     <LayoutGroup>
-      <div className="divide-secondary divide-y">
+      <div className="divide-secondary min-w-max divide-y md:min-w-0">
         <AnimatePresence initial={false}>
           {stacks.map((stack) => {
             const reactKey = activityStackReactKey(stack);

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -234,6 +234,7 @@ export function ActivityTrackedCount({ count }: { count: number }) {
         align="end"
         collisionPadding={8}
         container={typeof document === "undefined" ? undefined : document.body}
+        className="overflow-visible whitespace-nowrap"
       >
         {ACTIVITY_TRACKED_SINCE_TOOLTIP}
       </TooltipContent>

--- a/src/components/LiveNumber.tsx
+++ b/src/components/LiveNumber.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { motion } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
 
+import { DigitColumn } from "@/components/RollingDigits";
 import { cn } from "@/lib/utils";
 
 interface LiveNumberProps {
@@ -10,98 +10,6 @@ interface LiveNumberProps {
   baseTime: Date;
   rate: number; // units per second
   className?: string;
-}
-
-function DigitColumn({ digit, isIncreasing = true }: { digit: string; isIncreasing?: boolean }) {
-  const digitValue = parseInt(digit);
-
-  // Calculate rotation based on current and previous digit
-  const calculateRotation = useCallback(
-    (currentDigit: number, previousDigit: number): number => {
-      if (isNaN(currentDigit)) return 0;
-
-      if (previousDigit === currentDigit) {
-        return currentDigit * 36;
-      }
-
-      let rotationChange = 0;
-
-      if (isIncreasing) {
-        // For increasing numbers, always rotate upward
-        if (currentDigit < previousDigit) {
-          // Wrapping from 9 to 0 - continue upward through the wrap
-          rotationChange = (10 - previousDigit + currentDigit) * 36;
-        } else {
-          // Normal increase
-          rotationChange = (currentDigit - previousDigit) * 36;
-        }
-      } else {
-        // For decreasing numbers, use shortest path
-        const diff = currentDigit - previousDigit;
-        const wrappedDiff = diff > 5 ? diff - 10 : diff < -5 ? diff + 10 : diff;
-        rotationChange = (Math.abs(wrappedDiff) < Math.abs(diff) ? wrappedDiff : diff) * 36;
-      }
-
-      return rotationChange;
-    },
-    [isIncreasing],
-  );
-
-  const [cumulativeRotation, setCumulativeRotation] = useState(() => {
-    // Initial rotation based on digit value
-    return isNaN(digitValue) ? 0 : digitValue * 36;
-  });
-
-  // Track previous digit to detect changes
-  const [lastDigit, setLastDigit] = useState(digitValue);
-
-  // Update rotation when digit changes - using layout effect to avoid intermediate renders
-  if (lastDigit !== digitValue && !isNaN(digitValue)) {
-    const rotationChange = calculateRotation(digitValue, lastDigit);
-    setCumulativeRotation((prev) => prev + rotationChange);
-    setLastDigit(digitValue);
-  }
-
-  // If it's not a number (like comma), just render it statically
-  if (isNaN(digitValue)) {
-    return <span className="w-[0.5em] text-center">{digit}</span>;
-  }
-
-  // Radius of the cylinder - determines how "deep" the 3D effect looks
-  const radius = 1.2; // em units
-
-  return (
-    <span
-      className="relative inline-block h-[1em] w-[0.75em] overflow-hidden"
-      style={{ perspective: "200px" }}
-    >
-      <motion.div
-        className="absolute inset-0 flex items-center justify-center"
-        style={{ transformStyle: "preserve-3d" }}
-        animate={{
-          rotateX: cumulativeRotation,
-        }}
-        transition={{
-          duration: 0.5,
-          ease: "easeInOut",
-        }}
-      >
-        {/* Render all digits 0-9 positioned around the cylinder */}
-        {Array.from({ length: 10 }, (_, i) => (
-          <div
-            key={i}
-            className="absolute flex h-full w-full items-center justify-center text-center"
-            style={{
-              transform: `rotateX(${-i * 36}deg) translateZ(${radius}em)`,
-              backfaceVisibility: "hidden",
-            }}
-          >
-            {i}
-          </div>
-        ))}
-      </motion.div>
-    </span>
-  );
 }
 
 export function LiveNumber({ base, baseTime, rate, className }: LiveNumberProps) {

--- a/src/components/RollingDigits.tsx
+++ b/src/components/RollingDigits.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { useCallback, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function DigitColumn({
+  digit,
+  isIncreasing = true,
+}: {
+  digit: string;
+  isIncreasing?: boolean;
+}) {
+  const digitValue = parseInt(digit);
+
+  const calculateRotation = useCallback(
+    (currentDigit: number, previousDigit: number): number => {
+      if (isNaN(currentDigit)) return 0;
+
+      if (previousDigit === currentDigit) {
+        return currentDigit * 36;
+      }
+
+      let rotationChange = 0;
+
+      if (isIncreasing) {
+        if (currentDigit < previousDigit) {
+          rotationChange = (10 - previousDigit + currentDigit) * 36;
+        } else {
+          rotationChange = (currentDigit - previousDigit) * 36;
+        }
+      } else {
+        const diff = currentDigit - previousDigit;
+        const wrappedDiff = diff > 5 ? diff - 10 : diff < -5 ? diff + 10 : diff;
+        rotationChange = (Math.abs(wrappedDiff) < Math.abs(diff) ? wrappedDiff : diff) * 36;
+      }
+
+      return rotationChange;
+    },
+    [isIncreasing],
+  );
+
+  const [cumulativeRotation, setCumulativeRotation] = useState(() => {
+    return isNaN(digitValue) ? 0 : digitValue * 36;
+  });
+
+  const [lastDigit, setLastDigit] = useState(digitValue);
+
+  if (lastDigit !== digitValue && !isNaN(digitValue)) {
+    const rotationChange = calculateRotation(digitValue, lastDigit);
+    setCumulativeRotation((prev) => prev + rotationChange);
+    setLastDigit(digitValue);
+  }
+
+  if (isNaN(digitValue)) {
+    return <span className="w-[0.5em] text-center">{digit}</span>;
+  }
+
+  const radius = 1.2;
+
+  return (
+    <span
+      className="relative inline-block h-[1em] w-[0.75em] overflow-hidden"
+      style={{ perspective: "200px" }}
+    >
+      <motion.div
+        className="absolute inset-0 flex items-center justify-center"
+        style={{ transformStyle: "preserve-3d" }}
+        animate={{
+          rotateX: cumulativeRotation,
+        }}
+        transition={{
+          duration: 0.5,
+          ease: "easeInOut",
+        }}
+      >
+        {Array.from({ length: 10 }, (_, i) => (
+          <div
+            key={i}
+            className="absolute flex h-full w-full items-center justify-center text-center"
+            style={{
+              transform: `rotateX(${-i * 36}deg) translateZ(${radius}em)`,
+              backfaceVisibility: "hidden",
+            }}
+          >
+            {i}
+          </div>
+        ))}
+      </motion.div>
+    </span>
+  );
+}
+
+export function RollingDigits({ value, className }: { value: number; className?: string }) {
+  const prefersReducedMotion = useReducedMotion();
+  const formatted = new Intl.NumberFormat().format(value);
+
+  if (prefersReducedMotion) {
+    return <span className={className}>{formatted}</span>;
+  }
+
+  return (
+    <span className={cn("inline-flex", className)}>
+      {formatted.split("").map((char, i) => {
+        const positionFromRight = formatted.length - 1 - i;
+        return <DigitColumn key={`pos-${positionFromRight}`} digit={char} isIncreasing />;
+      })}
+    </span>
+  );
+}

--- a/src/components/RollingDigits.tsx
+++ b/src/components/RollingDigits.tsx
@@ -64,7 +64,7 @@ export function DigitColumn({
       className="relative inline-block h-[1em] w-[0.75em] overflow-hidden"
       style={{ perspective: "200px" }}
     >
-      <motion.div
+      <motion.span
         className="absolute inset-0 flex items-center justify-center"
         style={{ transformStyle: "preserve-3d" }}
         animate={{
@@ -76,7 +76,7 @@ export function DigitColumn({
         }}
       >
         {Array.from({ length: 10 }, (_, i) => (
-          <div
+          <span
             key={i}
             className="absolute flex h-full w-full items-center justify-center text-center"
             style={{
@@ -85,9 +85,9 @@ export function DigitColumn({
             }}
           >
             {i}
-          </div>
+          </span>
         ))}
-      </motion.div>
+      </motion.span>
     </span>
   );
 }

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -7,7 +7,23 @@ import { cn } from "@/lib/utils";
 
 const TooltipProvider = BaseUITooltip.Provider;
 
-const Tooltip = BaseUITooltip.Root;
+type TooltipProps = React.ComponentProps<typeof BaseUITooltip.Root> & {
+  delay?: number;
+  closeDelay?: number;
+};
+
+function Tooltip({ delay, closeDelay, children, ...props }: TooltipProps) {
+  const root = <BaseUITooltip.Root {...props}>{children}</BaseUITooltip.Root>;
+  if (delay === undefined && closeDelay === undefined) {
+    return root;
+  }
+
+  return (
+    <TooltipProvider delay={delay} closeDelay={closeDelay}>
+      {root}
+    </TooltipProvider>
+  );
+}
 
 const TooltipTrigger = BaseUITooltip.Trigger;
 
@@ -18,30 +34,52 @@ const TooltipPositioner = BaseUITooltip.Positioner;
 interface TooltipContentProps extends React.ComponentPropsWithoutRef<typeof BaseUITooltip.Popup> {
   sideOffset?: number;
   side?: "top" | "bottom" | "left" | "right";
+  align?: "start" | "center" | "end";
+  collisionPadding?: number;
+  container?: React.ComponentProps<typeof BaseUITooltip.Portal>["container"];
 }
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof BaseUITooltip.Popup>,
   TooltipContentProps
->(({ className, sideOffset = 4, side = "top", children, ...props }, ref) => (
-  <TooltipPortal>
-    <TooltipPositioner side={side} sideOffset={sideOffset}>
-      <BaseUITooltip.Popup
-        ref={ref}
-        className={cn(
-          "border-secondary bg-primary text-primary z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md",
-          "origin-(--transform-origin) transition-[transform,scale,opacity] duration-150",
-          "data-[starting-style]:scale-95 data-[starting-style]:opacity-0",
-          "data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
-          className,
-        )}
-        {...props}
+>(
+  (
+    {
+      className,
+      sideOffset = 4,
+      side = "top",
+      align,
+      collisionPadding,
+      container,
+      children,
+      ...props
+    },
+    ref,
+  ) => (
+    <TooltipPortal container={container}>
+      <TooltipPositioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        collisionPadding={collisionPadding}
       >
-        {children}
-      </BaseUITooltip.Popup>
-    </TooltipPositioner>
-  </TooltipPortal>
-));
+        <BaseUITooltip.Popup
+          ref={ref}
+          className={cn(
+            "border-secondary bg-primary text-primary z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md",
+            "origin-(--transform-origin) transition-[transform,scale,opacity] duration-150",
+            "data-[starting-style]:scale-95 data-[starting-style]:opacity-0",
+            "data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </BaseUITooltip.Popup>
+      </TooltipPositioner>
+    </TooltipPortal>
+  ),
+);
 TooltipContent.displayName = "TooltipContent";
 
 export {

--- a/src/lib/activity-geo.ts
+++ b/src/lib/activity-geo.ts
@@ -517,14 +517,19 @@ function isRegionalIndicator(char: string): boolean {
 export function splitVisitSummaryFlag(summary: string): { flag?: string; text: string } {
   const chars = [...summary];
   if (
-    chars.length >= 3 &&
+    chars.length >= 2 &&
     isRegionalIndicator(chars[0] ?? "") &&
-    isRegionalIndicator(chars[1] ?? "") &&
-    chars[2] === " "
+    isRegionalIndicator(chars[1] ?? "")
   ) {
-    return { flag: `${chars[0]}${chars[1]}`, text: chars.slice(3).join("") };
+    const rest = chars.slice(2).join("").replace(/^\s+/, "");
+    return { flag: `${chars[0]}${chars[1]}`, text: rest };
   }
   return { text: summary };
+}
+
+/** Display-only: drop a leading flag emoji. Ingest may still store one. */
+export function visitDisplaySummary(summary: string): string {
+  return splitVisitSummaryFlag(summary).text.trim();
 }
 
 export function geoFromVisitMeta(meta: Record<string, unknown> | undefined): {

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -116,6 +116,7 @@ function stackHref(events: ActivityEvent[]): string | undefined {
   return `/${section}`;
 }
 
+/** Consecutive runs only — an interrupting event always starts a new stack. */
 export function rollupActivityEvents(events: ActivityEvent[]): ActivityRollup[] {
   const runs: Array<{
     key: string;

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -25,8 +25,8 @@ export function activityStackReactKey(stack: Pick<ActivityRollup, "key" | "ancho
   return `${stack.key}:${stack.anchorId}`;
 }
 
-export const ACTIVITY_ENTER_STAGGER_STEP = 0.1;
-export const ACTIVITY_ENTER_STAGGER_MAX = 1;
+export const ACTIVITY_ENTER_STAGGER_STEP = 0.05;
+export const ACTIVITY_ENTER_STAGGER_MAX = 0.4;
 
 /** Enter delays for keys that were not on screen last paint. First paint (`previous` null) is empty. */
 export function activityEnterStaggerDelays(

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -47,6 +47,28 @@ export function activityEnterStaggerDelays(
   return delays;
 }
 
+/**
+ * First committed key set is already on screen — no enter delays.
+ * Later keys not in `previous` get stagger delays; existing keys do not.
+ */
+export function nextActivityEnterState(
+  keys: string[],
+  previous: Set<string> | null,
+  step = ACTIVITY_ENTER_STAGGER_STEP,
+  max = ACTIVITY_ENTER_STAGGER_MAX,
+): { seen: Set<string>; delays: Map<string, number> } {
+  if (previous === null) {
+    return { seen: new Set(keys), delays: new Map() };
+  }
+
+  const delays = activityEnterStaggerDelays(keys, previous, step, max);
+  if (delays.size === 0) return { seen: previous, delays };
+
+  const seen = new Set(previous);
+  for (const key of keys) seen.add(key);
+  return { seen, delays };
+}
+
 export function activityEventHref(event: ActivityEvent): string | undefined {
   if (event.subject?.href) return event.subject.href;
   const path = event.meta?.path;

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -76,6 +76,70 @@ export function resolveActivitySourceHref(
   return trimmed;
 }
 
+function normalizeHrefForCompare(href: string): string {
+  return href.trim().replace(/\/+$/, "");
+}
+
+function isSourceHomeHref(source: string, href: string | undefined): boolean {
+  const trimmed = href?.trim();
+  if (!trimmed || trimmed === "/") return true;
+  const home = activitySourceUrl(source);
+  if (!home) return false;
+  return normalizeHrefForCompare(trimmed) === normalizeHrefForCompare(home);
+}
+
+function hasSpecificSubjectHref(source: string, href: string | undefined): boolean {
+  return Boolean(href?.trim()) && !isSourceHomeHref(source, href);
+}
+
+function stripSourceNameFromSummary(summary: string, sourceLabel: string): string {
+  const escaped = sourceLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const trimmed = summary.trim();
+  const withoutSuffix = trimmed
+    .replace(new RegExp(`\\s+(?:on|for)\\s+${escaped}$`, "i"), "")
+    .trim();
+  if (withoutSuffix !== trimmed) return withoutSuffix;
+
+  const downloaded = trimmed.match(new RegExp(`^(Someone downloaded)\\s+${escaped}$`, "i"));
+  if (downloaded?.[1]) return downloaded[1];
+  return summary;
+}
+
+function attachSourceMetadata(
+  event: ActivityEvent,
+  row: {
+    summary: string;
+    flag?: string;
+    icon?: string;
+    href?: string;
+    label?: string;
+  },
+): {
+  summary: string;
+  flag?: string;
+  icon?: string;
+  href?: string;
+  label?: string;
+} {
+  if (event.type === "like" || event.source === ACTIVITY_SOURCE_BRIOS) {
+    return row;
+  }
+
+  const sourceLabel = activitySourceLabel(event.source);
+  const sourceUrl = activitySourceUrl(event.source);
+  if (hasSpecificSubjectHref(event.source, row.href)) {
+    return row;
+  }
+  if (!sourceUrl) return row;
+
+  return {
+    ...row,
+    summary: stripSourceNameFromSummary(row.summary, sourceLabel),
+    label: sourceLabel,
+    href: sourceUrl,
+  };
+}
+
 export function formatDownloadSummary(source: string, label?: string): string {
   return `Someone downloaded ${label?.trim() || activitySourceLabel(source)}`;
 }
@@ -593,12 +657,12 @@ export function getActivityRow(event: ActivityEvent): {
   label?: string;
 } {
   if (event.type === "caffeinated") {
-    return {
+    return attachSourceMetadata(event, {
       summary: event.summary,
       icon: getCaffeineIcon(caffeineDrinkFromEvent(event)),
       href: event.subject?.href,
       label: event.subject?.label,
-    };
+    });
   }
 
   if (event.type === "visit") {
@@ -610,19 +674,19 @@ export function getActivityRow(event: ActivityEvent): {
       : !storedText || storedText === "Visit"
         ? ANONYMOUS_VISIT_SUMMARY
         : visitSummaryWithFlag(event.summary, event.meta);
-    return {
+    return attachSourceMetadata(event, {
       summary,
       href: event.subject?.href,
       label: displaySubjectLabel(event.subject?.label, event.subject?.href),
-    };
+    });
   }
 
   if (event.type === "visit_country_first") {
-    return {
+    return attachSourceMetadata(event, {
       summary: visitSummaryWithFlag(event.summary, event.meta),
       href: event.subject?.href,
       label: displaySubjectLabel(event.subject?.label, event.subject?.href),
-    };
+    });
   }
 
   if (event.type === "like") {
@@ -631,18 +695,18 @@ export function getActivityRow(event: ActivityEvent): {
     });
     const fromSummary = likedTitleFromSummary(event.summary);
     const name = label || fromSummary || "Home";
-    return {
+    return attachSourceMetadata(event, {
       summary: "Someone liked",
       href: event.subject?.href || (name === "Home" ? "/" : undefined),
       label: name,
-    };
+    });
   }
 
-  return {
+  return attachSourceMetadata(event, {
     summary: event.summary,
     href: event.subject?.href,
     label: displaySubjectLabel(event.subject?.label, event.subject?.href),
-  };
+  });
 }
 
 export function getRequestCountry(headers: Headers): string | undefined {

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -455,6 +455,15 @@ function displaySubjectLabel(
   return looksLikeIdentifier(cleaned) ? undefined : formatActivityTitle(cleaned);
 }
 
+function likedTitleFromSummary(summary: string): string | undefined {
+  const trimmed = summary.trim();
+  if (/^someone liked$/i.test(trimmed)) return undefined;
+  const rest = trimmed.replace(/^Someone liked\s+/i, "").trim();
+  if (!rest) return undefined;
+  if (rest === "a page") return "Home";
+  return rest;
+}
+
 const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
 const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
 const IPV6_RE = /\b(?:[0-9a-f]{1,4}:){2,7}[0-9a-f]{1,4}\b/i;
@@ -620,11 +629,12 @@ export function getActivityRow(event: ActivityEvent): {
     const label = displaySubjectLabel(event.subject?.label, event.subject?.href, {
       preferStored: true,
     });
-    const name = label || "a page";
+    const fromSummary = likedTitleFromSummary(event.summary);
+    const name = label || fromSummary || "Home";
     return {
-      summary: `Someone liked ${name}`,
-      href: event.subject?.href,
-      label,
+      summary: "Someone liked",
+      href: event.subject?.href || (name === "Home" ? "/" : undefined),
+      label: name,
     };
   }
 

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -5,11 +5,10 @@
 
 import {
   ANONYMOUS_VISIT_SUMMARY,
-  countryCodeToFlag,
   formatVisitSummary,
   geoFromVisitMeta,
   normalizeCountryCode,
-  splitVisitSummaryFlag,
+  visitDisplaySummary,
 } from "./activity-geo";
 
 export { countryCodeToFlag, normalizeCountryCode } from "./activity-geo";
@@ -578,13 +577,6 @@ function scanPii(value: unknown, path: string): string | null {
   return null;
 }
 
-function visitSummaryWithFlag(summary: string, meta: Record<string, unknown> | undefined): string {
-  const split = splitVisitSummaryFlag(summary);
-  if (split.flag) return summary;
-  const flag = countryCodeToFlag(geoFromVisitMeta(meta).country);
-  return flag ? `${flag} ${summary}` : summary;
-}
-
 export function getMergedPullRequestDiff(
   meta: Record<string, unknown> | undefined,
 ): { additions: number; deletions: number } | null {
@@ -668,12 +660,12 @@ export function getActivityRow(event: ActivityEvent): {
   if (event.type === "visit") {
     const geo = geoFromVisitMeta(event.meta);
     const hasLocation = Boolean(geo.country || geo.city || geo.countryName);
-    const storedText = splitVisitSummaryFlag(event.summary).text.trim();
+    const storedText = visitDisplaySummary(event.summary);
     const summary = hasLocation
-      ? formatVisitSummary(geo)
+      ? visitDisplaySummary(formatVisitSummary(geo))
       : !storedText || storedText === "Visit"
         ? ANONYMOUS_VISIT_SUMMARY
-        : visitSummaryWithFlag(event.summary, event.meta);
+        : storedText;
     return attachSourceMetadata(event, {
       summary,
       href: event.subject?.href,
@@ -683,7 +675,7 @@ export function getActivityRow(event: ActivityEvent): {
 
   if (event.type === "visit_country_first") {
     return attachSourceMetadata(event, {
-      summary: visitSummaryWithFlag(event.summary, event.meta),
+      summary: visitDisplaySummary(event.summary),
       href: event.subject?.href,
       label: displaySubjectLabel(event.subject?.label, event.subject?.href),
     });

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -25,6 +25,7 @@ import {
   likeMetaFromRequest,
   looksLikeIdentifier,
   looksLikeShortId,
+  nextActivityEnterState,
   recordCaffeine,
   recordDigestSubscribed,
   recordLike,
@@ -1808,6 +1809,23 @@ describe("rollupActivityEvents", () => {
     expect(capped.get("n-8")).toBe(0.4);
     expect(capped.get("n-15")).toBe(0.4);
     expect(capped.has("old-1")).toBe(false);
+  });
+
+  test("first committed paint of N stacks has no enter delays", () => {
+    const keys = ["a", "b", "c", "d", "e"];
+    const first = nextActivityEnterState(keys, null);
+    expect(first.delays.size).toBe(0);
+    expect(first.seen).toEqual(new Set(keys));
+    expect(nextActivityEnterState(keys, first.seen).delays.size).toBe(0);
+  });
+
+  test("only a newly prepended stack gets an enter delay", () => {
+    const previous = new Set(["old-1", "old-2"]);
+    const next = nextActivityEnterState(["new-1", "old-1", "old-2"], previous);
+    expect([...next.delays.entries()]).toEqual([["new-1", 0]]);
+    expect(next.delays.has("old-1")).toBe(false);
+    expect(next.delays.has("old-2")).toBe(false);
+    expect(next.seen).toEqual(new Set(["new-1", "old-1", "old-2"]));
   });
 
   test("only pulses when the same run's count increments", () => {

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1741,17 +1741,17 @@ describe("rollupActivityEvents", () => {
     );
     expect([...delays.entries()]).toEqual([
       ["new-1", 0],
-      ["new-2", 0.1],
-      ["new-3", 0.2],
-      ["new-4", 0.3],
-      ["new-5", 0.4],
+      ["new-2", 0.05],
+      ["new-3", 0.1],
+      ["new-4", 0.15],
+      ["new-5", 0.2],
     ]);
 
     const many = Array.from({ length: 16 }, (_, index) => `n-${index}`);
     const capped = activityEnterStaggerDelays(many, new Set());
     expect(capped.get("n-0")).toBe(0);
-    expect(capped.get("n-10")).toBe(1);
-    expect(capped.get("n-15")).toBe(1);
+    expect(capped.get("n-8")).toBe(0.4);
+    expect(capped.get("n-15")).toBe(0.4);
     expect(capped.has("old-1")).toBe(false);
   });
 

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -759,8 +759,8 @@ describe("HMAC download ingest", () => {
     expect(result.ok && !result.duplicate).toBe(true);
     expect(await store.getCount()).toBe(1);
     expect(getActivityRow((await store.getTail(1))[0]!)).toEqual({
-      summary: "Someone downloaded Shiori",
-      href: undefined,
+      summary: "Someone downloaded",
+      href: "https://www.shiori.sh",
       label: "Shiori",
     });
   });
@@ -1278,6 +1278,181 @@ describe("getActivityRow page titles", () => {
       summary: "Someone liked",
       href: "/writing/grok-bot-first-impressions",
       label: "Grok Bot First Impressions",
+    });
+  });
+});
+
+describe("getActivityRow source metadata", () => {
+  function rowEvent(overrides: Partial<ActivityEvent>): ActivityEvent {
+    return {
+      v: 1,
+      id: "src-row",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "shiori",
+      type: "link_saved",
+      speed: "event",
+      summary: "Someone saved a link on Shiori",
+      visibility: "public",
+      idempotency_key: "src-row",
+      ...overrides,
+    };
+  }
+
+  test("lifts Shiori out of save/click/signup/subscribe/download summaries", () => {
+    expect(getActivityRow(rowEvent({ type: "link_saved" }))).toEqual({
+      summary: "Someone saved a link",
+      href: "https://www.shiori.sh",
+      label: "Shiori",
+    });
+    expect(
+      getActivityRow(
+        rowEvent({
+          type: "link_clicked",
+          summary: "Someone clicked a link on Shiori",
+        }),
+      ),
+    ).toEqual({
+      summary: "Someone clicked a link",
+      href: "https://www.shiori.sh",
+      label: "Shiori",
+    });
+    expect(
+      getActivityRow(
+        rowEvent({
+          type: "signed_up",
+          summary: "Someone signed up for Shiori",
+        }),
+      ),
+    ).toEqual({
+      summary: "Someone signed up",
+      href: "https://www.shiori.sh",
+      label: "Shiori",
+    });
+    expect(
+      getActivityRow(
+        rowEvent({
+          type: "subscription_started",
+          summary: "Someone subscribed on Shiori",
+        }),
+      ),
+    ).toEqual({
+      summary: "Someone subscribed",
+      href: "https://www.shiori.sh",
+      label: "Shiori",
+    });
+    expect(
+      getActivityRow(
+        rowEvent({
+          type: "download",
+          summary: "Someone downloaded Shiori",
+          subject: { kind: "download", label: "Shiori" },
+        }),
+      ),
+    ).toEqual({
+      summary: "Someone downloaded",
+      href: "https://www.shiori.sh",
+      label: "Shiori",
+    });
+  });
+
+  test("uses the product home for an external visit without a better page href", () => {
+    expect(
+      getActivityRow(
+        rowEvent({
+          source: "design-details",
+          type: "visit",
+          speed: "signal",
+          summary: "🇺🇸 Visit from United States",
+          subject: { kind: "home", label: "Home", href: "/" },
+          meta: { country: "US", path: "/", title: "Home" },
+        }),
+      ),
+    ).toEqual({
+      summary: "🇺🇸 Visit from United States",
+      href: "https://designdetails.fm",
+      label: "Design Details",
+    });
+  });
+
+  test("keeps a more specific staff.design page href instead of the product home", () => {
+    expect(
+      getActivityRow(
+        rowEvent({
+          source: "staff-design",
+          type: "visit",
+          speed: "signal",
+          summary: "🇩🇪 Visit from Germany",
+          subject: {
+            kind: "page",
+            label: "Karla Mickens Cole",
+            href: "/karla-mickens-cole",
+          },
+          meta: { country: "DE", path: "/karla-mickens-cole", title: "Karla Mickens Cole" },
+        }),
+      ),
+    ).toEqual({
+      summary: "🇩🇪 Visit from Germany",
+      href: "/karla-mickens-cole",
+      label: "Karla Mickens Cole",
+    });
+  });
+
+  test("keeps a public GitHub PR href instead of github.com/brianlovin", () => {
+    expect(
+      getActivityRow(
+        rowEvent({
+          source: "github",
+          type: "pr_opened",
+          summary: "Opened a pull request on briOS",
+          subject: {
+            kind: "pull_request",
+            label: "Add activity feed",
+            href: "https://github.com/brianlovin/briOS/pull/42",
+          },
+        }),
+      ),
+    ).toEqual({
+      summary: "Opened a pull request on briOS",
+      href: "https://github.com/brianlovin/briOS/pull/42",
+      label: "Add activity feed",
+    });
+  });
+
+  test("does not rewrite a first-party like or visit to briOS", () => {
+    expect(
+      getActivityRow(
+        rowEvent({
+          source: "brios",
+          type: "like",
+          summary: "Someone liked Cursor",
+          subject: { kind: "stack", label: "Cursor", href: "https://cursor.com" },
+        }),
+      ),
+    ).toEqual({
+      summary: "Someone liked",
+      href: "https://cursor.com",
+      label: "Cursor",
+    });
+    expect(
+      getActivityRow(
+        rowEvent({
+          source: "brios",
+          type: "visit",
+          speed: "signal",
+          summary: "🇮🇳 Visit from India",
+          subject: {
+            kind: "writing",
+            label: "Grok Bot first impressions",
+            href: "/writing/grok-bot-first-impressions",
+          },
+          meta: { country: "IN", path: "/writing/grok-bot-first-impressions" },
+        }),
+      ),
+    ).toEqual({
+      summary: "🇮🇳 Visit from India",
+      href: "/writing/grok-bot-first-impressions",
+      label: "Grok Bot first impressions",
     });
   });
 });

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -857,7 +857,7 @@ describe("recordLike", () => {
       href: "https://cursor.com",
     });
     expect(getActivityRow(event!)).toEqual({
-      summary: "Someone liked Cursor",
+      summary: "Someone liked",
       href: "https://cursor.com",
       label: "Cursor",
     });
@@ -877,7 +877,8 @@ describe("recordLike", () => {
     const [event] = await store.getTail(1);
     expect(event?.summary).toBe("Someone liked Secret for iOS");
     expect(event?.subject?.label).toBe("Secret for iOS");
-    expect(getActivityRow(event!).summary).toBe("Someone liked Secret for iOS");
+    expect(getActivityRow(event!).summary).toBe("Someone liked");
+    expect(getActivityRow(event!).label).toBe("Secret for iOS");
   });
 
   test("does not store a like title that looks like PII", async () => {
@@ -1212,6 +1213,27 @@ describe("getActivityRow page titles", () => {
     expect(row.href).toBe("/ama/2f2c711c-0ceb-810d-899d-e5feb99e70f4");
   });
 
+  test("splits a stored Home like into Someone liked plus a Home label", () => {
+    const row = getActivityRow({
+      v: 1,
+      id: "like-home",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "brios",
+      type: "like",
+      speed: "event",
+      summary: "Someone liked a page",
+      visibility: "public",
+      idempotency_key: "like-home",
+      subject: { kind: "home", label: "a page", href: "/" },
+    });
+    expect(row).toEqual({
+      summary: "Someone liked",
+      href: "/",
+      label: "Home",
+    });
+  });
+
   test("keeps a liked stack item name instead of rewriting it to Stack", () => {
     const row = getActivityRow({
       v: 1,
@@ -1228,7 +1250,7 @@ describe("getActivityRow page titles", () => {
       meta: { content_type: "stack", title: "Cursor", href: "/stack" },
     });
     expect(row).toEqual({
-      summary: "Someone liked Cursor",
+      summary: "Someone liked",
       href: "/stack",
       label: "Cursor",
     });
@@ -1253,7 +1275,7 @@ describe("getActivityRow page titles", () => {
       },
     });
     expect(row).toEqual({
-      summary: "Someone liked Grok Bot First Impressions",
+      summary: "Someone liked",
       href: "/writing/grok-bot-first-impressions",
       label: "Grok Bot First Impressions",
     });
@@ -1511,8 +1533,10 @@ describe("rollupActivityEvents", () => {
     expect(stacks).toHaveLength(2);
     expect(stacks[0]?.key).toBe("like:https://cursor.com");
     expect(stacks[1]?.key).toBe("like:https://www.raycast.com");
-    expect(getActivityRow(stacks[0]!.latest).summary).toBe("Someone liked Cursor");
-    expect(getActivityRow(stacks[1]!.latest).summary).toBe("Someone liked Raycast");
+    expect(getActivityRow(stacks[0]!.latest).summary).toBe("Someone liked");
+    expect(getActivityRow(stacks[0]!.latest).label).toBe("Cursor");
+    expect(getActivityRow(stacks[1]!.latest).summary).toBe("Someone liked");
+    expect(getActivityRow(stacks[1]!.latest).label).toBe("Raycast");
   });
 
   test("does not merge the same type across a different intervening event", () => {

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -37,7 +37,7 @@ import {
   stripSiteTitleSuffix,
   stripTrailingShortIdToken,
 } from "@/lib/activity";
-import { geoFromVisitMeta, normalizeRegionCode } from "@/lib/activity-geo";
+import { geoFromVisitMeta, normalizeRegionCode, visitDisplaySummary } from "@/lib/activity-geo";
 import { parseActivityStreamFields } from "@/lib/activity-redis";
 import { ACTIVITY_STREAM_MAXLEN, ACTIVITY_VISIT_STREAM_MAX_PER_SEC } from "@/lib/activity-shared";
 
@@ -342,6 +342,17 @@ describe("formatVisitSummary", () => {
   });
 });
 
+describe("visitDisplaySummary", () => {
+  test("drops a leading flag emoji and keeps the location text", () => {
+    expect(visitDisplaySummary("🇺🇸 Visit from San Francisco, California, United States")).toBe(
+      "Visit from San Francisco, California, United States",
+    );
+    expect(visitDisplaySummary("🇮🇳Visit from India")).toBe("Visit from India");
+    expect(visitDisplaySummary("Visit from India")).toBe("Visit from India");
+    expect(visitDisplaySummary(ANONYMOUS_VISIT_SUMMARY)).toBe(ANONYMOUS_VISIT_SUMMARY);
+  });
+});
+
 describe("normalizeRegionCode", () => {
   test("returns undefined for placeholder all-zero codes", () => {
     expect(normalizeRegionCode("00")).toBeUndefined();
@@ -391,7 +402,7 @@ describe("recordVisit", () => {
       title: "Grok Bot First Impressions",
     });
     expect(getActivityRow(event!)).toEqual({
-      summary: "🇮🇳 Visit from India",
+      summary: "Visit from India",
       href: "/writing/grok-bot-first-impressions",
       label: "Grok Bot First Impressions",
     });
@@ -597,7 +608,7 @@ describe("recordVisit", () => {
       idempotency_key: "old-located",
       subject: { kind: "writing", label: "Writing", href: "/writing" },
     });
-    expect(row.summary).toBe("🇫🇷 Visit from France");
+    expect(row.summary).toBe("Visit from France");
   });
 
   test("keeps the existing summary when the country has no flag", async () => {
@@ -610,7 +621,7 @@ describe("recordVisit", () => {
     expect(event?.meta).toEqual({ country: "XX", path: "/", title: "Home" });
   });
 
-  test("prefixes a flag in getActivityRow for older visits that lack the emoji", () => {
+  test("does not prefix a flag in getActivityRow for older visits that lack the emoji", () => {
     const row = getActivityRow({
       v: 1,
       id: "old-visit",
@@ -625,11 +636,12 @@ describe("recordVisit", () => {
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "🇮🇳 Visit from India",
+      summary: "Visit from India",
     });
+    expect(row.summary).not.toMatch(/\p{Regional_Indicator}/u);
   });
 
-  test("still flags leftover first-country stream rows", () => {
+  test("strips a stored flag from leftover first-country stream rows", () => {
     const row = getActivityRow({
       v: 1,
       id: "old-first",
@@ -638,13 +650,13 @@ describe("recordVisit", () => {
       source: "brios",
       type: "visit_country_first",
       speed: "event",
-      summary: "First visit from IN",
+      summary: "🇮🇳 First visit from IN",
       visibility: "public",
       idempotency_key: "old-first",
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "🇮🇳 First visit from IN",
+      summary: "First visit from IN",
     });
   });
 
@@ -1369,7 +1381,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "🇺🇸 Visit from United States",
+      summary: "Visit from United States",
       href: "https://designdetails.fm",
       label: "Design Details",
     });
@@ -1392,7 +1404,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "🇩🇪 Visit from Germany",
+      summary: "Visit from Germany",
       href: "/karla-mickens-cole",
       label: "Karla Mickens Cole",
     });
@@ -1450,7 +1462,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "🇮🇳 Visit from India",
+      summary: "Visit from India",
       href: "/writing/grok-bot-first-impressions",
       label: "Grok Bot first impressions",
     });

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1665,6 +1665,49 @@ describe("rollupActivityEvents", () => {
     expect(stacks[1]?.sectionLabel).toBe("Grok Bot First Impressions");
   });
 
+  test("starts a fresh Shiori stack after an interrupting visit", () => {
+    const shiori = (id: string): ActivityEvent =>
+      feedEvent({
+        id,
+        source: "shiori",
+        type: "link_saved",
+        summary: "Someone saved a link on Shiori",
+      });
+    const visit = springLakeVisit("visit-sf", "/");
+    const older = Array.from({ length: 15 }, (_, index) => shiori(`old-${index + 1}`));
+
+    expect(rollupActivityEvents(older).map((stack) => stack.count)).toEqual([15]);
+
+    const afterVisit = rollupActivityEvents([visit, ...older]);
+    expect(afterVisit.map((stack) => stack.count)).toEqual([1, 15]);
+    expect(afterVisit[0]?.key).toBe("visit:spring lake, north carolina, united states:home");
+    expect(afterVisit[1]?.key).toBe("shiori:link_saved");
+
+    const afterSave = rollupActivityEvents([shiori("new-1"), visit, ...older]);
+    expect(afterSave.map((stack) => stack.count)).toEqual([1, 1, 15]);
+    expect(afterSave[0]?.key).toBe("shiori:link_saved");
+    expect(afterSave[0]?.latest.id).toBe("new-1");
+    expect(afterSave[2]?.latest.id).toBe("old-1");
+    expect(activityStackReactKey(afterSave[0]!)).not.toBe(activityStackReactKey(afterSave[2]!));
+  });
+
+  test("16 / visit / 15 is only correct when those runs were actually consecutive", () => {
+    const shiori = (id: string): ActivityEvent =>
+      feedEvent({
+        id,
+        source: "shiori",
+        type: "link_saved",
+        summary: "Someone saved a link on Shiori",
+      });
+    const visit = springLakeVisit("visit-sf", "/");
+    const newest = Array.from({ length: 16 }, (_, index) => shiori(`new-${index + 1}`));
+    const older = Array.from({ length: 15 }, (_, index) => shiori(`old-${index + 1}`));
+
+    const stacks = rollupActivityEvents([...newest, visit, ...older]);
+    expect(stacks.map((stack) => stack.count)).toEqual([16, 1, 15]);
+    expect(activityStackReactKey(stacks[0]!)).not.toBe(activityStackReactKey(stacks[2]!));
+  });
+
   test("stacks consecutive Shiori link_saved events, then a like as its own row", () => {
     const shiori = (id: string): ActivityEvent =>
       feedEvent({
@@ -1755,12 +1798,27 @@ describe("rollupActivityEvents", () => {
     expect(capped.has("old-1")).toBe(false);
   });
 
-  test("only pulses when the top stack count increments", () => {
-    const top = { key: "visit:spring lake, north carolina, united states:ama", count: 3 };
+  test("only pulses when the same run's count increments", () => {
+    const top = { key: "visit:sf:ama:oldest", count: 3 };
     expect(shouldPulseActivityRollup(null, { ...top, count: 1 })).toBe(false);
     expect(shouldPulseActivityRollup(top, { ...top, count: 4 })).toBe(true);
     expect(shouldPulseActivityRollup(top, { ...top, count: 3 })).toBe(false);
-    expect(shouldPulseActivityRollup(top, { key: "like:/stack", count: 1 })).toBe(false);
+    expect(shouldPulseActivityRollup(top, { key: "like:/stack:other", count: 1 })).toBe(false);
+  });
+
+  test("does not pulse a new independent run that shares a rollup key", () => {
+    expect(
+      shouldPulseActivityRollup(
+        { key: "shiori:link_saved:old-anchor", count: 15 },
+        { key: "shiori:link_saved:new-anchor", count: 1 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldPulseActivityRollup(
+        { key: "shiori:link_saved:old-anchor", count: 15 },
+        { key: "shiori:link_saved:old-anchor", count: 16 },
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -55,6 +55,7 @@ export {
   activityEventHref,
   activityRollupKey,
   activityStackReactKey,
+  nextActivityEnterState,
   rollupActivityEvents,
   shouldPulseActivityRollup,
 } from "./activity-rollup";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visual polish on the public `/activity` feed. No ingest, geo, Shiori, or Spotify changes.

## Row chrome

1. **Merged-PR diffs sit at the end of the title.** Order is now `summary` → repo/PR context → rollup chip (when `count > 1`) → `+N -N`.
2. **GitHub mark and staff.design favicon are 20px.** Other source favicons stay 16×16.
3. **Single hairline between rows.** `ActivityRow` no longer has `border-b`; the list keeps `divide-y divide-secondary`.
4. **No Event / Time table header.** The feed is a raw stream, including the loading skeleton.

## Tooltip + motion + mobile

5. **Tracked-count tooltip is instant and unclipped.** This instance uses `delay={0}` / `closeDelay={0}`, `side="bottom"` `align="end"` `collisionPadding={8}`, and portals to `document.body`.
6. **Incoming live rows grow height and push the list one event at a time.** New stacks that appear after the first committed paint animate `height: 0 → auto` with `overflow: hidden`, 140ms, ease `[0.2, 0, 0, 1]`, staggered 50ms newest-first. **Hard navigation / first paint is a static list** — the SSR/initial key set is treated as already on screen, so there is no fade, y-slide, stagger, or height-enter on load. `useHydrated` flipping true and the first poll of the same events do not replay enter motion. A rollup count increment is still pulse + digit tick, not an enter. `AnimatePresence initial={false}` stays. `useReducedMotion` disables enter/exit.
7. **Event count is desktop-only.** `ActivityTrackedCount` uses `hidden md:inline`.
8. **Mobile horizontal scroll with a sticky time column.** One shared `data-scrollable` pane scrolls x+y. Titles are `whitespace-nowrap` below `md` (`min-width: max-content`). Time is `sticky right-0` with a solid background and an inset left hairline after scroll / on mobile. Desktop keeps the truncated 3-column grid. Touch axis lock after 5px so diagonal scroll does not fight the feed.
9. **Rollup count is a quiet chip after the metadata.** When `count > 1`, a small `rounded-sm` monospace tabular chip (`text-tertiary`, secondary hairline, no filled pill) sits at the end of the title cluster — after the page name / context link, before any PR diff and before the timestamp. Count of 1 renders nothing.
10. **Hover background is instant.** `ActivityRow` no longer uses `transition-colors duration-500`. Hover is `hover:bg-secondary md:dark:hover:bg-white/5`, same as `/stack`.

## Like copy

Like rows no longer print the title twice. Stored events stay `Someone liked {title}`; at render time `getActivityRow` / `ActivityRow` show **Someone liked** plus the page name once — as the context link when `href` exists, or as tertiary text when it does not. Home / `a page` becomes **Someone liked** + clickable **Home**. No stray double space.

## External product names

Project names are tertiary new-tab metadata, not part of the primary sentence. Stored copy is unchanged.

- `Someone saved a link on Shiori` → **Someone saved a link** + clickable **Shiori** → https://www.shiori.sh (`target="_blank"`)
- Same strip for click / signed up / subscribed / downloaded, and for Tax UI / Staff Design / Design Details
- External visits without a better page href use the product home (Visit from SF + **Design Details**)
- A more specific subject href wins: staff.design profile, Design Details episode, public GitHub PR
- First-party briOS likes/visits still link the page (Home, a writing title), not “briOS”
- Private GitHub rows with no PR URL link **GitHub** → https://github.com/brianlovin

## Hover

Hover background is instant (`hover:bg-secondary`, no `transition-colors duration-500`).

## Visit rows have no flag emoji

Visit titles are plain location text. `getActivityRow` strips a leading regional-indicator pair via `visitDisplaySummary` so Redis events that already stored a flag still render as **Visit from San Francisco, California, United States**. The icon column stays World / source favicon. Caffeine drink icons are untouched. Ingest is unchanged.

## Rollup reset, pulse, and count tick

`rollupActivityEvents` already merges **adjacent** same-key events only. Pulse is keyed by the run (`activityStackReactKey`). A new independent stack after an interrupt does not inherit the previous count and does not pulse. The same top run incrementing pulses that row only (550ms `bg-secondary` wash). Count chip digits tick with `RollingDigits` when `count > 1`.

## Tests

First committed paint of N stacks has no enter delays and does not start from `opacity: 0`. After a new stack is prepended, only that key gets an enter delay. Also: title order, no Event/Time header, rollup chip, like titles once, product links, no visit flags, pulse keyed by run, span-only digits.

## Viewport matrix

Puppeteer against `/activity` at 320 / 375 / 390 / 767 / 768 / 1024 / 1280, plus dark 375 / 1024 and `prefers-reduced-motion`.

| Width | Pattern | X-scroll | Time | Count |
| --- | --- | --- | --- | --- |
| 320 / 375 / 390 / 767 | flex, nowrap, sticky time, hairline | yes | pinned, opaque | hidden |
| 768 (`md`) | 3-col grid, title may truncate | no | static, not sticky | visible |
| 1024 / 1280 | desktop unchanged | no | static | visible |

[First paint of /activity is a static list, no enter cascade](https://cursor.com/agents/bc-310b270a-6e5f-43af-ba1c-eeb1a34364b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_first_paint_static_1024.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310b270a-6e5f-43af-ba1c-eeb1a34364b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310b270a-6e5f-43af-ba1c-eeb1a34364b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

