### PR TITLE
Add robots.txt and stop recording crawler-probe visits

### DIFF
--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import robots from "./robots";
+
+function ruleFor(result: ReturnType<typeof robots>, userAgent: string) {
+  const list = Array.isArray(result.rules) ? result.rules : [result.rules];
+  return list.find((rule) => {
+    const agents = Array.isArray(rule.userAgent) ? rule.userAgent : [rule.userAgent ?? "*"];
+    return agents.includes(userAgent);
+  });
+}
+
+describe("robots", () => {
+  test("allows * on / and disallows /api/ without a sitemap", () => {
+    const result = robots();
+    const wildcard = ruleFor(result, "*");
+
+    expect(wildcard?.allow).toBe("/");
+    expect(wildcard?.disallow).toBe("/api/");
+    expect(wildcard?.disallow).not.toBe("/");
+    expect(result.sitemap).toBeUndefined();
+  });
+
+  test("allows Googlebot / and disallows GPTBot /", () => {
+    const result = robots();
+
+    expect(ruleFor(result, "Googlebot")?.allow).toBe("/");
+    expect(ruleFor(result, "GPTBot")?.disallow).toBe("/");
+  });
+});

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+
+/**
+ * Honor-system robots.txt: search and retrieval crawlers are allowed;
+ * training-only agents are opted out. No sitemap until /sitemap.xml exists.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: "/api/",
+      },
+      {
+        userAgent: [
+          "Googlebot",
+          "Bingbot",
+          "OAI-SearchBot",
+          "ChatGPT-User",
+          "Claude-SearchBot",
+          "Claude-User",
+          "PerplexityBot",
+        ],
+        allow: "/",
+      },
+      {
+        userAgent: [
+          "GPTBot",
+          "Google-Extended",
+          "ClaudeBot",
+          "Applebot-Extended",
+          "CCBot",
+          "Bytespider",
+          "anthropic-ai",
+        ],
+        disallow: "/",
+      },
+    ],
+  };
+}

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -192,11 +192,23 @@ export function isActivityPath(pathname: string): boolean {
   return ACTIVITY_PATH.test(path);
 }
 
+const CRAWLER_PROBE_PATHS = new Set(["/robots.txt", "/sitemap.xml", "/favicon.ico"]);
+
+function isCrawlerProbePath(pathname: string): boolean {
+  if (CRAWLER_PROBE_PATHS.has(pathname)) return true;
+  if (pathname.startsWith("/apple-touch-icon")) return true;
+  return pathname === "/.well-known" || pathname.startsWith("/.well-known/");
+}
+
 export function shouldRecordVisit(pathname: string): boolean {
-  if (!pathname || pathname.startsWith("/api/") || pathname.startsWith("/_next/")) {
+  const path = pathname.split("?")[0] ?? pathname;
+  if (!path || path.startsWith("/api/") || path.startsWith("/_next/")) {
     return false;
   }
-  return !isActivityPath(pathname);
+  if (isCrawlerProbePath(path)) {
+    return false;
+  }
+  return !isActivityPath(path);
 }
 
 export function inferContentTypeFromPath(pathname: string): string {

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1574,7 +1574,17 @@ describe("shouldRecordVisit / likeMetaFromRequest", () => {
   test("skips the activity page and API routes", () => {
     expect(shouldRecordVisit("/activity")).toBe(false);
     expect(shouldRecordVisit("/writing")).toBe(true);
+    expect(shouldRecordVisit("/writing/foo")).toBe(true);
     expect(shouldRecordVisit("/api/activity/tail")).toBe(false);
+  });
+
+  test("skips crawler-probe paths", () => {
+    expect(shouldRecordVisit("/robots.txt")).toBe(false);
+    expect(shouldRecordVisit("/sitemap.xml")).toBe(false);
+    expect(shouldRecordVisit("/favicon.ico")).toBe(false);
+    expect(shouldRecordVisit("/apple-touch-icon.png")).toBe(false);
+    expect(shouldRecordVisit("/apple-touch-icon-precomposed.png")).toBe(false);
+    expect(shouldRecordVisit("/.well-known/security.txt")).toBe(false);
   });
 
   test("builds like meta from the referer and skips /activity", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`/robots.txt` is not defined, so crawlers get a Next 404. `shouldRecordVisit` then records that 404 as a visit (e.g. “Visit from Ashburn… robots.txt”). There is also no sitemap, so this PR does not add a `Sitemap:` line.

## Changes

- Add App Router `src/app/robots.ts` (`MetadataRoute.Robots`):
  - `User-agent: *` → `Allow: /`, `Disallow: /api/` only (no `Disallow: /`, no `/_next/` so CSS/JS stay crawlable)
  - Explicit `Allow: /` for search/retrieval: Googlebot, Bingbot, OAI-SearchBot, ChatGPT-User, Claude-SearchBot, Claude-User, PerplexityBot
  - Explicit `Disallow: /` for training-only: GPTBot, Google-Extended, ClaudeBot, Applebot-Extended, CCBot, Bytespider, anthropic-ai
  - No `Sitemap:` field
- `shouldRecordVisit` no longer records `/robots.txt`, `/sitemap.xml`, `/favicon.ico`, `/apple-touch-icon*` variants, or `/.well-known/*`. `/activity` stays excluded. The visit API already delegates to this helper.

Separate from the activity UI polish PR.

## Tests

- `robots()` allows `*` on `/`, disallows `/api/`, disallows GPTBot `/`, allows Googlebot `/`, and has no sitemap field
- `shouldRecordVisit("/robots.txt")` is false
- `shouldRecordVisit("/writing/foo")` is still true
- `shouldRecordVisit("/activity")` is still false

Verified locally: `bun test src/app/robots.test.ts src/lib/activity.test.ts` (128 pass), `bun run lint`, and `GET /robots.txt` returns `200 text/plain` with the rules above and no `Sitemap:` line. Production `https://brianlovin.com/robots.txt` still 404s until this ships.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff293dc6-15f3-4a3b-86ef-743f882d1367?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff293dc6-15f3-4a3b-86ef-743f882d1367&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

