### PR TITLE
Keep “on” before the linked Shiori source in activity rows

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -771,7 +771,7 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("shiori-icon.png");
-    expect(markup).toContain("Someone saved a link");
+    expect(markup).toContain("saved a link on");
     expect(markup).not.toContain("Someone saved a link on Shiori");
     expect(markup).toContain(">Shiori<");
     expect(markup).toContain('href="https://www.shiori.sh"');
@@ -784,17 +784,17 @@ describe("ActivityRow", () => {
       {
         type: "link_clicked" as const,
         summary: "Someone clicked a link on Shiori",
-        stripped: "Someone clicked a link",
+        stripped: "Someone clicked a link on",
       },
       {
         type: "signed_up" as const,
         summary: "Someone signed up for Shiori",
-        stripped: "Someone signed up",
+        stripped: "Someone signed up for",
       },
       {
         type: "subscription_started" as const,
         summary: "Someone subscribed on Shiori",
-        stripped: "Someone subscribed",
+        stripped: "Someone subscribed on",
       },
       {
         type: "download" as const,
@@ -929,7 +929,7 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("shiori-icon.png");
-    expect(markup).toContain("Someone clicked a link");
+    expect(markup).toContain("clicked a link on");
     expect(markup).not.toContain("Someone clicked a link on Shiori");
     expect(markup).toContain(">Shiori<");
     expect(markup).toContain('href="https://www.shiori.sh"');

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -112,17 +112,12 @@ function hasSpecificSubjectHref(source: string, href: string | undefined): boole
   return Boolean(href?.trim()) && !isSourceHomeHref(source, href);
 }
 
+/** Lift a trailing source name so the feed can link it. Keep on/for so "on {source}" still reads as a sentence. */
 function stripSourceNameFromSummary(summary: string, sourceLabel: string): string {
   const escaped = sourceLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const trimmed = summary.trim();
-  const withoutSuffix = trimmed
-    .replace(new RegExp(`\\s+(?:on|for)\\s+${escaped}$`, "i"), "")
-    .trim();
-  if (withoutSuffix !== trimmed) return withoutSuffix;
-
-  const downloaded = trimmed.match(new RegExp(`^(Someone downloaded)\\s+${escaped}$`, "i"));
-  if (downloaded?.[1]) return downloaded[1];
-  return summary;
+  const withoutName = trimmed.replace(new RegExp(`\\s+${escaped}$`, "i"), "").trim();
+  return withoutName || summary;
 }
 
 function attachSourceMetadata(

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -947,7 +947,7 @@ describe("HMAC download ingest", () => {
     expect(event?.actor).toBeUndefined();
     expect(JSON.stringify(event)).not.toMatch(/https?:\/\//);
     expect(getActivityRow(event!)).toEqual({
-      summary: "Someone clicked a link",
+      summary: "Someone clicked a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -969,7 +969,7 @@ describe("HMAC download ingest", () => {
     expect(result.ok && !result.duplicate).toBe(true);
     const row = getActivityRow((await store.getTail(1))[0]!);
     expect(row).toEqual({
-      summary: "Someone clicked a link",
+      summary: "Someone clicked a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -1761,7 +1761,7 @@ describe("getActivityRow source metadata", () => {
 
   test("lifts Shiori out of save/click/signup/subscribe/download summaries", () => {
     expect(getActivityRow(rowEvent({ type: "link_saved" }))).toEqual({
-      summary: "Someone saved a link",
+      summary: "Someone saved a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -1774,7 +1774,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Someone clicked a link",
+      summary: "Someone clicked a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -1786,7 +1786,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Someone signed up",
+      summary: "Someone signed up for",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -1798,7 +1798,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Someone subscribed",
+      summary: "Someone subscribed on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Shiori save rows were rendering as **Someone saved a link Shiori** because `stripSourceNameFromSummary` dropped the preposition along with the source name.

## Change
Only lift the trailing source name out of the summary. Keep `on` / `for` so the existing source-link render path reads as a sentence:

- Someone saved a link **on** [Shiori](https://www.shiori.sh)
- Same for click / signup / subscribe (`on` or `for` as already stored)
- Downloads stay **Someone downloaded** [Shiori] (no preposition in that pattern)

Shiori remains the outbound new-tab source link. Tax UI, staff.design, and Design Details visit/download copy is unchanged.

## Tests
Copy-only assertions that the rendered save row contains `saved a link on` and a linked `Shiori`. No layout or class-name checks.

## Out of scope
Like-rollup and badge alignment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10058241-647d-4fb6-be1d-315f352c34ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10058241-647d-4fb6-be1d-315f352c34ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

