### PR TITLE
Stop sending a frozen HN digest two days in a row

### DIFF
--- a/src/app/api/hn-digest/send/route.test.ts
+++ b/src/app/api/hn-digest/send/route.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+import { dynamic, revalidate } from "@/app/api/hn-digest/send/route";
+
+describe("GET /api/hn-digest/send", () => {
+  test("is force-dynamic so the cron response is never cached across days", () => {
+    expect(dynamic).toBe("force-dynamic");
+    expect(revalidate).toBe(0);
+  });
+});

--- a/src/app/api/hn-digest/send/route.test.ts
+++ b/src/app/api/hn-digest/send/route.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
-
-import { dynamic, revalidate } from "@/app/api/hn-digest/send/route";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
 describe("GET /api/hn-digest/send", () => {
-  test("is force-dynamic so the cron response is never cached across days", () => {
-    expect(dynamic).toBe("force-dynamic");
-    expect(revalidate).toBe(0);
+  test("opts the cron into request-time rendering without cacheComponents-incompatible segment configs", () => {
+    const source = readFileSync(resolve(import.meta.dir, "route.ts"), "utf8");
+
+    expect(source).not.toMatch(/export const dynamic/);
+    expect(source).not.toMatch(/export const revalidate/);
+    expect(source).toMatch(/await connection\(\)/);
+    expect(source).toContain("Cache-Control");
+    expect(source).toContain("no-store");
   });
 });

--- a/src/app/api/hn-digest/send/route.ts
+++ b/src/app/api/hn-digest/send/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { connection, NextResponse } from "next/server";
 
 import { recordDigestSent } from "@/lib/activity";
 import { afterActivity } from "@/lib/activity-schedule";
@@ -9,12 +9,13 @@ import { getHNPostsForDigest } from "@/lib/hn";
 import { getHNSubscribers } from "@/lib/subscriptions";
 import { formatDigestDate } from "@/lib/urls";
 
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
-
 const IS_PROD = process.env.NODE_ENV === "production";
 
 export async function GET(request: Request) {
+  // cacheComponents forbids `dynamic` / `revalidate` segment configs.
+  // connection() is the Next 16 equivalent of force-dynamic for this cron.
+  await connection();
+
   try {
     const authHeader = request.headers.get("authorization");
     const providedToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;

--- a/src/app/api/hn-digest/send/route.ts
+++ b/src/app/api/hn-digest/send/route.ts
@@ -9,6 +9,9 @@ import { getHNPostsForDigest } from "@/lib/hn";
 import { getHNSubscribers } from "@/lib/subscriptions";
 import { formatDigestDate } from "@/lib/urls";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 const IS_PROD = process.env.NODE_ENV === "production";
 
 export async function GET(request: Request) {
@@ -19,12 +22,18 @@ export async function GET(request: Request) {
       return errorResponse("Unauthorized", 401);
     }
 
-    // Fetch top HN posts for the digest
+    // Fetch top HN posts for the digest (uncached — must be today's set)
     const posts = await getHNPostsForDigest();
 
     if (!posts || posts.length === 0) {
       return errorResponse("No posts found for digest", 500);
     }
+
+    console.log(
+      `[HN Digest] ${posts.length} posts: ${posts
+        .map((post) => `${post.id} "${post.title}"`)
+        .join(", ")}`,
+    );
 
     const date = formatDigestDate();
 
@@ -53,12 +62,15 @@ export async function GET(request: Request) {
       afterActivity((store) => recordDigestSent({ date, postCount: digestPosts.length }, store));
     }
 
-    return NextResponse.json({
-      status: "done",
-      emailsSent: successCount,
-      failures: failureCount,
-      totalSubscribers: subscribers.length,
-    });
+    return NextResponse.json(
+      {
+        status: "done",
+        emailsSent: successCount,
+        failures: failureCount,
+        totalSubscribers: subscribers.length,
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
   } catch (error) {
     console.error("Error processing HN digest:", error);
     return errorResponse("Failed to process HN digest");

--- a/src/lib/hn.test.ts
+++ b/src/lib/hn.test.ts
@@ -128,7 +128,7 @@ describe("getHNPostsForDigest cache", () => {
     const source = readFileSync(resolve(import.meta.dir, "hn.ts"), "utf8");
 
     expect(source).not.toMatch(/getHNPostsForDigest\s*=\s*unstable_cache/);
-    expect(source).not.toContain('["hn:digest"]');
+    expect(source).not.toMatch(/unstable_cache\([\s\S]*?,\s*\["hn:digest"\]/);
     expect(source).toMatch(/export async function getHNPostsForDigest/);
   });
 });

--- a/src/lib/hn.test.ts
+++ b/src/lib/hn.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
-import { processPost } from "@/lib/hn";
+import { processPost, selectHNPostsForDigest } from "@/lib/hn";
 import { HackerNewsComment, HackerNewsPost } from "@/types/hackernews";
 
 function makePost(overrides: Partial<HackerNewsPost> = {}): HackerNewsPost {
@@ -63,5 +65,70 @@ describe("processPost", () => {
 
     expect(post.comments).toHaveLength(1);
     expect(post.comments?.[0]?.id).toBe(3);
+  });
+});
+
+describe("selectHNPostsForDigest", () => {
+  const now = 1_800_000_000;
+  const hour = 60 * 60;
+
+  test("keeps only links from the last 24 hours, ranked by points", () => {
+    const posts = [
+      makePost({ id: 1, title: "old high score", points: 500, time: now - 25 * hour }),
+      makePost({ id: 2, title: "yesterday's leftover", points: 400, time: now - 24 * hour }),
+      makePost({ id: 3, title: "fresh mid", points: 80, time: now - 2 * hour }),
+      makePost({ id: 4, title: "fresh high", points: 200, time: now - hour }),
+      makePost({ id: 5, title: "fresh low", points: 10, time: now - 3 * hour }),
+      makePost({ id: 6, title: "job", points: 999, time: now - hour, type: "job" }),
+      makePost({ id: 7, title: "poll", points: 888, time: now - hour, type: "poll" }),
+      null,
+    ];
+
+    const selected = selectHNPostsForDigest(posts, now);
+
+    expect(selected.map((post) => post.id)).toEqual([4, 3, 5]);
+    expect(selected.every((post) => post.type === "link")).toBe(true);
+    expect(selected.every((post) => post.time > now - 24 * hour)).toBe(true);
+  });
+
+  test("returns the top 16 by points when more than 16 qualify", () => {
+    const posts = Array.from({ length: 20 }, (_, index) =>
+      makePost({
+        id: index + 1,
+        title: `story ${index + 1}`,
+        points: index + 1,
+        time: now - hour,
+      }),
+    );
+
+    const selected = selectHNPostsForDigest(posts, now);
+
+    expect(selected).toHaveLength(16);
+    expect(selected[0]?.id).toBe(20);
+    expect(selected[0]?.points).toBe(20);
+    expect(selected[15]?.id).toBe(5);
+    expect(selected[15]?.points).toBe(5);
+    expect(selected.map((post) => post.points)).toEqual([
+      20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5,
+    ]);
+  });
+
+  test("treats missing points as zero when ranking", () => {
+    const posts = [
+      makePost({ id: 1, title: "no points", points: null, time: now - hour }),
+      makePost({ id: 2, title: "has points", points: 1, time: now - hour }),
+    ];
+
+    expect(selectHNPostsForDigest(posts, now).map((post) => post.id)).toEqual([2, 1]);
+  });
+});
+
+describe("getHNPostsForDigest cache", () => {
+  test("is not wrapped in a dateless unstable_cache that can survive 24h", () => {
+    const source = readFileSync(resolve(import.meta.dir, "hn.ts"), "utf8");
+
+    expect(source).not.toMatch(/getHNPostsForDigest\s*=\s*unstable_cache/);
+    expect(source).not.toContain('["hn:digest"]');
+    expect(source).toMatch(/export async function getHNPostsForDigest/);
   });
 });

--- a/src/lib/hn.ts
+++ b/src/lib/hn.ts
@@ -233,41 +233,51 @@ export const getRankedHNPosts = unstable_cache(
   { revalidate: HN_REVALIDATE, tags: ["hn:ranked"] },
 );
 
-export const getHNPostsForDigest = unstable_cache(
-  async (): Promise<HackerNewsPost[]> => {
-    const topPostIds = await fetchPostIds();
-    log(`[HN Digest] Starting with ${topPostIds.length} total story IDs`);
+const DIGEST_WINDOW_SECONDS = 60 * 60 * 24;
+const DIGEST_POST_LIMIT = 16;
 
-    // topPostIds returns 500 by default. this can block the API route from
-    // responding for a long time while each one is fetched individually.
-    // it's much more likely that the most recent 200 (by decrementing id) are
-    // the top posts within the last 24 hours
-    const filtered = topPostIds.sort((a: number, b: number) => b - a).slice(0, 200);
-    log(`[HN Digest] Filtered to top 200 most recent IDs`);
+/**
+ * Pick digest stories from already-fetched posts: links only, last 24h,
+ * top 16 by points. Pure so the daily send cannot inherit a dateless
+ * `unstable_cache` snapshot (see getHNPostsForDigest).
+ */
+export function selectHNPostsForDigest(
+  posts: (HackerNewsPost | null)[],
+  nowSeconds: number = Date.now() / 1000,
+): HackerNewsPost[] {
+  const dayAgo = nowSeconds - DIGEST_WINDOW_SECONDS;
 
-    const ids = filtered.map((id) => id.toString());
-    const posts = await getBatchPosts(ids, false);
+  const links = posts.filter(
+    (post): post is HackerNewsPost => post !== null && post.type === "link",
+  );
+  const withinLastDay = links.filter((post) => post.time > dayAgo);
+  return withinLastDay
+    .sort((a, b) => (b.points || 0) - (a.points || 0))
+    .slice(0, DIGEST_POST_LIMIT);
+}
 
-    const now = new Date().getTime() / 1000;
-    const dayAgo = now - 60 * 60 * 24;
+/**
+ * Fresh fetch for the daily email. Do not wrap this in `unstable_cache` —
+ * a dateless key like `["hn:digest"]` can survive past the 1h revalidate
+ * on Vercel cron and send yesterday's identical snapshot.
+ */
+export async function getHNPostsForDigest(): Promise<HackerNewsPost[]> {
+  const topPostIds = await fetchPostIds();
+  log(`[HN Digest] Starting with ${topPostIds.length} total story IDs`);
 
-    // don't return jobs or polls
-    const validPosts = posts.filter((post): post is HackerNewsPost => post !== null);
-    log(`[HN Digest] ${validPosts.length} valid posts fetched`);
+  // topPostIds returns 500 by default. this can block the API route from
+  // responding for a long time while each one is fetched individually.
+  // it's much more likely that the most recent 200 (by decrementing id) are
+  // the top posts within the last 24 hours
+  const filtered = topPostIds.sort((a: number, b: number) => b - a).slice(0, 200);
+  log(`[HN Digest] Filtered to top 200 most recent IDs`);
 
-    const links = validPosts.filter((post) => post.type === "link");
-    log(`[HN Digest] ${links.length} posts are links (filtered out jobs/polls)`);
+  const ids = filtered.map((id) => id.toString());
+  const posts = await getBatchPosts(ids, false);
 
-    const withinLastDay = links.filter((post) => post.time > dayAgo);
-    log(`[HN Digest] ${withinLastDay.length} posts within last 24 hours`);
+  const top16 = selectHNPostsForDigest(posts);
 
-    const sorted = withinLastDay.sort((a, b) => (b.points || 0) - (a.points || 0));
-    const top16 = sorted.slice(0, 16);
+  log(`[HN Digest] Returning top ${top16.length} posts by points`);
 
-    log(`[HN Digest] Returning top ${top16.length} posts by points`);
-
-    return top16;
-  },
-  ["hn:digest"],
-  { revalidate: HN_REVALIDATE, tags: ["hn:digest"] },
-);
+  return top16;
+}

--- a/src/lib/hn.ts
+++ b/src/lib/hn.ts
@@ -257,9 +257,9 @@ export function selectHNPostsForDigest(
 }
 
 /**
- * Fresh fetch for the daily email. Do not wrap this in `unstable_cache` —
- * a dateless key like `["hn:digest"]` can survive past the 1h revalidate
- * on Vercel cron and send yesterday's identical snapshot.
+ * Fresh fetch for the daily email. Do not wrap this in `unstable_cache`
+ * with a dateless key — that can survive past the 1h revalidate on Vercel
+ * cron and send yesterday's identical snapshot.
  */
 export async function getHNPostsForDigest(): Promise<HackerNewsPost[]> {
   const topPostIds = await fetchPostIds();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The daily HN digest cron (`0 23 * * *` → `/api/hn-digest/send`) sent identical emails on Aug 15 and Aug 16: same 16 titles, same HN ids, same comment counts. Live HN counts would have moved in 24 hours, so this was a frozen snapshot — not a coincidentally similar ranking.

## Cause

`getHNPostsForDigest` was wrapped in `unstable_cache(..., ["hn:digest"], { revalidate: 3600 })`. The cache key has no date. Combined with Next 16’s data cache and a once-a-day Vercel cron, that 3600s revalidate is not reliably treated as expired on the next send, so the route returned yesterday’s array.

Redis post TTL is 1 hour. If posts had been re-fetched, comment counts would have changed. The hit is the **full digest result cache**, not Redis.

`getRankedHNPosts` uses the same `["hn:ranked"]` pattern for `/hn`. That path is unchanged.

## Fix

- `getHNPostsForDigest` is an uncached fetch. Selection is a pure `selectHNPostsForDigest` helper (links only, last 24h by `post.time`, top 16 by points). Jobs/polls still excluded.
- `/api/hn-digest/send` cannot export `dynamic` / `revalidate` — Next 16 `cacheComponents` rejects those and CI failed on the first revision. The route now `await connection()` (the Cache Components equivalent of force-dynamic) and returns `Cache-Control: no-store`.
- Send-time log of post ids + titles (no emails, no tokens) so a repeat freeze is obvious in logs.
- Redis / `fetchPostIds` 1h TTL stays for the site. That at most 1h-stale list is fine for the digest send.

## Tests

- Source assertion: `getHNPostsForDigest` is not wrapped in a dateless `unstable_cache`.
- Unit: older-than-24h posts dropped; jobs/polls dropped; top 16 by points.
- Send route uses `connection()`, has no `dynamic`/`revalidate` exports, and sets `no-store`.
- Local production build succeeds; `/api/hn-digest/send` is `ƒ` (Dynamic).

No real email is sent. Do not merge automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f16b5aa3-c14e-4fb6-9725-684ca79ac12c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f16b5aa3-c14e-4fb6-9725-684ca79ac12c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

