### PR TITLE
Show private GitHub PRs as a single activity phrase

### DIFF
--- a/src/app/api/webhooks/github/route.test.ts
+++ b/src/app/api/webhooks/github/route.test.ts
@@ -157,7 +157,8 @@ describe("POST /api/webhooks/github", () => {
     const privateSerialized = JSON.stringify(privateEvent);
     expect(privateSerialized).not.toContain("secrets");
     expect(privateSerialized).not.toContain("private title");
-    expect(privateEvent?.summary).toBe("Opened a pull request");
+    expect(privateEvent?.summary).toBe("Opened a pull request in a private repo");
+    expect(privateEvent?.subject).toBeUndefined();
     expect(botRes.status).toBe(200);
     expect(await botRes.json()).toEqual({ ok: true, ignored: "bot_actor" });
     expect(closedRes.status).toBe(200);

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -272,6 +272,42 @@ describe("ActivityRow", () => {
     expect(markup).toContain("noopener noreferrer");
   });
 
+  test("renders a stored private opened PR as a single phrase", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "github",
+          type: "pr_opened",
+          speed: "event",
+          summary: "Opened a pull request",
+          subject: { kind: "pull_request", label: "a pull request" },
+          meta: { private: true, number: 1 },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Opened a pull request in a private repo");
+    expect(markup).not.toContain("A Pull Request");
+  });
+
+  test("renders a stored private merged PR as a single phrase", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "github",
+          type: "pr_merged",
+          speed: "event",
+          summary: "Merged a pull request",
+          subject: { kind: "pull_request", label: "a pull request" },
+          meta: { private: true, number: 2 },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Merged a pull request in a private repo");
+    expect(markup).not.toContain("A Pull Request");
+  });
+
   test("uses the GitHub icon for github-sourced events", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow

--- a/src/lib/activity-github.test.ts
+++ b/src/lib/activity-github.test.ts
@@ -228,8 +228,8 @@ describe("githubActivityFromWebhook", () => {
 
     expect(decision.status).toBe("ingest");
     if (decision.status === "ingest") {
-      expect(decision.input.summary).toBe("Opened a pull request");
-      expect(decision.input.subject).toEqual({ kind: "pull_request", label: "a pull request" });
+      expect(decision.input.summary).toBe("Opened a pull request in a private repo");
+      expect(decision.input.subject).toBeUndefined();
       expect(decision.input.meta).toEqual({ private: true, number: 1 });
       expect(decision.input.idempotency_key).toBe(`github:pr_opened:private:${repoHash}:1`);
     }
@@ -238,6 +238,39 @@ describe("githubActivityFromWebhook", () => {
     expect(serialized).not.toContain("private title");
     expect(serialized).not.toContain("secrets");
     expect(serialized).not.toContain("brianlovin");
+
+    const merged = githubActivityFromWebhook(
+      "pull_request",
+      pullRequestPayload({
+        action: "closed",
+        repository: {
+          name: "secrets",
+          full_name: "brianlovin/secrets",
+          private: true,
+          html_url: "https://github.com/brianlovin/secrets",
+        },
+        pull_request: {
+          number: 1,
+          title: "private title must not leak",
+          html_url: "https://github.com/brianlovin/secrets/pull/1",
+          merged: true,
+          additions: 4,
+          deletions: 1,
+          user: human(),
+        },
+      }),
+    );
+    expect(merged.status).toBe("ingest");
+    if (merged.status === "ingest") {
+      expect(merged.input.summary).toBe("Merged a pull request in a private repo");
+      expect(merged.input.subject).toBeUndefined();
+      expect(merged.input.meta).toEqual({
+        private: true,
+        number: 1,
+        additions: 4,
+        deletions: 1,
+      });
+    }
   });
 
   test("ignores Dependabot pull requests but keeps coding-agent PRs", () => {
@@ -404,8 +437,45 @@ describe("recordGithubActivity", () => {
     const serialized = JSON.stringify(event);
     expect(serialized).not.toContain("secrets");
     expect(serialized).not.toContain("Add activity feed");
-    expect(event?.summary).toBe("Opened a pull request");
+    expect(event?.summary).toBe("Opened a pull request in a private repo");
+    expect(event?.subject).toBeUndefined();
     expect(event?.meta).toEqual({ private: true, number: 42 });
+  });
+
+  test("records a private merge without a dummy subject", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordGithubActivity(
+      "pull_request",
+      pullRequestPayload({
+        action: "closed",
+        repository: publicRepo({
+          private: true,
+          name: "secrets",
+          full_name: "brianlovin/secrets",
+          html_url: "https://github.com/brianlovin/secrets",
+        }),
+        pull_request: {
+          number: 7,
+          title: "private title must not leak",
+          html_url: "https://github.com/brianlovin/secrets/pull/7",
+          merged: true,
+          additions: 12,
+          deletions: 3,
+          user: human(),
+        },
+      }),
+      store,
+    );
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, duplicate: false }));
+    const [event] = await store.getTail(1);
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain("secrets");
+    expect(serialized).not.toContain("private title");
+    expect(event?.type).toBe("pr_merged");
+    expect(event?.summary).toBe("Merged a pull request in a private repo");
+    expect(event?.subject).toBeUndefined();
+    expect(event?.meta).toEqual({ private: true, number: 7, additions: 12, deletions: 3 });
   });
 
   test("treats the same person starring twice as one event", async () => {

--- a/src/lib/activity-github.ts
+++ b/src/lib/activity-github.ts
@@ -1,6 +1,10 @@
 import { createHash, createHmac } from "crypto";
 
-import { ACTIVITY_SOURCE_GITHUB, type ActivityIngestInput } from "./activity-shared";
+import {
+  ACTIVITY_SOURCE_GITHUB,
+  type ActivityIngestInput,
+  privatePullRequestSummary,
+} from "./activity-shared";
 import { safeCompare } from "./api-utils";
 
 const GITHUB_BOT_LOGINS = new Set(["dependabot[bot]", "cursor[bot]", "github-actions[bot]"]);
@@ -108,15 +112,6 @@ function pullRequestInput(
   const repoToken = repoIdempotencyToken(repository, isPrivate);
   if (number === undefined || !repoToken) return { status: "ignore", reason: "incomplete_pr" };
 
-  const summary =
-    type === "pr_opened"
-      ? isPrivate
-        ? "Opened a pull request"
-        : `Opened a pull request on ${repoShortName(repository)}`
-      : isPrivate
-        ? "Merged a pull request"
-        : `Merged a pull request on ${repoShortName(repository)}`;
-
   if (isPrivate) {
     const diff = type === "pr_merged" ? pullRequestDiffMeta(pullRequest) : {};
     return {
@@ -125,15 +120,19 @@ function pullRequestInput(
         source: ACTIVITY_SOURCE_GITHUB,
         type,
         speed: "event",
-        summary,
+        summary: privatePullRequestSummary(type),
         visibility: "public",
         idempotency_key: `github:${type}:${repoToken}:${number}`,
-        subject: { kind: "pull_request", label: "a pull request" },
         meta: { private: true, number, ...diff },
         idempotencyTtlSeconds: 0,
       },
     };
   }
+
+  const summary =
+    type === "pr_opened"
+      ? `Opened a pull request on ${repoShortName(repository)}`
+      : `Merged a pull request on ${repoShortName(repository)}`;
 
   const title = asString(pullRequest?.title) || "a pull request";
   const href = asString(pullRequest?.html_url);

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -576,6 +576,22 @@ export function caffeineDrinkFromEvent(event: ActivityEvent): string {
   return "";
 }
 
+const PRIVATE_PULL_REQUEST_DUMMY_LABEL = "a pull request";
+
+export function privatePullRequestSummary(type: "pr_opened" | "pr_merged"): string {
+  return type === "pr_opened"
+    ? "Opened a pull request in a private repo"
+    : "Merged a pull request in a private repo";
+}
+
+function isPrivatePullRequestEvent(
+  event: ActivityEvent,
+): event is ActivityEvent & { type: "pr_opened" | "pr_merged" } {
+  if (event.type !== "pr_opened" && event.type !== "pr_merged") return false;
+  if (event.meta?.private === true) return true;
+  return event.subject?.label === PRIVATE_PULL_REQUEST_DUMMY_LABEL && !event.subject.href;
+}
+
 export function getActivityRow(event: ActivityEvent): {
   summary: string;
   flag?: string;
@@ -583,6 +599,10 @@ export function getActivityRow(event: ActivityEvent): {
   href?: string;
   label?: string;
 } {
+  if (isPrivatePullRequestEvent(event)) {
+    return { summary: privatePullRequestSummary(event.type) };
+  }
+
   if (event.type === "caffeinated") {
     return {
       summary: event.summary,

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1305,6 +1305,91 @@ describe("getActivityRow page titles", () => {
   });
 });
 
+describe("getActivityRow private pull requests", () => {
+  function prEvent(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+    return {
+      v: 1,
+      id: "pr",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "github",
+      type: "pr_opened",
+      speed: "event",
+      summary: "Opened a pull request",
+      visibility: "public",
+      idempotency_key: "pr",
+      ...overrides,
+    };
+  }
+
+  test("rewrites a stored private opened PR to a single phrase", () => {
+    const row = getActivityRow(
+      prEvent({
+        subject: { kind: "pull_request", label: "a pull request" },
+        meta: { private: true, number: 1 },
+      }),
+    );
+    expect(row).toEqual({ summary: "Opened a pull request in a private repo" });
+    expect(JSON.stringify(row)).not.toContain("A Pull Request");
+  });
+
+  test("rewrites a stored private merged PR to a single phrase", () => {
+    const row = getActivityRow(
+      prEvent({
+        type: "pr_merged",
+        summary: "Merged a pull request",
+        subject: { kind: "pull_request", label: "a pull request" },
+        meta: { private: true, number: 2, additions: 12, deletions: 3 },
+      }),
+    );
+    expect(row).toEqual({ summary: "Merged a pull request in a private repo" });
+    expect(JSON.stringify(row)).not.toContain("A Pull Request");
+  });
+
+  test("rewrites a new private PR that has no subject", () => {
+    const row = getActivityRow(
+      prEvent({
+        summary: "Opened a pull request in a private repo",
+        meta: { private: true, number: 1 },
+      }),
+    );
+    expect(row).toEqual({ summary: "Opened a pull request in a private repo" });
+  });
+
+  test("rewrites a dummy subject even without meta.private", () => {
+    const row = getActivityRow(
+      prEvent({
+        subject: { kind: "pull_request", label: "a pull request" },
+      }),
+    );
+    expect(row).toEqual({ summary: "Opened a pull request in a private repo" });
+  });
+
+  test("keeps a public PR repo name and real title", () => {
+    const row = getActivityRow(
+      prEvent({
+        summary: "Opened a pull request on briOS",
+        subject: {
+          kind: "pull_request",
+          label: "Add activity feed",
+          href: "https://github.com/brianlovin/briOS/pull/42",
+        },
+        meta: {
+          repo: "briOS",
+          title: "Add activity feed",
+          number: 42,
+          href: "https://github.com/brianlovin/briOS/pull/42",
+        },
+      }),
+    );
+    expect(row).toEqual({
+      summary: "Opened a pull request on briOS",
+      href: "https://github.com/brianlovin/briOS/pull/42",
+      label: "Add activity feed",
+    });
+  });
+});
+
 describe("shouldRecordVisit / likeMetaFromRequest", () => {
   test("skips the activity page and API routes", () => {
     expect(shouldRecordVisit("/activity")).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Private-repo pull request rows on `/activity` currently render as `Opened a pull request` plus a title-cased dummy label (`A Pull Request`).

This PR rewrites those rows at **render time** so existing Redis events pick up the new copy, and updates **ingest** so new events never store the dummy subject.

### Render
If the event is `pr_opened` / `pr_merged` and either `meta.private === true` or the subject is the dummy `"a pull request"` with no href:
- summary becomes `Opened a pull request in a private repo` / `Merged a pull request in a private repo`
- no label, no href

Public PRs are unchanged (repo name in the summary, real title as metadata).

### Ingest
Private `pullRequestInput` now writes those full summaries and omits `subject`. Still stores `meta.private: true`, the hashed idempotency key, and no repo name / title / URL.

Stars, geo, tooltips, and motion are untouched.

### Verification
159 tests passed across the activity GitHub, shared, feed, and webhook files. Stored events with the old summary + dummy subject now render the new single phrase and no longer include `A Pull Request`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86d22646-19f4-4c9a-bf7b-d3f76c803f91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86d22646-19f4-4c9a-bf7b-d3f76c803f91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

