### PR TITLE
Load the full kept activity log and add an end-cap

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { ActivityRow, ActivityTrackedCount } from "@/components/ActivityFeed";
+import { ActivityFeed, ActivityRow, ActivityTrackedCount } from "@/components/ActivityFeed";
 import { ActivityLiveBadge, TopBarTrail } from "@/components/GlobalTopBar";
 import type { ActivityEvent } from "@/lib/activity";
 import { rollupActivityEvents } from "@/lib/activity-rollup";
@@ -763,5 +763,23 @@ describe("ActivityTrackedCount", () => {
     expect(one).toContain("text-sm");
     expect(many).toContain("12 events tracked");
     expect(many).not.toContain("Live");
+  });
+});
+
+describe("ActivityFeed", () => {
+  test("shows the end-cap after a non-empty feed and not on the empty state", () => {
+    const empty = renderToStaticMarkup(<ActivityFeed initialEvents={[]} initialCount={0} />);
+    const filled = renderToStaticMarkup(
+      <ActivityFeed initialEvents={[event({ id: "evt-1" })]} initialCount={1} />,
+    );
+
+    expect(empty).toContain("Nothing yet. Likes and visits will show up here.");
+    expect(empty).not.toContain("Older activity is dust in the wind...");
+    expect(filled).toContain("Older activity is dust in the wind...");
+    expect(filled).toContain("p-32");
+    expect(filled).toContain("text-center");
+    expect(filled).toContain("text-sm");
+    expect(filled).toContain("text-tertiary");
+    expect(filled).not.toContain("Nothing yet. Likes and visits will show up here.");
   });
 });

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -367,7 +367,12 @@ export function ActivityFeed({
               Nothing yet. Likes and visits will show up here.
             </p>
           ) : (
-            <ActivityStackList stacks={stacks} pulseKey={pulseKey} />
+            <>
+              <ActivityStackList stacks={stacks} pulseKey={pulseKey} />
+              <p className="text-tertiary p-32 text-center text-sm">
+                Older activity is dust in the wind...
+              </p>
+            </>
           )}
         </motion.div>
       </div>

--- a/src/lib/activity-feed.test.ts
+++ b/src/lib/activity-feed.test.ts
@@ -14,6 +14,7 @@ import {
   ACTIVITY_FEED_CACHE_CONTROL,
   ACTIVITY_FEED_DEDUPING_MS,
   ACTIVITY_FEED_POLL_MS,
+  ACTIVITY_STREAM_MAXLEN,
   activityFeedRefreshInterval,
 } from "@/lib/activity-shared";
 
@@ -64,6 +65,35 @@ describe("activity feed payload", () => {
       expect.objectContaining({ type: "like", summary: "Someone liked a page" }),
     );
     expect(payload.count).toBe(1);
+  });
+
+  test("requests ACTIVITY_STREAM_MAXLEN events from the store", async () => {
+    const store = createMemoryActivityStore();
+    const requested: number[] = [];
+    const getTail = store.getTail.bind(store);
+    store.getTail = async (limit) => {
+      requested.push(limit);
+      return getTail(limit);
+    };
+
+    for (let i = 0; i < 101; i++) {
+      await ingestActivityEvent(
+        {
+          source: "brios",
+          type: "like",
+          speed: "event",
+          summary: `Someone liked page ${i}`,
+          visibility: "public",
+          idempotency_key: `feed:like:window:${i}`,
+        },
+        store,
+      );
+    }
+
+    const payload = await buildActivityFeed(store);
+    expect(requested).toEqual([ACTIVITY_STREAM_MAXLEN]);
+    expect(payload.events).toHaveLength(101);
+    expect(payload.count).toBe(101);
   });
 });
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -134,7 +134,10 @@ export type ActivityStore = {
 
 export async function buildActivityFeed(store: ActivityStore | null): Promise<ActivityFeedPayload> {
   if (!store) return { events: [], count: 0 };
-  const [events, count] = await Promise.all([store.getTail(100), store.getCount()]);
+  const [events, count] = await Promise.all([
+    store.getTail(ACTIVITY_STREAM_MAXLEN),
+    store.getCount(),
+  ]);
   return { events, count };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `/activity` page was capped at the latest 100 events even though Redis already keeps 1500 (`ACTIVITY_STREAM_MAXLEN`). Brian hits the end of the scroll too fast.

## Changes

- `buildActivityFeed` now calls `store.getTail(ACTIVITY_STREAM_MAXLEN)` instead of `getTail(100)`. Same helper feeds the SSR page and the poll blob (`/api/activity/feed`, `/api/activity/tail`).
- Confirmed `useActivity` does not slice the payload — no client-side 100-event cap.
- After a non-empty rolled-up list, a small non-sticky end-cap sits at the bottom of the scroll container: *Older activity is dust in the wind...*
- Empty state is unchanged.

Redis `ACTIVITY_STREAM_MAXLEN` and the approximate MAXLEN trim are untouched. No pagination.

## Tests

- `buildActivityFeed` requests `ACTIVITY_STREAM_MAXLEN` and returns more than 100 stored events.
- The footer copy renders after a non-empty feed and not on the empty state.
- Local `/api/activity/feed` returned 827 events (was 100). SSR `/activity` includes the end-cap and not the empty state.

[Activity feed end-cap after the last row](https://cursor.com/agents/bc-757ecc74-e410-4690-bc89-f3e323d6a835/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_feed_end_cap.webp)
[activity_feed_end_cap_scroll.mp4](https://cursor.com/agents/bc-757ecc74-e410-4690-bc89-f3e323d6a835/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_feed_end_cap_scroll.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-757ecc74-e410-4690-bc89-f3e323d6a835?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-757ecc74-e410-4690-bc89-f3e323d6a835&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

