### PR TITLE
Label HN index visits as Hacker News, not a story

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -150,6 +150,22 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain(">secret for ios<");
   });
 
+  test("labels an HN index visit as Hacker News, not a story", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          summary: "🇺🇸 Visit from San Francisco, California, United States",
+          subject: { kind: "page", label: "a page", href: "/hn" },
+          meta: { country: "US", path: "/hn" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Hacker News");
+    expect(markup).toContain('href="/hn"');
+    expect(markup).not.toContain("a Hacker News story");
+  });
+
   test("shows a Hacker News story instead of a raw story id", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -330,7 +330,6 @@ export function activitySectionFromPath(pathname: string | undefined): string {
 export function activitySectionPhrase(section: string): string {
   if (!section || section === "home" || isProtocolSegment(section)) return "Home";
   if (section === "ama") return "an AMA question";
-  if (section === "hn") return "a Hacker News story";
   const known = KNOWN_PATH_TITLES[`/${section}`];
   if (known) return known;
   return inferTitleFromPath(`/${section}`);

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1314,6 +1314,28 @@ describe("getActivityRow page titles", () => {
     expect(row.href).toBe("/app-dissection/secret-for-ios");
   });
 
+  test("labels an HN index visit as Hacker News, not a story", () => {
+    for (const href of ["/hn", "/hn/"]) {
+      const row = getActivityRow({
+        v: 1,
+        id: "hn-index",
+        ts: "2026-08-16T00:00:00.000Z",
+        received_at: "2026-08-16T00:00:00.000Z",
+        source: "brios",
+        type: "visit",
+        speed: "signal",
+        summary: "Visit from San Francisco, California, United States",
+        visibility: "public",
+        idempotency_key: "hn-index",
+        subject: { kind: "page", label: "a page", href },
+        meta: { path: href, country: "US", city: "San Francisco" },
+      });
+      expect(row.label).toBe("Hacker News");
+      expect(row.href).toBe(href);
+      expect(row.label).not.toBe("a Hacker News story");
+    }
+  });
+
   test("rewrites a stored HN story id to a Hacker News story", () => {
     const row = getActivityRow({
       v: 1,
@@ -1737,6 +1759,39 @@ describe("rollupActivityEvents", () => {
     expect(next[0]?.latest.id).toBe("ama-0");
     expect(next[0]?.anchorId).toBe(first[0]?.anchorId);
     expect(activityStackReactKey(next[0]!)).toBe(activityStackReactKey(first[0]!));
+  });
+
+  test("stacks two SF visits to the HN index as Hacker News", () => {
+    const sfHn = (id: string, href = "/hn"): ActivityEvent =>
+      feedEvent({
+        id,
+        type: "visit",
+        summary: "Visit from San Francisco, California, United States",
+        subject: { kind: "page", label: "a page", href },
+        meta: {
+          country: "US",
+          country_name: "United States",
+          region: "CA",
+          region_name: "California",
+          city: "San Francisco",
+          path: href,
+        },
+      });
+
+    const stacks = rollupActivityEvents([sfHn("hn-1"), sfHn("hn-2")]);
+    expect(stacks).toHaveLength(1);
+    expect(stacks[0]?.count).toBe(2);
+    expect(stacks[0]?.sectionLabel).toBe("Hacker News");
+    expect(stacks[0]?.sectionLabel).not.toBe("a Hacker News story");
+    expect(stacks[0]?.href).toBe("/hn");
+    expect(getActivityRow(stacks[0]!.latest).label).toBe("Hacker News");
+
+    const mixed = rollupActivityEvents([sfHn("hn-index", "/hn"), sfHn("hn-story", "/hn/123")]);
+    expect(mixed).toHaveLength(1);
+    expect(mixed[0]?.count).toBe(2);
+    expect(mixed[0]?.sectionLabel).toBe("Hacker News");
+    expect(mixed[0]?.href).toBe("/hn");
+    expect(getActivityRow(sfHn("hn-story", "/hn/123")).label).toBe("a Hacker News story");
   });
 
   test("does not show Https: when stacking SF visits with different absolute URLs", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

Visit rollups to `/hn` (the Hacker News index) rendered the subtitle **“a Hacker News story”**. `/hn` is the listing — they just viewed **Hacker News**.

This is the same render-time fix from `cursor/fix-github-pr-activity-rows-54a8` after #2297 merged, so that commit never landed. Re-applied on a new branch from `main`.

## Cause

`activitySectionPhrase("hn")` hardcoded `"a Hacker News story"`.

- `KNOWN_PATH_TITLES["/hn"]` is already `"Hacker News"`
- `ID_ROUTE_PHRASES` `/hn/` → `"a Hacker News story"` (kept for `/hn/123`)

## Fix

Drop the `hn` special case in `activitySectionPhrase` so it falls through to `KNOWN_PATH_TITLES["/hn"]` → **Hacker News**.

- `/hn` and `/hn/` → label **Hacker News**, href `/hn`
- `/hn/<id>` still → **a Hacker News story**
- AMA is unchanged
- Render-time only (no ingest / Redis rewrite)

## Tests

- Visit `/hn` or `/hn/` → label `Hacker News`, never `a Hacker News story`
- Two SF visits to `/hn` rolled up → count 2, label `Hacker News`, href `/hn`
- Visit `/hn/123` still says `a Hacker News story`
- Mixed `/hn` + `/hn/123` rollup uses **Hacker News** and href `/hn`

`bun test src/lib/activity.test.ts src/components/ActivityFeed.test.tsx` — 157 pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-183af31d-531f-4e7b-82af-714110cd0b46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-183af31d-531f-4e7b-82af-714110cd0b46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

