### PR TITLE
Prevent duplicate first-party activity visit pings

### DIFF
--- a/src/components/ActivityVisit.test.ts
+++ b/src/components/ActivityVisit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { activityVisitStorageKey, runActivityVisitEffect } from "@/components/ActivityVisit";
+
+type VisitStorage = Pick<Storage, "getItem" | "setItem">;
+
+function memoryStorage(initial: Record<string, string> = {}): VisitStorage {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+function mockFetch() {
+  return mock((input: string, init?: RequestInit) => {
+    if (init?.signal?.aborted) {
+      return Promise.reject(new DOMException("Aborted", "AbortError"));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+  });
+}
+
+describe("ActivityVisit", () => {
+  test("two effect runs for the same path post once", () => {
+    const fetchImpl = mockFetch();
+    const postedPathRef = { current: null as string | null };
+    const storage = memoryStorage();
+
+    const cleanup = runActivityVisitEffect({
+      pathname: "/writing",
+      title: "Writing | Brian Lovin",
+      postedPathRef,
+      fetchImpl,
+      storage,
+    });
+    cleanup?.();
+
+    runActivityVisitEffect({
+      pathname: "/writing",
+      title: "Writing | Brian Lovin",
+      postedPathRef,
+      fetchImpl,
+      storage,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe("/api/activity/visit");
+    expect(fetchImpl.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: "/writing", title: "Writing | Brian Lovin" }),
+      }),
+    );
+  });
+
+  test("skips /activity via shouldRecordVisit", () => {
+    const fetchImpl = mockFetch();
+
+    runActivityVisitEffect({
+      pathname: "/activity",
+      title: "Activity | Brian Lovin",
+      postedPathRef: { current: null },
+      fetchImpl,
+      storage: memoryStorage(),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+
+  test("a remount after the first POST completed no-ops via sessionStorage", async () => {
+    const fetchImpl = mockFetch();
+    const storage = memoryStorage();
+
+    runActivityVisitEffect({
+      pathname: "/til",
+      title: "Today I Learned",
+      postedPathRef: { current: null },
+      fetchImpl,
+      storage,
+    });
+
+    await Promise.resolve();
+
+    runActivityVisitEffect({
+      pathname: "/til",
+      title: "Today I Learned",
+      postedPathRef: { current: null },
+      fetchImpl,
+      storage,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(activityVisitStorageKey("/til"))).toBe("1");
+  });
+
+  test("ignores a completed visit for a different pathname", () => {
+    const fetchImpl = mockFetch();
+    const postedPathRef = { current: null as string | null };
+    const storage = memoryStorage({
+      [activityVisitStorageKey("/writing")]: "1",
+    });
+
+    runActivityVisitEffect({
+      pathname: "/til",
+      title: "Today I Learned",
+      postedPathRef,
+      fetchImpl,
+      storage,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({ path: "/til", title: "Today I Learned" }),
+      }),
+    );
+  });
+});

--- a/src/components/ActivityVisit.tsx
+++ b/src/components/ActivityVisit.tsx
@@ -1,21 +1,91 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useRef } from "react";
 
 import { shouldRecordVisit } from "@/lib/activity-shared";
 
+export function activityVisitStorageKey(pathname: string): string {
+  return `activity:visit:${pathname}`;
+}
+
+type VisitStorage = Pick<Storage, "getItem" | "setItem">;
+type VisitFetch = (input: string, init?: RequestInit) => Promise<unknown>;
+
+function readVisitStorage(): VisitStorage | null {
+  try {
+    if (typeof sessionStorage === "undefined") return null;
+    return sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function hasCompletedVisit(pathname: string, storage: VisitStorage | null): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(activityVisitStorageKey(pathname)) != null;
+  } catch {
+    return false;
+  }
+}
+
+function markCompletedVisit(pathname: string, storage: VisitStorage | null): void {
+  if (!storage) return;
+  try {
+    storage.setItem(activityVisitStorageKey(pathname), "1");
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+}
+
+export function runActivityVisitEffect(input: {
+  pathname: string | null;
+  title: string;
+  postedPathRef: { current: string | null };
+  fetchImpl?: VisitFetch;
+  storage?: VisitStorage | null;
+}): (() => void) | undefined {
+  const { pathname, title, postedPathRef } = input;
+  if (!pathname || !shouldRecordVisit(pathname)) return;
+  if (postedPathRef.current === pathname) return;
+
+  const storage = input.storage === undefined ? readVisitStorage() : input.storage;
+  if (hasCompletedVisit(pathname, storage)) {
+    postedPathRef.current = pathname;
+    return;
+  }
+
+  postedPathRef.current = pathname;
+  const controller = new AbortController();
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  void fetchImpl("/api/activity/visit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ path: pathname, title }),
+    signal: controller.signal,
+  })
+    .then(() => {
+      markCompletedVisit(pathname, storage);
+    })
+    .catch(() => {});
+
+  return () => {
+    controller.abort();
+  };
+}
+
 function TrackVisit() {
   const pathname = usePathname();
+  const postedPathRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!pathname || !shouldRecordVisit(pathname)) return;
-
-    void fetch("/api/activity/visit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path: pathname, title: document.title }),
-    }).catch(() => {});
+    return runActivityVisitEffect({
+      pathname,
+      title: document.title,
+      postedPathRef,
+    });
   }, [pathname]);
 
   return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visit rows on `/activity` were almost always rolling up to 2 because the client could `POST /api/activity/visit` twice for one pageview. `recordVisit` uses a fresh `idempotency_key` (`brios:visit:${crypto.randomUUID()}`), so both writes succeeded.

## Fix

`ActivityVisit` now treats one client pageview as one stream event:

- `useRef` so the same `pathname` does not POST twice in one mount lifetime
- `AbortController` in the effect cleanup so React Strict Mode’s first invoke is aborted and does not count as a completed ping (if the request already left, the ref still blocks the remount)
- `sessionStorage` key `activity:visit:${pathname}` so a remount after the first POST completed still no-ops; other pathnames are ignored
- `/activity` is still skipped via `shouldRecordVisit`

This does **not** debounce on geo+path+time on the server (that would merge two real people in the same city). `reactStrictMode` stays on. `ACTIVITY_VISIT_STREAM_MAX_PER_SEC` is unchanged.

HMAC ingest from other sites is out of scope.

## Tests

- Two effect runs for the same path → one mocked `fetch`
- `/activity` still skipped
- Completed POST remembered per pathname in sessionStorage
- Existing `recordVisit` / visit route tests stay green (116 pass)

Headless Chrome against the local app: `/writing` and `/til` each issued one `POST /api/activity/visit`; `/activity` issued none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7553f5f4-c4b2-4fb8-9ff4-7c10c208fe53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7553f5f4-c4b2-4fb8-9ff4-7c10c208fe53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

