### PR TITLE
Improve activity-feed visit labels for app dissections and HN stories

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -145,9 +145,10 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain(">Secret for iOS<");
+    expect(markup).toContain(">Secret for iOS App Dissection<");
     expect(markup).toContain('href="/app-dissection/secret-for-ios"');
     expect(markup).not.toContain(">secret for ios<");
+    expect(markup).not.toContain(">Secret for iOS<");
   });
 
   test("labels an HN index visit as Hacker News, not a story", () => {
@@ -164,6 +165,43 @@ describe("ActivityRow", () => {
     expect(markup).toContain("Hacker News");
     expect(markup).toContain('href="/hn"');
     expect(markup).not.toContain("a Hacker News story");
+  });
+
+  test("labels an Instagram iOS dissection visit with the section name", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          summary: "🇺🇸 Visit from United States",
+          subject: {
+            kind: "app_dissection",
+            label: "Instagram",
+            href: "/app-dissection/instagram-ios",
+          },
+          meta: { country: "US", path: "/app-dissection/instagram-ios" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain(">Instagram App Dissection<");
+    expect(markup).toContain('href="/app-dissection/instagram-ios"');
+    expect(markup).not.toContain(">Instagram<");
+  });
+
+  test("shows a stored HN story title instead of the generic phrase", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          summary: "🇺🇸 Visit from United States",
+          subject: { kind: "page", label: "Some HN Story", href: "/hn/42991019" },
+          meta: { country: "US", path: "/hn/42991019", title: "Some HN Story" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain(">Some HN Story<");
+    expect(markup).toContain('href="/hn/42991019"');
+    expect(markup).not.toContain("a Hacker News story");
+    expect(markup).not.toContain(">42991019<");
   });
 
   test("shows a Hacker News story instead of a raw story id", () => {

--- a/src/lib/activity-hn.ts
+++ b/src/lib/activity-hn.ts
@@ -1,0 +1,12 @@
+import { getPostById } from "./hn";
+
+/** Ingest-only HN title lookup. Never call this from the activity feed render path. */
+export async function lookupHnStoryTitle(id: string): Promise<string | null> {
+  try {
+    const post = await getPostById(id, false);
+    const title = post?.title?.trim();
+    return title || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -240,6 +240,87 @@ const ID_ROUTE_PHRASES: { prefix: string; label: string }[] = [
   { prefix: "/ama/", label: "an AMA question" },
 ];
 
+/** Child routes that should keep their section name after `stripSiteTitleSuffix`. */
+const CHILD_ROUTE_SECTION_SUFFIXES: { prefix: string; suffix: string }[] = [
+  { prefix: "/app-dissection/", suffix: "App Dissection" },
+  { prefix: "/design-details/", suffix: "Design Details" },
+];
+
+const GENERIC_HN_STORY_TITLES = new Set([
+  "a page",
+  "hacker news",
+  "a hacker news story",
+  "hacker news post",
+  "hacker news post not found",
+]);
+
+const HN_STORY_PATH_RE = /^\/hn\/(\d+)$/;
+
+/** Story id from `/hn/{id}` (and absolute briOS URLs). Index `/hn` is undefined. */
+export function hnStoryIdFromPath(pathname: string): string | undefined {
+  const path = normalizeActivityPath(pathnameFromHref(pathname));
+  const match = HN_STORY_PATH_RE.exec(path);
+  return match?.[1];
+}
+
+/** Missing, generic, or identifier titles that should not win over a real HN story name. */
+export function isGenericHnStoryTitle(title: string | undefined, storyId?: string): boolean {
+  const trimmed = title?.trim();
+  if (!trimmed) return true;
+  if (storyId && trimmed === storyId) return true;
+  if (looksLikeIdentifier(trimmed)) return true;
+  return GENERIC_HN_STORY_TITLES.has(trimmed.toLowerCase());
+}
+
+function childRouteSectionTitle(pathname: string): string | undefined {
+  const path = normalizeActivityPath(pathnameFromHref(pathname));
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length < 2) return undefined;
+  return KNOWN_PATH_TITLES[`/${segments[0]}`];
+}
+
+/** Section index title used on a child route (e.g. "App Dissection" on `/app-dissection/foo`). */
+function isGenericSectionTitle(title: string, pathname: string): boolean {
+  const section = childRouteSectionTitle(pathname);
+  if (!section) return false;
+  return title.trim().toLowerCase() === section.toLowerCase();
+}
+
+/**
+ * Stored/client titles that are not a real page name: empty, "a page", raw ids,
+ * a section index title on a child route, or a generic HN phrase.
+ */
+export function isUnusableActivityTitle(title: string | undefined, pathname: string): boolean {
+  const stored = title?.trim();
+  if (!stored) return true;
+  if (stored === "a page") return true;
+  if (looksLikeIdentifier(stored)) return true;
+  if (isProtocolSegment(stored)) return true;
+  if (isAbsoluteHttpUrl(stored)) return true;
+  if (isGenericHnStoryTitle(stored, hnStoryIdFromPath(pathname))) return true;
+  if (isGenericSectionTitle(stored, pathname)) return true;
+  return false;
+}
+
+/** `{Post name} App Dissection` — format the name first, then append so title-case still runs. */
+export function appendKnownSectionSuffix(label: string, pathname: string): string {
+  const path = normalizeActivityPath(pathnameFromHref(pathname));
+  const trimmed = label.trim();
+  if (!trimmed) return trimmed;
+
+  for (const { prefix, suffix } of CHILD_ROUTE_SECTION_SUFFIXES) {
+    if (!path.startsWith(prefix)) continue;
+    if (trimmed.toLowerCase() === suffix.toLowerCase()) return suffix;
+    if (trimmed.toLowerCase().endsWith(` ${suffix.toLowerCase()}`)) return trimmed;
+    return `${trimmed} ${suffix}`;
+  }
+  return trimmed;
+}
+
+function formatSubjectLabel(label: string, pathname: string): string {
+  return appendKnownSectionSuffix(formatActivityTitle(label), pathname);
+}
+
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const UUID_COMPACT_RE = /^[0-9a-f]{32}$/i;
 const UUID_SPACED_RE = /^[0-9a-f]{8}\s+[0-9a-f]{4}\s+[0-9a-f]{4}\s+[0-9a-f]{4}\s+[0-9a-f]{12}$/i;
@@ -392,14 +473,15 @@ export function stripSiteTitleSuffix(title: string): string {
  * slug-like leftovers. Falls back to the smart route map — never invents a name.
  */
 export function sanitizeActivityTitle(title: string | undefined, path: string): string {
-  const fallback = formatActivityTitle(inferTitleFromPath(path));
+  const fallback = formatSubjectLabel(inferTitleFromPath(path), path);
   const trimmed = title?.trim();
   if (!trimmed) return fallback;
 
   const stripped = stripSiteTitleSuffix(trimmed);
   if (!stripped || /^brian lovin$/i.test(stripped)) return fallback;
   if (findForbiddenPii(stripped)) return fallback;
-  return formatActivityTitle(stripped);
+  if (isUnusableActivityTitle(stripped, path)) return fallback;
+  return formatSubjectLabel(stripped, path);
 }
 
 export const sanitizeVisitTitle = sanitizeActivityTitle;
@@ -463,14 +545,8 @@ function displaySubjectLabel(
   if (href) {
     const inferred = inferTitleFromPath(href);
     const stored = label?.trim();
-    const storedUnusable =
-      !stored ||
-      stored === "a page" ||
-      looksLikeIdentifier(stored) ||
-      isProtocolSegment(stored) ||
-      isAbsoluteHttpUrl(stored);
-    if (storedUnusable) {
-      return isProtocolSegment(inferred) ? undefined : formatActivityTitle(inferred);
+    if (isUnusableActivityTitle(stored, href)) {
+      return isProtocolSegment(inferred) ? undefined : formatSubjectLabel(inferred, href);
     }
 
     const path = normalizeActivityPath(pathnameFromHref(href));
@@ -481,10 +557,10 @@ function displaySubjectLabel(
     }
 
     const cleaned = stripTrailingShortIdToken(stored);
-    if (looksLikeIdentifier(cleaned) || isProtocolSegment(cleaned)) {
-      return isProtocolSegment(inferred) ? undefined : formatActivityTitle(inferred);
+    if (isUnusableActivityTitle(cleaned, href)) {
+      return isProtocolSegment(inferred) ? undefined : formatSubjectLabel(inferred, href);
     }
-    return formatActivityTitle(cleaned || inferred);
+    return formatSubjectLabel(cleaned || inferred, href);
   }
 
   if (!label) return undefined;

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -545,7 +545,7 @@ function displaySubjectLabel(
   if (href) {
     const inferred = inferTitleFromPath(href);
     const stored = label?.trim();
-    if (isUnusableActivityTitle(stored, href)) {
+    if (!stored || isUnusableActivityTitle(stored, href)) {
       return isProtocolSegment(inferred) ? undefined : formatSubjectLabel(inferred, href);
     }
 

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import {
   activityEnterStaggerDelays,
@@ -33,6 +33,7 @@ import {
   recordLike,
   recordVisit,
   resolveActivitySourceHref,
+  resolveIngestVisitTitle,
   rollupActivityEvents,
   sanitizeVisitTitle,
   shouldPulseActivityRollup,
@@ -41,6 +42,7 @@ import {
   stripTrailingShortIdToken,
 } from "@/lib/activity";
 import { geoFromVisitMeta, normalizeRegionCode } from "@/lib/activity-geo";
+import * as activityHn from "@/lib/activity-hn";
 import { parseActivityStreamFields } from "@/lib/activity-redis";
 import { ACTIVITY_STREAM_MAXLEN, ACTIVITY_VISIT_STREAM_MAX_PER_SEC } from "@/lib/activity-shared";
 
@@ -52,6 +54,36 @@ function baseEvent(overrides: Record<string, unknown> = {}) {
     summary: "Someone liked a page",
     visibility: "public" as const,
     idempotency_key: `test:${crypto.randomUUID()}`,
+    ...overrides,
+  };
+}
+
+let lookupHnStoryTitleSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  lookupHnStoryTitleSpy = spyOn(activityHn, "lookupHnStoryTitle").mockResolvedValue(null);
+});
+
+afterEach(() => {
+  lookupHnStoryTitleSpy.mockRestore();
+});
+
+function visitRowEvent(
+  subject: { kind: string; label: string; href: string },
+  overrides: Record<string, unknown> = {},
+): ActivityEvent {
+  return {
+    v: 1,
+    id: "visit-row",
+    ts: "2026-08-16T00:00:00.000Z",
+    received_at: "2026-08-16T00:00:00.000Z",
+    source: "brios",
+    type: "visit",
+    speed: "signal",
+    summary: "Visit from United States",
+    visibility: "public",
+    idempotency_key: "visit-row",
+    subject,
     ...overrides,
   };
 }
@@ -443,16 +475,16 @@ describe("recordVisit", () => {
     const [event] = await store.getTail(1);
     expect(event?.subject).toEqual({
       kind: "app_dissection",
-      label: "Secret for iOS",
+      label: "Secret for iOS App Dissection",
       href: "/app-dissection/secret-for-ios",
     });
     expect(event?.meta).toEqual(
       expect.objectContaining({
         path: "/app-dissection/secret-for-ios",
-        title: "Secret for iOS",
+        title: "Secret for iOS App Dissection",
       }),
     );
-    expect(getActivityRow(event!).label).toBe("Secret for iOS");
+    expect(getActivityRow(event!).label).toBe("Secret for iOS App Dissection");
   });
 
   test("uses a client title for writing, home, HN, and TIL", async () => {
@@ -489,9 +521,11 @@ describe("recordVisit", () => {
       store,
     );
     const [event] = await store.getTail(1);
-    expect(event?.subject?.label).toBe("Secret for iOS");
-    expect(event?.meta).toEqual(expect.objectContaining({ title: "Secret for iOS" }));
-    expect(getActivityRow(event!).label).toBe("Secret for iOS");
+    expect(event?.subject?.label).toBe("Secret for iOS App Dissection");
+    expect(event?.meta).toEqual(
+      expect.objectContaining({ title: "Secret for iOS App Dissection" }),
+    );
+    expect(getActivityRow(event!).label).toBe("Secret for iOS App Dissection");
   });
 
   test("stores a contextual phrase for an HN story id at ingest", async () => {
@@ -505,6 +539,41 @@ describe("recordVisit", () => {
     });
     expect(event?.meta).toEqual(expect.objectContaining({ title: "a Hacker News story" }));
     expect(getActivityRow(event!).label).toBe("a Hacker News story");
+    expect(lookupHnStoryTitleSpy).toHaveBeenCalledWith("46993596");
+  });
+
+  test("looks up an HN story title at ingest when the client title is generic or empty", async () => {
+    lookupHnStoryTitleSpy.mockResolvedValue("Some HN Story");
+
+    const store = createMemoryActivityStore();
+    await recordVisit({ path: "/hn/42991019", title: "Hacker News" }, store);
+    await recordVisit({ path: "/hn/42991019" }, store);
+
+    const events = await store.getTail(2);
+    expect(events.map((event) => event.subject?.label)).toEqual(["Some HN Story", "Some HN Story"]);
+    expect(lookupHnStoryTitleSpy).toHaveBeenCalledWith("42991019");
+    expect(getActivityRow(events[0]!).label).toBe("Some HN Story");
+    expect(getActivityRow(events[0]!).label).not.toBe("a Hacker News story");
+  });
+
+  test("does not look up an HN story when the client already sent a real title", async () => {
+    lookupHnStoryTitleSpy.mockResolvedValue("Ignored lookup title");
+    const store = createMemoryActivityStore();
+    await recordVisit({ path: "/hn/42991019", title: "A story about iOS | Brian Lovin" }, store);
+    const [event] = await store.getTail(1);
+    expect(event?.subject?.label).toBe("A story about iOS");
+    expect(lookupHnStoryTitleSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolveIngestVisitTitle uses the mocked HN helper for a generic title", async () => {
+    lookupHnStoryTitleSpy.mockResolvedValue("Some HN Story");
+    await expect(resolveIngestVisitTitle("/hn/42991019", "Hacker News")).resolves.toBe(
+      "Some HN Story",
+    );
+    await expect(resolveIngestVisitTitle("/hn/42991019", "")).resolves.toBe("Some HN Story");
+    await expect(resolveIngestVisitTitle("/hn/42991019", "42991019")).resolves.toBe(
+      "Some HN Story",
+    );
   });
 
   test("strips a trailing short id from the visit title at ingest", async () => {
@@ -923,9 +992,9 @@ describe("recordLike", () => {
     );
     expect("ok" in result && result.ok).toBe(true);
     const [event] = await store.getTail(1);
-    expect(event?.summary).toBe("Someone liked Secret for iOS");
-    expect(event?.subject?.label).toBe("Secret for iOS");
-    expect(getActivityRow(event!).summary).toBe("Someone liked Secret for iOS");
+    expect(event?.summary).toBe("Someone liked Secret for iOS App Dissection");
+    expect(event?.subject?.label).toBe("Secret for iOS App Dissection");
+    expect(getActivityRow(event!).summary).toBe("Someone liked Secret for iOS App Dissection");
   });
 
   test("does not store a like title that looks like PII", async () => {
@@ -1154,25 +1223,47 @@ describe("sanitizeVisitTitle / formatActivityTitle", () => {
   test("client title wins over the slug and strips Brian Lovin suffixes", () => {
     expect(
       sanitizeVisitTitle("Secret for iOS | Brian Lovin", "/app-dissection/secret-for-ios"),
-    ).toBe("Secret for iOS");
+    ).toBe("Secret for iOS App Dissection");
     expect(
       sanitizeVisitTitle("Secret for iOS – Brian Lovin", "/app-dissection/secret-for-ios"),
-    ).toBe("Secret for iOS");
+    ).toBe("Secret for iOS App Dissection");
     expect(
       sanitizeVisitTitle("Secret for iOS — Brian Lovin", "/app-dissection/secret-for-ios"),
-    ).toBe("Secret for iOS");
+    ).toBe("Secret for iOS App Dissection");
     expect(
       sanitizeVisitTitle("Secret for iOS - App Dissection", "/app-dissection/secret-for-ios"),
-    ).toBe("Secret for iOS");
+    ).toBe("Secret for iOS App Dissection");
   });
 
   test("falls back to the path title when the client title is missing or PII", () => {
-    expect(sanitizeVisitTitle(undefined, "/app-dissection/secret-for-ios")).toBe("Secret for iOS");
-    expect(sanitizeVisitTitle("   ", "/app-dissection/secret-for-ios")).toBe("Secret for iOS");
-    expect(sanitizeVisitTitle("a@b.com", "/app-dissection/secret-for-ios")).toBe("Secret for iOS");
+    expect(sanitizeVisitTitle(undefined, "/app-dissection/secret-for-ios")).toBe(
+      "Secret for iOS App Dissection",
+    );
+    expect(sanitizeVisitTitle("   ", "/app-dissection/secret-for-ios")).toBe(
+      "Secret for iOS App Dissection",
+    );
+    expect(sanitizeVisitTitle("a@b.com", "/app-dissection/secret-for-ios")).toBe(
+      "Secret for iOS App Dissection",
+    );
     expect(sanitizeVisitTitle("Brian Lovin", "/")).toBe("Home");
     expect(sanitizeVisitTitle("Home | Brian Lovin", "/")).toBe("Home");
     expect(shouldRecordVisit("/activity")).toBe(false);
+  });
+
+  test("puts App Dissection back on child routes after stripping the site suffix", () => {
+    expect(
+      sanitizeVisitTitle(
+        "Instagram – App Dissection | Brian Lovin",
+        "/app-dissection/instagram-ios",
+      ),
+    ).toBe("Instagram App Dissection");
+    expect(sanitizeVisitTitle(undefined, "/app-dissection/instagram-ios")).toBe(
+      "Instagram iOS App Dissection",
+    );
+    expect(sanitizeVisitTitle("App Dissection", "/app-dissection")).toBe("App Dissection");
+    expect(sanitizeVisitTitle("Hacker News", "/hn")).toBe("Hacker News");
+    expect(sanitizeVisitTitle("Hacker News", "/hn/42991019")).toBe("a Hacker News story");
+    expect(sanitizeVisitTitle("Some HN Story", "/hn/42991019")).toBe("Some HN Story");
   });
 
   test("strips a site suffix from a document title", () => {
@@ -1310,7 +1401,7 @@ describe("getActivityRow page titles", () => {
         href: "/app-dissection/secret-for-ios",
       },
     });
-    expect(row.label).toBe("Secret for iOS");
+    expect(row.label).toBe("Secret for iOS App Dissection");
     expect(row.href).toBe("/app-dissection/secret-for-ios");
   });
 
@@ -1333,6 +1424,74 @@ describe("getActivityRow page titles", () => {
       expect(row.label).toBe("Hacker News");
       expect(row.href).toBe(href);
       expect(row.label).not.toBe("a Hacker News story");
+    }
+  });
+
+  test("labels an app dissection post as the post name plus App Dissection", () => {
+    const fromSlug = getActivityRow(
+      visitRowEvent({
+        kind: "app_dissection",
+        label: "a page",
+        href: "/app-dissection/instagram-ios",
+      }),
+    );
+    expect(fromSlug.label).toBe("Instagram iOS App Dissection");
+    expect(fromSlug.href).toBe("/app-dissection/instagram-ios");
+    expect(fromSlug.label).not.toBe("Instagram");
+
+    const fromStored = getActivityRow(
+      visitRowEvent({
+        kind: "app_dissection",
+        label: "Instagram",
+        href: "/app-dissection/instagram-ios",
+      }),
+    );
+    expect(fromStored.label).toBe("Instagram App Dissection");
+    expect(fromStored.href).toBe("/app-dissection/instagram-ios");
+    expect(fromStored.label).not.toBe("Instagram");
+
+    const alreadySuffixed = getActivityRow(
+      visitRowEvent({
+        kind: "app_dissection",
+        label: "Instagram iOS App Dissection",
+        href: "/app-dissection/instagram-ios",
+      }),
+    );
+    expect(alreadySuffixed.label).toBe("Instagram iOS App Dissection");
+
+    const index = getActivityRow(
+      visitRowEvent({ kind: "app_dissection", label: "a page", href: "/app-dissection" }),
+    );
+    expect(index.label).toBe("App Dissection");
+    expect(index.href).toBe("/app-dissection");
+  });
+
+  test("uses a stored HN story title instead of the generic phrase", () => {
+    const row = getActivityRow(
+      visitRowEvent({
+        kind: "page",
+        label: "Some HN Story",
+        href: "/hn/42991019",
+      }),
+    );
+    expect(row.label).toBe("Some HN Story");
+    expect(row.href).toBe("/hn/42991019");
+    expect(row.label).not.toBe("a Hacker News story");
+    expect(row.label).not.toBe("42991019");
+  });
+
+  test("falls back to a Hacker News story when the stored title is generic", () => {
+    for (const label of ["Hacker News", "a Hacker News story", "a page", ""]) {
+      const row = getActivityRow(
+        visitRowEvent({
+          kind: "page",
+          label,
+          href: "/hn/42991019",
+        }),
+      );
+      expect(row.label).toBe("a Hacker News story");
+      expect(row.href).toBe("/hn/42991019");
+      expect(row.label).not.toBe("42991019");
     }
   });
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -7,6 +7,7 @@ import {
   geoFromVisitMeta,
 } from "./activity-geo";
 import { githubActivityFromWebhook } from "./activity-github";
+import { lookupHnStoryTitle } from "./activity-hn";
 import { isRegisteredActivityEvent } from "./activity-registry";
 import {
   ACTIVITY_ENVELOPE_VERSION,
@@ -23,8 +24,10 @@ import {
   type ActivitySpeed,
   findForbiddenPii,
   formatDownloadSummary,
+  hnStoryIdFromPath,
   inferContentTypeFromPath,
   isActivityPath,
+  isGenericHnStoryTitle,
   likeActivityPayload,
   normalizeCaffeineDrink,
   resolveVisitTitle,
@@ -86,6 +89,7 @@ export {
   activitySourceFaviconSrc,
   activitySourceLabel,
   activitySourceUrl,
+  appendKnownSectionSuffix,
   countryCodeToFlag,
   findForbiddenPii,
   formatActivityTitle,
@@ -95,14 +99,17 @@ export {
   getCaffeineIcon,
   getMergedPullRequestDiff,
   getRequestCountry,
+  hnStoryIdFromPath,
   inferContentTypeFromPath,
   inferTitleFromPath,
   isAbsoluteHttpUrl,
   isActivityFeedPayload,
   isActivityPath,
   isCoffeeFamilyDrink,
+  isGenericHnStoryTitle,
   isKnownActivitySection,
   isKnownActivityTitle,
+  isUnusableActivityTitle,
   likeActivityPayload,
   looksLikeDehyphenatedSlug,
   looksLikeIdentifier,
@@ -199,13 +206,32 @@ function validateRef(name: string, value: unknown): string | null {
   return null;
 }
 
-function applyIngestDefaults(input: ActivityIngestInput): ActivityIngestInput {
+/**
+ * Sanitize a visit title, then look up `/hn/{id}` when the client title is
+ * missing or generic. Ingest-only — the activity feed render path stays sync.
+ */
+export async function resolveIngestVisitTitle(path: string, title?: string): Promise<string> {
+  const resolved = resolveVisitTitle(path, title);
+  const id = hnStoryIdFromPath(path);
+  if (!id || !isGenericHnStoryTitle(resolved, id)) return resolved;
+
+  try {
+    const lookedUp = await lookupHnStoryTitle(id);
+    if (!lookedUp) return resolved;
+    const fromHn = resolveVisitTitle(path, lookedUp);
+    return isGenericHnStoryTitle(fromHn, id) ? resolved : fromHn;
+  } catch {
+    return resolved;
+  }
+}
+
+async function applyIngestDefaults(input: ActivityIngestInput): Promise<ActivityIngestInput> {
   if (input.type === "visit") {
     const meta = isPlainObject(input.meta) ? { ...input.meta } : {};
     const path =
       typeof meta.path === "string" && meta.path ? meta.path : input.subject?.href || "/";
     const providedTitle = typeof meta.title === "string" ? meta.title : input.subject?.label;
-    const title = resolveVisitTitle(path, providedTitle);
+    const title = await resolveIngestVisitTitle(path, providedTitle);
     const geo = geoFromVisitMeta(meta);
     const country = geo.country?.trim() || undefined;
     const countryName = geo.countryName || (country ? countryCodeToName(country) : undefined);
@@ -220,10 +246,10 @@ function applyIngestDefaults(input: ActivityIngestInput): ActivityIngestInput {
       ...input,
       speed: input.speed ?? "signal",
       summary,
-      subject: input.subject ?? {
-        kind: inferContentTypeFromPath(path),
+      subject: {
+        kind: input.subject?.kind ?? inferContentTypeFromPath(path),
         label: title,
-        href: path,
+        href: input.subject?.href ?? path,
       },
       meta: {
         ...meta,
@@ -297,7 +323,7 @@ export async function ingestActivityEvent(
     return { ok: false, error: "unregistered source/type", status: 400 };
   }
 
-  const normalized = applyIngestDefaults(input);
+  const normalized = await applyIngestDefaults(input);
   const fieldError = validateIngestInput(normalized);
   if (fieldError) return { ok: false, error: fieldError, status: 400 };
 
@@ -387,7 +413,7 @@ export async function recordVisit(
   const regionName = input.regionName?.trim() || undefined;
   const city = input.city?.trim() || undefined;
   const summary = formatVisitSummary({ country, countryName, region, regionName, city });
-  const title = resolveVisitTitle(input.path, input.title);
+  const title = await resolveIngestVisitTitle(input.path, input.title);
   const windowKey = `visit:${Math.floor(now.getTime() / 1000)}`;
   const windowCount = await store.incrementVisitWindow(windowKey, 2);
   const writeToStream = windowCount <= ACTIVITY_VISIT_STREAM_MAX_PER_SEC;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
App dissection child routes and HN story visits were losing the useful part of the page name: `stripSiteTitleSuffix` dropped “App Dissection” (so Instagram iOS showed as **Instagram**), and `/hn/{id}` preferred the generic phrase over a stored title when `document.title` was still “Hacker News”.

## App Dissection
- `/app-dissection` stays **App Dissection**
- `/app-dissection/{slug}` is `{Post name} App Dissection`
- Post name comes from the slug (`instagram-ios` → `Instagram iOS`) or a stored `document.title` after `stripSiteTitleSuffix`
- The section is appended again after stripping so existing Redis events recover at render
- Same helper also covers `/design-details/{slug}` when a real episode title is stored

## HN stories
- `/hn` stays **Hacker News** (no regression of #2298)
- `/hn/{id}` uses the stored story title when it is real
- Falls back to **a Hacker News story** only when the stored label is missing, generic, or the raw id
- At ingest, if the client title is empty / “Hacker News” / the id, look up the item via `getPostById` (cache then API). Render path stays sync — no per-row HN network on `/activity`

## Tests
- `/app-dissection/instagram-ios` → `Instagram iOS App Dissection` (or `Instagram App Dissection` from a stored title), never bare `Instagram`
- `/app-dissection` → `App Dissection`
- `/hn/42991019` with stored “Some HN Story” → that title
- `/hn/42991019` with no usable title → `a Hacker News story`
- `/hn` → `Hacker News`
- Visit ingest for `/hn/{id}` with title “Hacker News” or empty uses the mocked HN helper title

Verified: `bun test` (372 pass), `bun run lint`, `bun run build`.

Does not change Redis trim, the 1500 window, or the UI polish in #2294.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8266c5e5-8aa8-4af7-927f-06d9e8a4017b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8266c5e5-8aa8-4af7-927f-06d9e8a4017b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

