### PR TITLE
Fix activity Home likes and stack mixed like runs

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -699,7 +699,7 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain(">Stack<");
   });
 
-  test("renders a stored Home like as Someone liked plus a Home link", () => {
+  test("hides a stored Home like instead of showing Home", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow
         event={event({
@@ -711,12 +711,68 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone liked");
-    expect(markup).toContain(">Home<");
-    expect(markup).toContain('href="/"');
-    expect(markup).not.toContain("Someone liked a page");
-    expect(markup).not.toContain("Someone liked Home");
+    expect(markup).toBe("");
+    expect(markup).not.toContain("Home");
+    expect(markup).not.toContain("Someone liked");
     expect(markup).not.toContain("a page");
+  });
+
+  test("renders one 1Password like without Home", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "like",
+          speed: "event",
+          summary: "Someone liked 1Password",
+          subject: { kind: "stack", label: "1Password", href: "https://1password.com" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Someone liked");
+    expect(markup).toContain(">1Password<");
+    expect(markup).toContain('href="https://1password.com"');
+    expect(markup).not.toContain("Home");
+    expect(markup).not.toContain("Someone liked 1Password");
+  });
+
+  test("renders mixed consecutive likes as a title plus others", () => {
+    const stacks = rollupActivityEvents([
+      event({
+        id: "like-1password",
+        type: "like",
+        speed: "event",
+        summary: "Someone liked 1Password",
+        subject: { kind: "stack", label: "1Password", href: "https://1password.com" },
+      }),
+      event({
+        id: "like-cursor",
+        type: "like",
+        speed: "event",
+        summary: "Someone liked Cursor",
+        subject: { kind: "stack", label: "Cursor", href: "https://cursor.com" },
+      }),
+    ]);
+
+    expect(stacks).toHaveLength(1);
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={stacks[0]!.latest}
+        count={stacks[0]!.count}
+        href={stacks[0]!.href}
+        likeTargets={stacks[0]!.likeTargets}
+      />,
+    );
+
+    expect(markup).toContain("Someone liked");
+    expect(markup).toContain(">1Password<");
+    expect(markup).toContain("+ 1 other");
+    expect(markup).toContain("Cursor");
+    expect(stacks[0]?.likeTargets).toEqual([
+      { title: "1Password", href: "https://1password.com" },
+      { title: "Cursor", href: "https://cursor.com" },
+    ]);
+    expect(markup).not.toContain("Home");
   });
 
   test("keeps a like title as plain text when there is no href", () => {
@@ -1025,8 +1081,8 @@ describe("ActivityFeed", () => {
             id: "like-1",
             type: "like",
             speed: "event",
-            summary: "Someone liked Home",
-            subject: { kind: "home", label: "Home", href: "/" },
+            summary: "Someone liked 1Password",
+            subject: { kind: "stack", label: "1Password", href: "https://1password.com" },
           }),
         ]}
         initialCount={3}

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -21,7 +21,7 @@ import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { RollingDigits } from "@/components/RollingDigits";
 import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
-import type { ActivityEvent, ActivityRollup } from "@/lib/activity";
+import type { ActivityEvent, ActivityLikeTarget, ActivityRollup } from "@/lib/activity";
 import {
   activityStackReactKey,
   nextActivityEnterState,
@@ -32,9 +32,11 @@ import {
   ACTIVITY_TRACKED_SINCE_TOOLTIP,
   activitySourceFaviconSrc,
   activitySourceUrl,
+  formatLikeOthersLabel,
   formatTrackedEventsLabel,
   getActivityRow,
   getMergedPullRequestDiff,
+  isHomeLikeTitle,
   resolveActivitySourceHref,
 } from "@/lib/activity-shared";
 import { useActivity } from "@/lib/hooks/useActivity";
@@ -159,37 +161,92 @@ function ActivityContextLink({ href, children }: { href: string; children: React
   );
 }
 
+function LikeOthersTooltip({
+  targets,
+  otherCount,
+}: {
+  targets: ActivityLikeTarget[];
+  otherCount: number;
+}) {
+  return (
+    <Tooltip delay={0} closeDelay={0}>
+      <TooltipTrigger
+        delay={0}
+        closeDelay={0}
+        className="text-tertiary cursor-default bg-transparent p-0"
+      >
+        {formatLikeOthersLabel(otherCount)}
+        <span className="sr-only">{targets.map((target) => target.title).join(", ")}</span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        collisionPadding={8}
+        container={typeof document === "undefined" ? undefined : document.body}
+        className="overflow-visible"
+      >
+        <ul className="flex flex-col gap-1">
+          {targets.map((target) => (
+            <li key={`${target.title}:${target.href ?? ""}`}>
+              {target.href ? (
+                <ActivityContextLink href={target.href}>{target.title}</ActivityContextLink>
+              ) : (
+                <span>{target.title}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function likeTargetsFromRow(
+  event: ActivityEvent,
+  row: ReturnType<typeof getActivityRow>,
+  likeTargets?: ActivityLikeTarget[],
+): ActivityLikeTarget[] {
+  if (likeTargets && likeTargets.length > 0) return likeTargets;
+  const title = row.label?.trim();
+  if (event.type !== "like" || !title || isHomeLikeTitle(title)) return [];
+  return [{ title, ...(row.href ? { href: row.href } : {}) }];
+}
+
 export function ActivityRow({
   event,
   count = 1,
   sectionLabel,
   href: hrefOverride,
   pulse = false,
+  likeTargets: likeTargetsProp,
 }: {
   event: ActivityEvent;
   count?: number;
   sectionLabel?: string;
   href?: string;
   pulse?: boolean;
+  likeTargets?: ActivityLikeTarget[];
 }) {
   const row = getActivityRow(event);
   const homeUrl = activitySourceUrl(event.source);
   const isLike = event.type === "like";
-  const likeTitle = isLike ? row.label || "Home" : "";
+  const likeTargets = likeTargetsFromRow(event, row, likeTargetsProp);
+  const featured = likeTargets[0];
+  const othersCount = Math.max(0, likeTargets.length - 1);
+  const likeTitle = featured?.title ?? "";
   const label = isLike ? likeTitle : (sectionLabel ?? row.label);
-  const rawHref = hrefOverride ?? row.href;
+  const rawHref = hrefOverride ?? featured?.href ?? row.href;
   const href =
     resolveActivitySourceHref(event.source, rawHref) ??
     rawHref ??
-    (isLike
-      ? likeTitle === "Home"
-        ? (homeUrl ?? "/")
-        : undefined
-      : label || event.type === "download"
-        ? homeUrl
-        : undefined);
+    (isLike ? undefined : label || event.type === "download" ? homeUrl : undefined);
   const context = isLike ? likeTitle : (label ?? (href || undefined));
   const diff = event.type === "pr_merged" ? getMergedPullRequestDiff(event.meta) : null;
+  const showCountChip = count > 1 && !(isLike && othersCount > 0);
+
+  if (isLike && likeTargets.length === 0) {
+    return null;
+  }
 
   return (
     <div
@@ -217,8 +274,14 @@ export function ActivityRow({
           ) : context ? (
             <span className="text-tertiary"> {context}</span>
           ) : null}
+          {isLike && othersCount > 0 ? (
+            <>
+              {" "}
+              <LikeOthersTooltip targets={likeTargets} otherCount={othersCount} />
+            </>
+          ) : null}
         </span>
-        {count > 1 ? (
+        {showCountChip ? (
           <span
             data-count={count}
             className="text-tertiary border-secondary shrink-0 rounded-sm border px-1 font-mono text-[11px] leading-4 tabular-nums"
@@ -428,6 +491,7 @@ function ActivityStackList({
                 count={stack.count}
                 sectionLabel={stack.sectionLabel}
                 href={stack.href}
+                likeTargets={stack.likeTargets}
                 pulse={pulseKey === reactKey}
               />
             </motion.div>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -284,7 +284,7 @@ export function ActivityRow({
         {showCountChip ? (
           <span
             data-count={count}
-            className="text-tertiary border-secondary shrink-0 rounded-sm border px-1 font-mono text-[11px] leading-4 tabular-nums"
+            className="text-tertiary border-secondary shrink-0 -translate-y-[2px] rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
           >
             <RollingDigits value={count} />
           </span>

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -10,8 +10,15 @@ import {
   activitySectionPhrase,
   getActivityRow,
   isAbsoluteHttpUrl,
+  isHiddenLikeEvent,
+  isHomeLikeTitle,
   isKnownActivitySection,
 } from "./activity-shared";
+
+export type ActivityLikeTarget = {
+  title: string;
+  href?: string;
+};
 
 export type ActivityRollup = {
   key: string;
@@ -21,6 +28,7 @@ export type ActivityRollup = {
   anchorId: string;
   sectionLabel: string;
   href?: string;
+  likeTargets?: ActivityLikeTarget[];
 };
 
 export function activityStackReactKey(stack: Pick<ActivityRollup, "key" | "anchorId">): string {
@@ -115,7 +123,7 @@ export function activityRollupKey(event: ActivityEvent): string {
   }
 
   if (event.type === "like") {
-    return `like:${activityEventHref(event) ?? ""}`;
+    return "like";
   }
 
   if (event.type === "visit" || event.type === "visit_country_first") {
@@ -138,6 +146,10 @@ function stackSectionLabel(events: ActivityEvent[], section: string): string {
   const latestLabel = getActivityRow(events[0]!).label;
   const isVisit = events[0]?.type === "visit" || events[0]?.type === "visit_country_first";
 
+  if (events[0]?.type === "like") {
+    return latestLabel ?? "";
+  }
+
   if (isVisit) {
     if (unique.size !== 1) return activitySectionPhrase(section);
     return labels[0] ?? activitySectionPhrase(section);
@@ -148,7 +160,25 @@ function stackSectionLabel(events: ActivityEvent[], section: string): string {
   return latestLabel ?? "";
 }
 
+function uniqueLikeTargets(events: ActivityEvent[]): ActivityLikeTarget[] {
+  const seen = new Set<string>();
+  const targets: ActivityLikeTarget[] = [];
+  for (const event of events) {
+    const row = getActivityRow(event);
+    const title = row.label?.trim();
+    if (!title || isHomeLikeTitle(title)) continue;
+    const key = title.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    targets.push({ title, ...(row.href ? { href: row.href } : {}) });
+  }
+  return targets;
+}
+
 function stackHref(events: ActivityEvent[]): string | undefined {
+  if (events[0]?.type === "like") {
+    return activityEventHref(events[0]);
+  }
   const hrefs = [
     ...new Set(events.map(activityEventHref).filter((href): href is string => Boolean(href))),
   ];
@@ -177,6 +207,7 @@ export function rollupActivityEvents(events: ActivityEvent[]): ActivityRollup[] 
   }> = [];
 
   for (const event of events) {
+    if (isHiddenLikeEvent(event)) continue;
     const key = activityRollupKey(event);
     const current = runs[runs.length - 1];
     if (current && current.key === key) {
@@ -187,17 +218,24 @@ export function rollupActivityEvents(events: ActivityEvent[]): ActivityRollup[] 
     runs.push({ key, count: 1, latest: event, events: [event] });
   }
 
-  return runs.map((run) => {
+  return runs.flatMap((run) => {
     const section = activitySectionFromPath(activityEventHref(run.latest));
     const href = stackHref(run.events);
-    return {
-      key: run.key,
-      count: run.count,
-      latest: run.latest,
-      anchorId: run.events[run.events.length - 1]!.id,
-      sectionLabel: stackSectionLabel(run.events, section),
-      ...(href ? { href } : {}),
-    };
+    const likeTargets = run.latest.type === "like" ? uniqueLikeTargets(run.events) : undefined;
+    if (run.latest.type === "like" && (!likeTargets || likeTargets.length === 0)) {
+      return [];
+    }
+    return [
+      {
+        key: run.key,
+        count: run.count,
+        latest: run.latest,
+        anchorId: run.events[run.events.length - 1]!.id,
+        sectionLabel: stackSectionLabel(run.events, section),
+        ...(href ? { href } : {}),
+        ...(likeTargets && likeTargets.length > 0 ? { likeTargets } : {}),
+      },
+    ];
   });
 }
 

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -274,6 +274,35 @@ export function shouldRecordVisit(pathname: string): boolean {
   return !isActivityPath(path);
 }
 
+const HOME_LIKE_TITLES = new Set(["home", "a page"]);
+
+/** Titles that must never appear as a liked thing. Empty is not Home. */
+export function isHomeLikeTitle(title: string | undefined): boolean {
+  const trimmed = title?.trim().toLowerCase();
+  if (!trimmed) return false;
+  return HOME_LIKE_TITLES.has(trimmed);
+}
+
+/**
+ * Site-relative home (`/`, empty). External product URLs stay likeable even
+ * when their pathname is `/` (e.g. `https://1password.com`).
+ */
+export function isSiteHomeLikeHref(href: string | undefined): boolean {
+  const trimmed = href?.trim();
+  if (!trimmed) return true;
+  if (isAbsoluteHttpUrl(trimmed)) return false;
+  const path = normalizeActivityPath(trimmed.split("?")[0] ?? trimmed);
+  return path === "/";
+}
+
+/** Ingest gate for likes — skip home, empty href, and activity paths. */
+export function shouldRecordLike(href: string | undefined, title?: string): boolean {
+  if (isSiteHomeLikeHref(href)) return false;
+  if (isActivityPath(href!)) return false;
+  if (title !== undefined && isHomeLikeTitle(title)) return false;
+  return true;
+}
+
 export function inferContentTypeFromPath(pathname: string): string {
   if (pathname.startsWith("/writing")) return "writing";
   if (pathname.startsWith("/til")) return "til";
@@ -433,6 +462,8 @@ function normalizeActivityPath(pathname: string): string {
 export function looksLikeShortId(token: string): boolean {
   if (token.length < 5 || token.length > 12) return false;
   if (!/^[A-Za-z0-9]+$/.test(token)) return false;
+  // Product names like 1Password start with a digit; Notion short ids do not.
+  if (/^\d/.test(token)) return false;
 
   const hasDigit = /\d/.test(token);
   const hasUpper = /[A-Z]/.test(token);
@@ -511,13 +542,17 @@ export function activitySectionPhrase(section: string): string {
 }
 
 export function inferTitleFromPath(pathname: string): string {
+  const absolute = isAbsoluteHttpUrl(pathname);
   const path = normalizeActivityPath(pathnameFromHref(pathname));
-  const known = KNOWN_PATH_TITLES[path];
-  if (known) return known;
+  // External product homes (`https://1password.com`) are not this site's Home.
+  if (!absolute || path !== "/") {
+    const known = KNOWN_PATH_TITLES[path];
+    if (known) return known;
+  }
 
   const segments = path.split("/").filter(Boolean);
   const last = segments[segments.length - 1];
-  if (!last) return "Home";
+  if (!last) return absolute ? "" : "Home";
 
   let decodedLast = last;
   try {
@@ -649,11 +684,17 @@ export type LikeActivityPayload = {
 export function likeActivityPayload(
   target: LikeActivityTarget = {},
   fallback: { title?: string; href?: string } = {},
-): LikeActivityPayload {
-  const href = target.href?.trim() || fallback.href?.trim() || "/";
+): LikeActivityPayload | null {
+  const href = target.href?.trim() || fallback.href?.trim() || "";
+  if (!shouldRecordLike(href)) return null;
   const title = sanitizeActivityTitle(target.title || fallback.title, href);
+  if (!title.trim() || isHomeLikeTitle(title)) return null;
   const content_type = target.contentType?.trim() || inferContentTypeFromPath(href);
   return { title, href, content_type };
+}
+
+export function formatLikeOthersLabel(otherCount: number): string {
+  return otherCount === 1 ? "+ 1 other" : `+ ${otherCount} others`;
 }
 
 export function isKnownActivityTitle(label: string): boolean {
@@ -697,9 +738,22 @@ function likedTitleFromSummary(summary: string): string | undefined {
   const trimmed = summary.trim();
   if (/^someone liked$/i.test(trimmed)) return undefined;
   const rest = trimmed.replace(/^Someone liked\s+/i, "").trim();
-  if (!rest) return undefined;
-  if (rest === "a page") return "Home";
+  if (!rest || isHomeLikeTitle(rest)) return undefined;
   return rest;
+}
+
+/** Old Redis home likes (`/` + "a page" / Home) — hide instead of showing Home. */
+export function isHiddenLikeEvent(event: ActivityEvent): boolean {
+  if (event.type !== "like") return false;
+  if (isHomeLikeTitle(event.subject?.label)) return true;
+  const rest = event.summary.replace(/^Someone liked\s+/i, "").trim();
+  if (!event.subject?.label && isHomeLikeTitle(rest)) return true;
+  const href = event.subject?.href?.trim();
+  if (href && !isAbsoluteHttpUrl(href)) {
+    const path = normalizeActivityPath(href.split("?")[0] ?? href);
+    if (path === "/") return true;
+  }
+  return false;
 }
 
 const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
@@ -905,14 +959,20 @@ export function getActivityRow(event: ActivityEvent): {
   }
 
   if (event.type === "like") {
+    if (isHiddenLikeEvent(event)) {
+      return attachSourceMetadata(event, { summary: "Someone liked" });
+    }
     const label = displaySubjectLabel(event.subject?.label, event.subject?.href, {
       preferStored: true,
     });
     const fromSummary = likedTitleFromSummary(event.summary);
-    const name = label || fromSummary || "Home";
+    const name = label || fromSummary;
+    if (!name || isHomeLikeTitle(name)) {
+      return attachSourceMetadata(event, { summary: "Someone liked" });
+    }
     return attachSourceMetadata(event, {
       summary: "Someone liked",
-      href: event.subject?.href || (name === "Home" ? "/" : undefined),
+      href: event.subject?.href,
       label: name,
     });
   }

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -15,6 +15,7 @@ import {
   findForbiddenPii,
   formatActivityTitle,
   formatDownloadSummary,
+  formatLikeOthersLabel,
   formatVisitSummary,
   getActivityRow,
   getCaffeineIcon,
@@ -23,6 +24,7 @@ import {
   hashDigestSubscriber,
   inferTitleFromPath,
   ingestActivityEvent,
+  isHiddenLikeEvent,
   isSlugLikeActivityTitle,
   likeActivityPayload,
   likeMetaFromRequest,
@@ -40,6 +42,7 @@ import {
   sanitizeVisitTitle,
   shouldLookupCmsPostTitle,
   shouldPulseActivityRollup,
+  shouldRecordLike,
   shouldRecordVisit,
   stripSiteTitleSuffix,
   stripTrailingShortIdToken,
@@ -1027,6 +1030,50 @@ describe("recordLike", () => {
     expect(await store.getCount()).toBe(0);
   });
 
+  test("does not ingest a like for / or a Home title", async () => {
+    const store = createMemoryActivityStore();
+    expect(await recordLike({ title: "Home", href: "/", content_type: "home" }, store)).toEqual({
+      skipped: true,
+      reason: "home",
+    });
+    expect(await recordLike({ title: "a page", href: "/", content_type: "home" }, store)).toEqual({
+      skipped: true,
+      reason: "home",
+    });
+    expect(
+      await recordLike({ title: "1Password", href: "", content_type: "stack" }, store),
+    ).toEqual({ skipped: true, reason: "home" });
+    expect(await store.getCount()).toBe(0);
+    expect(await store.getTail(10)).toEqual([]);
+  });
+
+  test("keeps a 1Password like title instead of rewriting it to Home", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordLike(
+      {
+        title: "1Password",
+        href: "https://1password.com",
+        content_type: "stack",
+        pageId: "stack-1password",
+      },
+      store,
+    );
+    expect("ok" in result && result.ok).toBe(true);
+    const [event] = await store.getTail(1);
+    expect(event?.summary).toBe("Someone liked 1Password");
+    expect(event?.subject).toEqual({
+      kind: "stack",
+      label: "1Password",
+      href: "https://1password.com",
+    });
+    expect(getActivityRow(event!)).toEqual({
+      summary: "Someone liked",
+      href: "https://1password.com",
+      label: "1Password",
+    });
+    expect(getActivityRow(event!).label).not.toBe("Home");
+  });
+
   test("writes a public like with subject + meta and no actor", async () => {
     const store = createMemoryActivityStore();
     const result = await recordLike(
@@ -1239,6 +1286,8 @@ describe("inferTitleFromPath", () => {
     );
     expect(looksLikeShortId("writing")).toBe(false);
     expect(looksLikeShortId("stack")).toBe(false);
+    expect(looksLikeShortId("1Password")).toBe(false);
+    expect(looksLikeIdentifier("1Password")).toBe(false);
     expect(looksLikeShortId("kcJun01")).toBe(true);
     expect(looksLikeShortId("B57IXLJ")).toBe(true);
     expect(stripTrailingShortIdToken("grok bot first impressions kcJun01")).toBe(
@@ -1284,6 +1333,8 @@ describe("inferTitleFromPath", () => {
     expect(title).not.toMatch(/^https?:/i);
     expect(inferTitleFromPath("https://brianlovin.com/writing/foo")).toBe("foo");
     expect(inferTitleFromPath("https://brianlovin.com/writing")).toBe("Writing");
+    expect(inferTitleFromPath("https://1password.com")).not.toBe("Home");
+    expect(inferTitleFromPath("https://1password.com")).toBe("");
   });
 });
 
@@ -1673,25 +1724,25 @@ describe("getActivityRow page titles", () => {
     expect(row.href).toBe("/ama/2f2c711c-0ceb-810d-899d-e5feb99e70f4");
   });
 
-  test("splits a stored Home like into Someone liked plus a Home label", () => {
-    const row = getActivityRow({
+  test("does not display a stored Home like as a liked thing", () => {
+    const event = {
       v: 1,
       id: "like-home",
       ts: "2026-08-16T00:00:00.000Z",
       received_at: "2026-08-16T00:00:00.000Z",
       source: "brios",
       type: "like",
-      speed: "event",
+      speed: "event" as const,
       summary: "Someone liked a page",
-      visibility: "public",
+      visibility: "public" as const,
       idempotency_key: "like-home",
       subject: { kind: "home", label: "a page", href: "/" },
-    });
-    expect(row).toEqual({
-      summary: "Someone liked",
-      href: "/",
-      label: "Home",
-    });
+    };
+    expect(isHiddenLikeEvent(event)).toBe(true);
+    const row = getActivityRow(event);
+    expect(row.label).not.toBe("Home");
+    expect(row.href).toBeUndefined();
+    expect(rollupActivityEvents([event])).toEqual([]);
   });
 
   test("keeps a liked stack item name instead of rewriting it to Stack", () => {
@@ -2097,6 +2148,29 @@ describe("shouldRecordVisit / likeMetaFromRequest", () => {
     expect(activity).toBeNull();
   });
 
+  test("does not default a missing like href to /", () => {
+    expect(shouldRecordLike("/")).toBe(false);
+    expect(shouldRecordLike("")).toBe(false);
+    expect(shouldRecordLike(undefined)).toBe(false);
+    expect(shouldRecordLike("/stack/1password", "1Password")).toBe(true);
+    expect(shouldRecordLike("https://1password.com", "1Password")).toBe(true);
+    expect(shouldRecordLike("https://1password.com", "Home")).toBe(false);
+
+    expect(likeMetaFromRequest(new Request("https://brianlovin.com/api/likes/1"))).toBeNull();
+    expect(
+      likeMetaFromRequest(new Request("https://brianlovin.com/api/likes/1"), { href: "/" }),
+    ).toBeNull();
+    expect(
+      likeMetaFromRequest(
+        new Request("https://brianlovin.com/api/likes/1", {
+          headers: { referer: "https://brianlovin.com/" },
+        }),
+      ),
+    ).toBeNull();
+    expect(likeActivityPayload({ title: "Home", href: "/", contentType: "home" })).toBeNull();
+    expect(likeActivityPayload({}, { title: "Brian Lovin", href: "/" })).toBeNull();
+  });
+
   test("uses a passed item title instead of falling back to Stack", () => {
     const request = new Request("https://brianlovin.com/api/likes/1", {
       headers: { referer: "https://brianlovin.com/stack" },
@@ -2183,6 +2257,20 @@ describe("likeActivityPayload", () => {
       href: "/writing/hello-world",
       content_type: "writing",
     });
+  });
+
+  test("keeps a 1Password title and does not default href to /", () => {
+    expect(
+      likeActivityPayload(
+        { title: "1Password", href: "https://1password.com", contentType: "stack" },
+        { title: "Home", href: "/" },
+      ),
+    ).toEqual({
+      title: "1Password",
+      href: "https://1password.com",
+      content_type: "stack",
+    });
+    expect(likeActivityPayload({}, { title: "Home | Brian Lovin", href: "/" })).toBeNull();
   });
 });
 
@@ -2416,7 +2504,7 @@ describe("rollupActivityEvents", () => {
     expect(stacks[0]?.key).toBe("shiori:link_saved");
     expect(stacks[0]?.latest.id).toBe("s1");
     expect(stacks[1]?.count).toBe(1);
-    expect(stacks[1]?.key).toBe("like:/stack");
+    expect(stacks[1]?.key).toBe("like");
   });
 
   test("stacks consecutive Shiori link_clicked events separately from saves", () => {
@@ -2442,7 +2530,7 @@ describe("rollupActivityEvents", () => {
     expect(stacks[1]?.key).toBe("shiori:link_saved");
   });
 
-  test("does not stack likes for different apps", () => {
+  test("stacks consecutive likes of different pages as one run", () => {
     const stacks = rollupActivityEvents([
       feedEvent({
         id: "like-cursor",
@@ -2458,13 +2546,45 @@ describe("rollupActivityEvents", () => {
       }),
     ]);
 
-    expect(stacks).toHaveLength(2);
-    expect(stacks[0]?.key).toBe("like:https://cursor.com");
-    expect(stacks[1]?.key).toBe("like:https://www.raycast.com");
+    expect(stacks).toHaveLength(1);
+    expect(stacks[0]?.key).toBe("like");
+    expect(stacks[0]?.count).toBe(2);
+    expect(stacks[0]?.likeTargets).toEqual([
+      { title: "Cursor", href: "https://cursor.com" },
+      { title: "Raycast", href: "https://www.raycast.com" },
+    ]);
+    expect(formatLikeOthersLabel((stacks[0]?.likeTargets?.length ?? 1) - 1)).toBe("+ 1 other");
     expect(getActivityRow(stacks[0]!.latest).summary).toBe("Someone liked");
     expect(getActivityRow(stacks[0]!.latest).label).toBe("Cursor");
-    expect(getActivityRow(stacks[1]!.latest).summary).toBe("Someone liked");
-    expect(getActivityRow(stacks[1]!.latest).label).toBe("Raycast");
+    expect(stacks[0]?.likeTargets?.map((target) => target.title)).toEqual(["Cursor", "Raycast"]);
+  });
+
+  test("drops a stored Home like from a mixed like run", () => {
+    const stacks = rollupActivityEvents([
+      feedEvent({
+        id: "like-1password",
+        type: "like",
+        summary: "Someone liked 1Password",
+        subject: { kind: "stack", label: "1Password", href: "https://1password.com" },
+      }),
+      feedEvent({
+        id: "like-home",
+        type: "like",
+        summary: "Someone liked a page",
+        subject: { kind: "home", label: "a page", href: "/" },
+      }),
+      feedEvent({
+        id: "like-cursor",
+        type: "like",
+        summary: "Someone liked Cursor",
+        subject: { kind: "stack", label: "Cursor", href: "https://cursor.com" },
+      }),
+    ]);
+
+    expect(stacks).toHaveLength(1);
+    expect(stacks[0]?.count).toBe(2);
+    expect(stacks[0]?.likeTargets?.map((target) => target.title)).toEqual(["1Password", "Cursor"]);
+    expect(stacks[0]?.likeTargets?.some((target) => target.title === "Home")).toBe(false);
   });
 
   test("does not merge the same type across a different intervening event", () => {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -31,11 +31,13 @@ import {
   inferContentTypeFromPath,
   isActivityPath,
   isGenericHnStoryTitle,
+  isHomeLikeTitle,
   likeActivityPayload,
   normalizeCaffeineDrink,
   resolveVisitTitle,
   sanitizeVisitTitle,
   shouldLookupCmsPostTitle,
+  shouldRecordLike,
   shouldRecordVisit,
   stripSiteTitleSuffix,
 } from "./activity-shared";
@@ -55,7 +57,7 @@ export {
   verifyGithubWebhookSignature,
 } from "./activity-github";
 export { isRegisteredActivityEvent } from "./activity-registry";
-export type { ActivityRollup } from "./activity-rollup";
+export type { ActivityLikeTarget, ActivityRollup } from "./activity-rollup";
 export {
   ACTIVITY_ENTER_STAGGER_MAX,
   ACTIVITY_ENTER_STAGGER_STEP,
@@ -101,6 +103,7 @@ export {
   findForbiddenPii,
   formatActivityTitle,
   formatDownloadSummary,
+  formatLikeOthersLabel,
   formatTrackedEventsLabel,
   getActivityRow,
   getCaffeineIcon,
@@ -114,8 +117,11 @@ export {
   isActivityPath,
   isCoffeeFamilyDrink,
   isGenericHnStoryTitle,
+  isHiddenLikeEvent,
+  isHomeLikeTitle,
   isKnownActivitySection,
   isKnownActivityTitle,
+  isSiteHomeLikeHref,
   isSlugLikeActivityTitle,
   isUnusableActivityTitle,
   likeActivityPayload,
@@ -129,6 +135,7 @@ export {
   sanitizeActivityTitle,
   sanitizeVisitTitle,
   shouldLookupCmsPostTitle,
+  shouldRecordLike,
   shouldRecordVisit,
   stripSiteTitleSuffix,
   stripTrailingShortIdToken,
@@ -411,9 +418,15 @@ export async function recordLike(
   if (isActivityPath(input.href)) {
     return { skipped: true, reason: "activity_path" };
   }
+  if (!shouldRecordLike(input.href, input.title)) {
+    return { skipped: true, reason: "home" };
+  }
 
   const href = input.href;
-  const title = sanitizeVisitTitle(input.title, href) || "a page";
+  const title = sanitizeVisitTitle(input.title, href);
+  if (!title.trim() || isHomeLikeTitle(title)) {
+    return { skipped: true, reason: "home" };
+  }
   const contentType = input.content_type || inferContentTypeFromPath(href);
 
   return ingestActivityEvent(
@@ -739,7 +752,7 @@ export function likeMetaFromRequest(
     }
   }
 
-  if (!href) href = "/";
+  if (!href) return null;
   if (isActivityPath(href)) return null;
 
   return likeActivityPayload({

--- a/src/lib/hooks/useLikes.ts
+++ b/src/lib/hooks/useLikes.ts
@@ -51,6 +51,12 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
   const addLike = async () => {
     if (!viewerKnown || userLikes >= MAX_LIKES_PER_USER) return;
 
+    const payload = likeActivityPayload(target, {
+      title: document.title,
+      href: window.location.pathname,
+    });
+    if (!payload) return;
+
     const optimisticData: LikeData = {
       count: count + 1,
       userLikes: userLikes + 1,
@@ -62,12 +68,7 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
         const res = await fetch(`/api/likes/${pageId}`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(
-            likeActivityPayload(target, {
-              title: document.title,
-              href: window.location.pathname,
-            }),
-          ),
+          body: JSON.stringify(payload),
         });
         if (!res.ok) {
           throw new Error("Failed to like");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Brian saw

A row “Someone liked **Home**” with count **6**, linking to 1Password. You cannot like `/`, so that row should not exist.

## Hypothesis (verified)

Two things stacked into “liked Home”:

1. **Missing href → `/`.** `likeMetaFromRequest` and `likeActivityPayload` defaulted href to `/`. `recordLike` then stored `sanitizeVisitTitle(...) || "a page"`. `getActivityRow` mapped `/` + “a page” to **Home**. Those events shared rollup key `like:/`.

2. **Product names treated as identifiers.** `looksLikeShortId("1Password")` was true (digit + mixed case, Notion-id heuristic). The real title was discarded, `inferTitleFromPath("https://1password.com")` used pathname `/` → **Home**, and the row still linked to 1Password. Same-href likes then rolled up as count 6.

This is not an `ai: "AI"` title map. The identifier heuristic now rejects tokens that start with a digit (Notion short ids do not), and external product homes are not this site’s Home.

## Fixes

**Ingest**
- Do not default like href to `/`.
- Skip likes for `/`, empty href, activity paths, and titles Home / “a page”.
- Client `useLikes` does not POST when the resolved payload is home/`/`.

**Render**
- Never show Home as a liked thing. Old Redis `/` + “a page” / Home likes are dropped from the feed.

**Mixed like rollups**
- Consecutive likes share one key (`like`), like Shiori.
- 1 unique title: `Someone liked {title}`.
- 2+ unique titles: `Someone liked {latest title} + {n} others`. Hover “+ N others” for the unique title list (ported tooltip).

**Count badge**
- Call-site classes only: slightly larger type/padding and `-translate-y-[2px]` so the chip sits on the text centerline.

## Tests

Behavior only (no className / overflow assertions):

- Like with href `/` or missing href is not ingested and is not shown as Home.
- Two consecutive likes of different pages → one stack, copy includes “+ 1 other”, both titles in the others list.
- One like of 1Password → “Someone liked 1Password”, no Home.

`bun test src/lib/activity.test.ts src/components/ActivityFeed.test.tsx src/lib/activity-feed.test.ts` — 212 pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc94b95d-29b4-4db4-85fa-dcf9500795cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc94b95d-29b4-4db4-85fa-dcf9500795cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

