### PR TITLE
Remove relative timestamps from /activity rows

### DIFF
--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -29,13 +29,9 @@ function ActivityFallback() {
         <div data-scrollable className="relative min-w-0 flex-1 overflow-auto">
           <div className="divide-secondary divide-y">
             {Array.from({ length: 8 }, (_, index) => (
-              <div
-                key={index}
-                className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 md:gap-4"
-              >
+              <div key={index} className="flex items-center gap-3 px-4 py-3 md:gap-4">
                 <LoadingSkeleton className="size-6" />
                 <LoadingSkeleton className="h-5 w-2/3" />
-                <LoadingSkeleton className="h-4 w-14" />
               </div>
             ))}
           </div>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -2,15 +2,7 @@
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
-import {
-  type ReactNode,
-  type RefObject,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { type ReactNode, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 
 import { Activity } from "@/components/icons/Activity";
 import { Github } from "@/components/icons/Github";
@@ -39,42 +31,6 @@ import {
 } from "@/lib/activity-shared";
 import { useActivity } from "@/lib/hooks/useActivity";
 import { cn } from "@/lib/utils";
-
-function formatRelativeTime(iso: string): string {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return "";
-  const delta = Math.max(0, Date.now() - then);
-  const seconds = Math.floor(delta / 1000);
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-function RelativeTime({ iso, className }: { iso: string; className?: string }) {
-  const [label, setLabel] = useState("");
-
-  useEffect(() => {
-    const tick = () => setLabel(formatRelativeTime(iso));
-    tick();
-    const id = window.setInterval(tick, 1000);
-    return () => window.clearInterval(id);
-  }, [iso]);
-
-  return (
-    <time
-      className={cn("text-quaternary shrink-0 text-right text-sm tabular-nums", className)}
-      dateTime={iso}
-      title={iso}
-    >
-      {label || "\u00a0"}
-    </time>
-  );
-}
 
 function ActivitySourceFavicon({ src, source }: { src: string; source: string }) {
   const [failed, setFailed] = useState(false);
@@ -194,7 +150,7 @@ export function ActivityRow({
   return (
     <div
       data-rollup-pulse={pulse ? "" : undefined}
-      className="group hover:bg-secondary relative isolate flex w-max min-w-full items-center gap-3 py-3 pl-4 md:grid md:w-auto md:min-w-0 md:grid-cols-[2rem_minmax(0,1fr)_auto] md:gap-4 md:px-4 md:py-2 md:dark:hover:bg-white/5"
+      className="group hover:bg-secondary relative isolate flex items-center gap-3 px-4 py-3 md:gap-4 md:py-2 md:dark:hover:bg-white/5"
     >
       {pulse ? (
         <span
@@ -206,8 +162,8 @@ export function ActivityRow({
       <div className="relative z-10 flex size-8 shrink-0 items-center justify-center">
         <ActivityRowIcon event={event} icon={row.icon} />
       </div>
-      <p className="relative z-10 flex items-baseline gap-1.5 whitespace-nowrap md:min-w-0">
-        <span className="md:min-w-0 md:truncate">
+      <p className="relative z-10 flex min-w-0 items-baseline gap-1.5">
+        <span className="min-w-0">
           <span className="text-primary">{row.summary}</span>
           {href && context ? (
             <>
@@ -233,16 +189,6 @@ export function ActivityRow({
           </span>
         ) : null}
       </p>
-      <RelativeTime
-        iso={event.received_at}
-        className={cn(
-          "sticky right-0 z-10 ml-auto bg-white px-4 dark:bg-black",
-          "group-hover:bg-inherit group-data-[rollup-pulse]:bg-inherit",
-          "max-md:[box-shadow:inset_1px_0_0_var(--border-color-secondary)]",
-          "md:static md:ml-0 md:bg-transparent md:px-0 md:shadow-none md:dark:bg-transparent",
-          "md:group-hover:bg-inherit md:group-data-[rollup-pulse]:bg-inherit md:dark:group-hover:bg-white/5",
-        )}
-      />
     </div>
   );
 }
@@ -283,75 +229,6 @@ function useHydrated(): boolean {
     () => true,
     () => false,
   );
-}
-
-function useIsMobile(): boolean {
-  return useSyncExternalStore(
-    (onChange) => {
-      const media = window.matchMedia("(max-width: 767px)");
-      media.addEventListener("change", onChange);
-      return () => media.removeEventListener("change", onChange);
-    },
-    () => window.matchMedia("(max-width: 767px)").matches,
-    () => false,
-  );
-}
-
-function useMobileAxisLock(ref: RefObject<HTMLElement | null>, enabled: boolean) {
-  useEffect(() => {
-    const container = ref.current;
-    if (!container || !enabled) return;
-
-    let touchStartPos: { x: number; y: number } | null = null;
-    let lockedAxis: "x" | "y" | null = null;
-    let lockedScrollValue: number | null = null;
-    const threshold = 5;
-
-    const handleTouchStart = (event: TouchEvent) => {
-      const touch = event.touches[0];
-      if (!touch) return;
-      touchStartPos = { x: touch.clientX, y: touch.clientY };
-      lockedAxis = null;
-      lockedScrollValue = null;
-    };
-
-    const handleTouchMove = (event: TouchEvent) => {
-      if (!touchStartPos) return;
-      const touch = event.touches[0];
-      if (!touch || lockedAxis !== null) return;
-
-      const deltaX = Math.abs(touch.clientX - touchStartPos.x);
-      const deltaY = Math.abs(touch.clientY - touchStartPos.y);
-      if (deltaX <= threshold && deltaY <= threshold) return;
-
-      lockedAxis = deltaX > deltaY ? "x" : "y";
-      lockedScrollValue = lockedAxis === "x" ? container.scrollTop : container.scrollLeft;
-    };
-
-    const handleScroll = () => {
-      if (lockedAxis === null || lockedScrollValue === null) return;
-      if (lockedAxis === "x" && container.scrollTop !== lockedScrollValue) {
-        container.scrollTop = lockedScrollValue;
-      } else if (lockedAxis === "y" && container.scrollLeft !== lockedScrollValue) {
-        container.scrollLeft = lockedScrollValue;
-      }
-    };
-
-    const handleTouchEnd = () => {
-      touchStartPos = null;
-    };
-
-    container.addEventListener("touchstart", handleTouchStart, { passive: true });
-    container.addEventListener("touchmove", handleTouchMove, { passive: true });
-    container.addEventListener("touchend", handleTouchEnd);
-    container.addEventListener("scroll", handleScroll);
-    return () => {
-      container.removeEventListener("touchstart", handleTouchStart);
-      container.removeEventListener("touchmove", handleTouchMove);
-      container.removeEventListener("touchend", handleTouchEnd);
-      container.removeEventListener("scroll", handleScroll);
-    };
-  }, [enabled, ref]);
 }
 
 function pruneEnterDelays(delays: Map<string, number>, liveKeys: Set<string>): Map<string, number> {
@@ -396,7 +273,7 @@ function ActivityStackList({
   if (nextDelays !== enterDelays) setEnterDelays(nextDelays);
 
   return (
-    <div className="divide-secondary min-w-max divide-y md:min-w-0">
+    <div className="divide-secondary divide-y">
       <AnimatePresence initial={false}>
         {stacks.map((stack) => {
           const reactKey = activityStackReactKey(stack);
@@ -418,10 +295,7 @@ function ActivityStackList({
                   return remaining;
                 });
               }}
-              className={cn(
-                "w-max min-w-full md:w-auto md:min-w-0",
-                isEntering ? "overflow-hidden" : "[clip-path:inset(0)]",
-              )}
+              className={isEntering ? "overflow-hidden" : "[clip-path:inset(0)]"}
             >
               <ActivityRow
                 event={stack.latest}
@@ -477,9 +351,6 @@ export function ActivityFeed({
   const { events, count } = useActivity(initialEvents, initialCount);
   const stacks = useMemo(() => rollupActivityEvents(events), [events]);
   const pulseKey = useRollupPulse(stacks);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const isMobile = useIsMobile();
-  useMobileAxisLock(scrollRef, isMobile);
 
   const topBarContent = useMemo(() => <ActivityTrackedCount count={count} />, [count]);
   useTopBarActions(topBarContent);
@@ -487,11 +358,7 @@ export function ActivityFeed({
   return (
     <ListDetailWrapper>
       <div className="relative flex min-h-0 flex-1 overflow-hidden">
-        <div
-          ref={scrollRef}
-          data-scrollable
-          className="relative min-w-0 flex-1 overflow-auto overscroll-contain [-webkit-overflow-scrolling:touch]"
-        >
+        <div data-scrollable className="relative min-w-0 flex-1 overflow-auto">
           {events.length === 0 ? (
             <p className="text-tertiary px-4 py-10">
               Nothing yet. Likes and visits will show up here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Brian noted the right-side relative timestamp on `/activity` rows isn’t adding much, and it was the only reason we kept a sticky time column (plus horizontal scroll and axis-lock) on small viewports.

## Changes
- Delete `RelativeTime` / `formatRelativeTime` and the time column from `ActivityRow`.
- Drop mobile sticky-right time, horizontal-scroll-for-time, `useMobileAxisLock`, and the inset shadow hacks that existed only to pin the timestamp.
- Rows are a normal single column again: icon + sentence.
- Loading skeleton no longer reserves a third column for time.
- Lifetime event count stays in the top bar.

No copy/verb/Shiori changes in this PR.

## Verification
- `bun run lint` passed
- `bun test src/components/ActivityFeed.test.tsx` — 44 pass
- Manual check of `/activity`: no right-side timestamps on desktop or ~390px; lifetime count still in the top bar

[Desktop activity rows without timestamps](https://cursor.com/agents/bc-7a719a29-53d7-4407-909f-9f6dc3368fb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_rows_desktop_no_timestamp.webp)
[Mobile activity rows without a sticky time column](https://cursor.com/agents/bc-7a719a29-53d7-4407-909f-9f6dc3368fb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_rows_mobile_no_timestamp.webp)
[activity_rows_no_timestamp_walkthrough.mp4](https://cursor.com/agents/bc-7a719a29-53d7-4407-909f-9f6dc3368fb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_rows_no_timestamp_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a719a29-53d7-4407-909f-9f6dc3368fb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a719a29-53d7-4407-909f-9f6dc3368fb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

