### PR TITLE
Use exact writing and TIL titles on activity visit rows

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -47,6 +47,30 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain("block truncate");
   });
 
+  test("renders an exact stored writing title, including I'm and AI", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          summary: "🇮🇳 Visit from India",
+          subject: {
+            kind: "writing",
+            label: "How I'm Feeling About AI in August 2026",
+            href: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+          },
+          meta: {
+            country: "IN",
+            path: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+            title: "How I'm Feeling About AI in August 2026",
+          },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("How I&#x27;m Feeling About AI in August 2026");
+    expect(markup).not.toContain("How Im Feeling About Ai in August 2026");
+    expect(markup).toContain('href="/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS"');
+  });
+
   test("strips a short id from a stored writing slug", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow

--- a/src/lib/activity-cms.ts
+++ b/src/lib/activity-cms.ts
@@ -1,0 +1,31 @@
+import { getTilByShortId, getWritingPostByShortId, getWritingPostContentBySlug } from "./notion";
+import { extractShortIdFromSlug } from "./short-id";
+
+/**
+ * Ingest-only writing/TIL title lookup. Uses the same Notion helpers as the
+ * post pages. Never call this from the activity feed render path.
+ */
+export async function lookupCmsPostTitle(
+  kind: "writing" | "til",
+  slug: string,
+): Promise<string | null> {
+  try {
+    if (kind === "writing") {
+      const shortId = extractShortIdFromSlug(slug);
+      let content = shortId ? await getWritingPostByShortId(shortId) : null;
+      if (!content) {
+        content = await getWritingPostContentBySlug(slug);
+      }
+      const title = content?.metadata.title?.trim();
+      return title || null;
+    }
+
+    const shortId = extractShortIdFromSlug(slug);
+    if (!shortId) return null;
+    const content = await getTilByShortId(shortId);
+    const title = content?.title?.trim();
+    return title || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -330,12 +330,23 @@ const GENERIC_HN_STORY_TITLES = new Set([
 ]);
 
 const HN_STORY_PATH_RE = /^\/hn\/(\d+)$/;
+const CMS_POST_PATH_RE = /^\/(writing|til)\/([^/]+)$/;
 
 /** Story id from `/hn/{id}` (and absolute briOS URLs). Index `/hn` is undefined. */
 export function hnStoryIdFromPath(pathname: string): string | undefined {
   const path = normalizeActivityPath(pathnameFromHref(pathname));
   const match = HN_STORY_PATH_RE.exec(path);
   return match?.[1];
+}
+
+/** Writing/TIL child slug from `/writing/{slug}` or `/til/{slug}` (and absolute URLs). */
+export function cmsPostRefFromPath(
+  pathname: string,
+): { kind: "writing" | "til"; slug: string } | undefined {
+  const path = normalizeActivityPath(pathnameFromHref(pathname));
+  const match = CMS_POST_PATH_RE.exec(path);
+  if (!match) return undefined;
+  return { kind: match[1] as "writing" | "til", slug: match[2] };
 }
 
 /** Missing, generic, or identifier titles that should not win over a real HN story name. */
@@ -394,6 +405,14 @@ export function appendKnownSectionSuffix(label: string, pathname: string): strin
 
 function formatSubjectLabel(label: string, pathname: string): string {
   return appendKnownSectionSuffix(formatActivityTitle(label), pathname);
+}
+
+/** Keep a real mixed-case title as-is; title-case only slug leftovers. */
+function preserveOrFormatSubjectLabel(label: string, pathname: string): string {
+  if (!looksLikeDehyphenatedSlug(label)) {
+    return appendKnownSectionSuffix(label, pathname);
+  }
+  return formatSubjectLabel(label, pathname);
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -556,7 +575,7 @@ export function sanitizeActivityTitle(title: string | undefined, path: string): 
   if (!stripped || /^brian lovin$/i.test(stripped)) return fallback;
   if (findForbiddenPii(stripped)) return fallback;
   if (isUnusableActivityTitle(stripped, path)) return fallback;
-  return formatSubjectLabel(stripped, path);
+  return preserveOrFormatSubjectLabel(stripped, path);
 }
 
 export const sanitizeVisitTitle = sanitizeActivityTitle;
@@ -566,6 +585,35 @@ export function looksLikeDehyphenatedSlug(label: string): boolean {
   const trimmed = label.trim();
   if (!trimmed || !/[a-z]/i.test(trimmed)) return false;
   return !/[A-Z]/.test(trimmed);
+}
+
+/**
+ * True when `title` is the path slug (raw, de-hyphenated, or title-cased).
+ * Real CMS titles that differ (apostrophes, `AI`) return false.
+ */
+export function isSlugLikeActivityTitle(title: string | undefined, pathname: string): boolean {
+  const trimmed = title?.trim();
+  if (!trimmed) return true;
+  if (looksLikeDehyphenatedSlug(trimmed)) return true;
+
+  const inferred = inferTitleFromPath(pathname);
+  const normalized = stripTrailingShortIdToken(trimmed)
+    .replace(/-/g, " ")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+  if (normalized === inferred.toLowerCase()) return true;
+  return trimmed === formatActivityTitle(inferred);
+}
+
+/** Missing, generic, or slug-derived titles that should lose to a CMS lookup. */
+export function shouldLookupCmsPostTitle(title: string | undefined, pathname: string): boolean {
+  if (!cmsPostRefFromPath(pathname)) return false;
+  const trimmed = title?.trim();
+  if (!trimmed) return true;
+  const stripped = stripSiteTitleSuffix(trimmed);
+  if (!stripped || /^brian lovin$/i.test(stripped)) return true;
+  if (isUnusableActivityTitle(stripped, pathname)) return true;
+  return isSlugLikeActivityTitle(stripped, pathname);
 }
 
 /** Title-case a slug-like label. Leaves already-capped titles alone. */
@@ -635,7 +683,7 @@ function displaySubjectLabel(
     if (isUnusableActivityTitle(cleaned, href)) {
       return isProtocolSegment(inferred) ? undefined : formatSubjectLabel(inferred, href);
     }
-    return formatSubjectLabel(cleaned || inferred, href);
+    return preserveOrFormatSubjectLabel(cleaned || inferred, href);
   }
 
   if (!label) return undefined;

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -23,6 +23,7 @@ import {
   hashDigestSubscriber,
   inferTitleFromPath,
   ingestActivityEvent,
+  isSlugLikeActivityTitle,
   likeActivityPayload,
   likeMetaFromRequest,
   looksLikeIdentifier,
@@ -37,11 +38,13 @@ import {
   resolveIngestVisitTitle,
   rollupActivityEvents,
   sanitizeVisitTitle,
+  shouldLookupCmsPostTitle,
   shouldPulseActivityRollup,
   shouldRecordVisit,
   stripSiteTitleSuffix,
   stripTrailingShortIdToken,
 } from "@/lib/activity";
+import * as activityCms from "@/lib/activity-cms";
 import { geoFromVisitMeta, normalizeRegionCode, visitDisplaySummary } from "@/lib/activity-geo";
 import * as activityHn from "@/lib/activity-hn";
 import { parseActivityStreamFields } from "@/lib/activity-redis";
@@ -60,13 +63,16 @@ function baseEvent(overrides: Record<string, unknown> = {}) {
 }
 
 let lookupHnStoryTitleSpy: ReturnType<typeof spyOn>;
+let lookupCmsPostTitleSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
   lookupHnStoryTitleSpy = spyOn(activityHn, "lookupHnStoryTitle").mockResolvedValue(null);
+  lookupCmsPostTitleSpy = spyOn(activityCms, "lookupCmsPostTitle").mockResolvedValue(null);
 });
 
 afterEach(() => {
   lookupHnStoryTitleSpy.mockRestore();
+  lookupCmsPostTitleSpy.mockRestore();
 });
 
 function visitRowEvent(
@@ -586,6 +592,75 @@ describe("recordVisit", () => {
     await expect(resolveIngestVisitTitle("/hn/42991019", "42991019")).resolves.toBe(
       "Some HN Story",
     );
+  });
+
+  test("looks up a writing title at ingest when the client title is generic or empty", async () => {
+    lookupCmsPostTitleSpy.mockResolvedValue("How I'm Feeling About AI in August 2026");
+    const path = "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS";
+
+    const store = createMemoryActivityStore();
+    await recordVisit({ path, title: "Brian Lovin" }, store);
+    await recordVisit({ path }, store);
+    await recordVisit({ path, title: "Writing | Brian Lovin" }, store);
+
+    const events = await store.getTail(3);
+    expect(events.map((event) => event.subject?.label)).toEqual([
+      "How I'm Feeling About AI in August 2026",
+      "How I'm Feeling About AI in August 2026",
+      "How I'm Feeling About AI in August 2026",
+    ]);
+    expect(lookupCmsPostTitleSpy).toHaveBeenCalledWith(
+      "writing",
+      "how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+    );
+    expect(getActivityRow(events[0]!).label).toBe("How I'm Feeling About AI in August 2026");
+    expect(getActivityRow(events[0]!).label).not.toBe("How Im Feeling About Ai in August 2026");
+  });
+
+  test("looks up a TIL title at ingest when the client title is slug-like", async () => {
+    lookupCmsPostTitleSpy.mockResolvedValue("Cache-Control: max-age vs s-maxage");
+    const path = "/til/cache-headers-B57IXLJ";
+    const store = createMemoryActivityStore();
+    await recordVisit({ path, title: "cache headers" }, store);
+    const [event] = await store.getTail(1);
+    expect(event?.subject?.label).toBe("Cache-Control: max-age vs s-maxage");
+    expect(lookupCmsPostTitleSpy).toHaveBeenCalledWith("til", "cache-headers-B57IXLJ");
+  });
+
+  test("does not look up a writing title when the client already sent the real title", async () => {
+    lookupCmsPostTitleSpy.mockResolvedValue("Ignored lookup title");
+    const store = createMemoryActivityStore();
+    await recordVisit(
+      {
+        path: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+        title: "How I'm Feeling About AI in August 2026 | Brian Lovin",
+      },
+      store,
+    );
+    const [event] = await store.getTail(1);
+    expect(event?.subject?.label).toBe("How I'm Feeling About AI in August 2026");
+    expect(lookupCmsPostTitleSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolveIngestVisitTitle stores the exact CMS title, not a title-cased slug", async () => {
+    lookupCmsPostTitleSpy.mockResolvedValue("How I'm Feeling About AI in August 2026");
+    const path = "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS";
+    await expect(resolveIngestVisitTitle(path, "Brian Lovin")).resolves.toBe(
+      "How I'm Feeling About AI in August 2026",
+    );
+    await expect(resolveIngestVisitTitle(path, "")).resolves.toBe(
+      "How I'm Feeling About AI in August 2026",
+    );
+    await expect(
+      resolveIngestVisitTitle(path, "How Im Feeling About Ai in August 2026"),
+    ).resolves.toBe("How I'm Feeling About AI in August 2026");
+  });
+
+  test("slug fallback may still title-case when the CMS lookup misses", async () => {
+    await expect(
+      resolveIngestVisitTitle("/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS"),
+    ).resolves.toBe("How Im Feeling About Ai in August 2026");
+    expect(lookupCmsPostTitleSpy).toHaveBeenCalled();
   });
 
   test("strips a trailing short id from the visit title at ingest", async () => {
@@ -1295,12 +1370,51 @@ describe("sanitizeVisitTitle / formatActivityTitle", () => {
     expect(formatActivityTitle("secret for ios")).toBe("Secret for iOS");
     expect(formatActivityTitle("grok bot first impressions")).toBe("Grok Bot First Impressions");
     expect(formatActivityTitle("Secret for iOS")).toBe("Secret for iOS");
+    expect(formatActivityTitle("How I'm Feeling About AI in August 2026")).toBe(
+      "How I'm Feeling About AI in August 2026",
+    );
     expect(formatActivityTitle("https:")).toBe("https:");
     expect(formatActivityTitle("https:")).not.toBe("Https:");
+  });
+
+  test("treats a title-cased slug as slug-like and a real CMS title as not", () => {
+    const path = "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS";
+    expect(isSlugLikeActivityTitle("how im feeling about ai in august 2026", path)).toBe(true);
+    expect(isSlugLikeActivityTitle("How Im Feeling About Ai in August 2026", path)).toBe(true);
+    expect(isSlugLikeActivityTitle("How I'm Feeling About AI in August 2026", path)).toBe(false);
+    expect(shouldLookupCmsPostTitle(undefined, path)).toBe(true);
+    expect(shouldLookupCmsPostTitle("Brian Lovin", path)).toBe(true);
+    expect(shouldLookupCmsPostTitle("Writing | Brian Lovin", path)).toBe(true);
+    expect(shouldLookupCmsPostTitle("How I'm Feeling About AI in August 2026", path)).toBe(false);
+    expect(shouldLookupCmsPostTitle("Home", "/")).toBe(false);
   });
 });
 
 describe("getActivityRow page titles", () => {
+  test("keeps an exact stored writing title, including I'm and AI", () => {
+    const row = getActivityRow(
+      visitRowEvent({
+        kind: "writing",
+        label: "How I'm Feeling About AI in August 2026",
+        href: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+      }),
+    );
+    expect(row.label).toBe("How I'm Feeling About AI in August 2026");
+    expect(row.label).not.toBe("How Im Feeling About Ai in August 2026");
+    expect(row.href).toBe("/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS");
+  });
+
+  test("keeps an exact stored writing title on an absolute briOS href", () => {
+    const row = getActivityRow(
+      visitRowEvent({
+        kind: "writing",
+        label: "How I'm Feeling About AI in August 2026",
+        href: "https://brianlovin.com/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+      }),
+    );
+    expect(row.label).toBe("How I'm Feeling About AI in August 2026");
+  });
+
   test("infers a writing visit title from an absolute briOS href", () => {
     const stored = getActivityRow({
       v: 1,

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,5 +1,6 @@
 import { createHash } from "crypto";
 
+import { lookupCmsPostTitle } from "./activity-cms";
 import {
   type ActivityGeo,
   countryCodeToName,
@@ -16,12 +17,14 @@ import {
   ACTIVITY_SOURCE_BRIOS,
   ACTIVITY_STREAM_MAXLEN,
   ACTIVITY_VISIT_STREAM_MAX_PER_SEC,
+  ACTIVITY_VISIT_TITLE_MAX,
   type ActivityEvent,
   type ActivityFeedPayload,
   type ActivityIngestInput,
   type ActivityRef,
   activitySourceLabel,
   type ActivitySpeed,
+  cmsPostRefFromPath,
   findForbiddenPii,
   formatDownloadSummary,
   hnStoryIdFromPath,
@@ -32,7 +35,9 @@ import {
   normalizeCaffeineDrink,
   resolveVisitTitle,
   sanitizeVisitTitle,
+  shouldLookupCmsPostTitle,
   shouldRecordVisit,
+  stripSiteTitleSuffix,
 } from "./activity-shared";
 
 export type { ActivityGeo } from "./activity-geo";
@@ -91,6 +96,7 @@ export {
   activitySourceLabel,
   activitySourceUrl,
   appendKnownSectionSuffix,
+  cmsPostRefFromPath,
   countryCodeToFlag,
   findForbiddenPii,
   formatActivityTitle,
@@ -110,6 +116,7 @@ export {
   isGenericHnStoryTitle,
   isKnownActivitySection,
   isKnownActivityTitle,
+  isSlugLikeActivityTitle,
   isUnusableActivityTitle,
   likeActivityPayload,
   looksLikeDehyphenatedSlug,
@@ -121,6 +128,7 @@ export {
   resolveVisitTitle,
   sanitizeActivityTitle,
   sanitizeVisitTitle,
+  shouldLookupCmsPostTitle,
   shouldRecordVisit,
   stripSiteTitleSuffix,
   stripTrailingShortIdToken,
@@ -207,23 +215,49 @@ function validateRef(name: string, value: unknown): string | null {
   return null;
 }
 
+/** Store a CMS title exactly — no slug title-casing. */
+function exactCmsActivityTitle(title: string): string | null {
+  const stripped = stripSiteTitleSuffix(title.trim());
+  if (!stripped || /^brian lovin$/i.test(stripped)) return null;
+  if (findForbiddenPii(stripped)) return null;
+  if (stripped === "a page") return null;
+  return stripped.slice(0, ACTIVITY_VISIT_TITLE_MAX);
+}
+
 /**
- * Sanitize a visit title, then look up `/hn/{id}` when the client title is
- * missing or generic. Ingest-only — the activity feed render path stays sync.
+ * Sanitize a visit title, then look up HN / writing / TIL when the client
+ * title is missing, generic, or slug-like. Ingest-only — the activity feed
+ * render path stays sync.
  */
 export async function resolveIngestVisitTitle(path: string, title?: string): Promise<string> {
   const resolved = resolveVisitTitle(path, title);
-  const id = hnStoryIdFromPath(path);
-  if (!id || !isGenericHnStoryTitle(resolved, id)) return resolved;
 
-  try {
-    const lookedUp = await lookupHnStoryTitle(id);
-    if (!lookedUp) return resolved;
-    const fromHn = resolveVisitTitle(path, lookedUp);
-    return isGenericHnStoryTitle(fromHn, id) ? resolved : fromHn;
-  } catch {
+  const hnId = hnStoryIdFromPath(path);
+  if (hnId && isGenericHnStoryTitle(resolved, hnId)) {
+    try {
+      const lookedUp = await lookupHnStoryTitle(hnId);
+      if (lookedUp) {
+        const fromHn = resolveVisitTitle(path, lookedUp);
+        if (!isGenericHnStoryTitle(fromHn, hnId)) return fromHn;
+      }
+    } catch {
+      return resolved;
+    }
     return resolved;
   }
+
+  const cms = cmsPostRefFromPath(path);
+  if (cms && shouldLookupCmsPostTitle(title, path)) {
+    try {
+      const lookedUp = await lookupCmsPostTitle(cms.kind, cms.slug);
+      const exact = lookedUp ? exactCmsActivityTitle(lookedUp) : null;
+      if (exact) return exact;
+    } catch {
+      return resolved;
+    }
+  }
+
+  return resolved;
 }
 
 async function applyIngestDefaults(input: ActivityIngestInput): Promise<ActivityIngestInput> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visit rows were showing a title-cased URL slug instead of the real post title. A visit to `/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS` rendered **How Im Feeling About Ai in August 2026** because `ActivityVisit` POSTs `document.title` immediately (often still “Brian Lovin”), then `sanitizeActivityTitle` falls back to `inferTitleFromPath` → `formatActivityTitle`. That invents casing from the slug (`ai` → `Ai`) and drops the apostrophe in I’m.

Adding `ai: "AI"` to `TITLE_ACRONYMS` would still be a fake title.

## Fix
- **Render:** If `subject.label` is a real title (not “a page”, not the raw slug, not an id), display it exactly. Do not title-case it. Do not turn `AI` into `Ai`.
- **Ingest:** For `/writing/{slug}` and `/til/{slug}`, if the incoming `document.title` is missing, generic (“Brian Lovin” / “Writing”), or slug-like, look up the real title with the same Notion helpers the post pages use (`getWritingPostByShortId` / `getWritingPostContentBySlug` / `getTilByShortId`). Store that exact title on the event. Same idea as HN story lookup in #2301 — ingest-time only, no per-row network on `/activity`.
- Slug title-casing remains last-resort fallback when the CMS lookup misses.
- Existing Redis events that only stored the slug still show the title-cased slug. Recovering those would need a network fetch per row; this change does not do that.

## Tests
- Stored label `How I'm Feeling About AI in August 2026` + that writing href → label is exactly that string (I’m + AI).
- Ingest with a generic/empty/slug-like client title stores the mocked CMS title, not the title-cased slug.
- A real client title is stored as-is and does not trigger a CMS lookup.
- Slug-only fallback may still title-case when lookup misses.

Verified: `bun test` on activity + feed tests (233 pass), `bun run lint`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f0ea920-9707-4159-ba78-a759e1aa0534?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f0ea920-9707-4159-ba78-a759e1aa0534&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

