### PR TITLE
Make /activity visit rows read as human sentences

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -35,7 +35,7 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from India viewed");
+    expect(markup).toContain("Someone from India visited");
     expect(markup).not.toContain("Visit from");
     expect(markup).not.toContain("🇮🇳");
     expect(markup).toContain("/activity/favicons/brios.png");
@@ -283,7 +283,7 @@ describe("ActivityRow", () => {
     );
 
     expect(visit).toContain("/activity/favicons/tax-ui.png");
-    expect(visit).toContain("Someone from United States viewed");
+    expect(visit).toContain("Someone from United States visited");
     expect(visit).not.toContain("Visit from");
     expect(visit).not.toContain("🇺🇸");
     expect(download).toContain("/activity/favicons/design-details.png");
@@ -294,7 +294,7 @@ describe("ActivityRow", () => {
     expect(download).toContain('target="_blank"');
     expect(download).toContain("noopener noreferrer");
     expect(unknown).not.toContain("/activity/favicons/");
-    expect(unknown).toContain("Someone from United States viewed the site");
+    expect(unknown).toContain("Someone from United States visited the site");
     expect(unknown).not.toContain("Visit from");
     expect(unknown).not.toContain("🇺🇸");
   });
@@ -304,7 +304,7 @@ describe("ActivityRow", () => {
       <ActivityRow event={event({ summary: "Visit from TW", meta: { country: "TW" } })} />,
     );
     expect(markup).not.toContain("🇹🇼");
-    expect(markup).toContain("Someone from Taiwan viewed the site");
+    expect(markup).toContain("Someone from Taiwan visited the site");
     expect(markup).not.toContain("Visit from");
   });
 
@@ -318,7 +318,7 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from a mysterious place on earth viewed");
+    expect(markup).toContain("Someone from a mysterious place on earth visited");
     expect(markup).toContain("the site");
     expect(markup).not.toContain("Someone visited from a mysterious place on earth");
     expect(markup).not.toContain("Home");
@@ -860,18 +860,41 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(staff).toContain("Someone from United States viewed");
+    expect(staff).toContain("Someone from United States visited");
     expect(staff).not.toContain("Visit from");
     expect(staff).not.toContain("🇺🇸");
     expect(staff).toContain(">Staff Design<");
     expect(staff).toContain('href="https://staff.design"');
     expect(staff).toContain('target="_blank"');
     expect(details).toContain("Someone from San Francisco");
+    expect(details).toContain("visited");
+    expect(details).not.toContain("listened to");
     expect(details).not.toContain("Visit from");
     expect(details).toContain(">Design Details<");
     expect(details).toContain('href="https://designdetails.fm"');
     expect(details).toContain('target="_blank"');
     expect(details).not.toContain(">Home<");
+  });
+
+  test("listens to a Design Details episode instead of the show name", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          source: "design-details",
+          summary: "🇨🇳 Visit from China",
+          subject: { kind: "page", label: "On Leaving", href: "/episodes/on-leaving" },
+          meta: { country: "CN", path: "/episodes/on-leaving", title: "On Leaving" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Someone from China listened to");
+    expect(markup).toContain(">On Leaving<");
+    expect(markup).not.toContain("Visit from");
+    expect(markup).not.toContain("listened to Design Details");
+    expect(markup).not.toContain(">Design Details<");
+    expect(markup).toContain('href="https://designdetails.fm/episodes/on-leaving"');
+    expect(markup).toContain('target="_blank"');
   });
 
   test("keeps a specific staff.design page as the new-tab link", () => {
@@ -890,7 +913,7 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from Germany viewed");
+    expect(markup).toContain("Someone from Germany read");
     expect(markup).not.toContain("Visit from");
     expect(markup).not.toContain("🇩🇪");
     expect(markup).toContain(">Karla Mickens Cole<");
@@ -1022,7 +1045,7 @@ describe("ActivityFeed", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from India viewed the site");
+    expect(markup).toContain("Someone from India visited the site");
     expect(markup).not.toContain("Visit from");
     expect(markup).not.toContain("🇮🇳");
     expect(markup).not.toContain(">Event<");
@@ -1055,7 +1078,7 @@ describe("ActivityFeed", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from India viewed");
+    expect(markup).toContain("Someone from India visited");
     expect(markup).toContain("Someone from San Francisco");
     expect(markup).not.toContain("Visit from");
     expect(markup).toContain("Someone liked");

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -35,11 +35,13 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Visit from India");
+    expect(markup).toContain("Someone from India viewed");
+    expect(markup).not.toContain("Visit from");
     expect(markup).not.toContain("🇮🇳");
     expect(markup).toContain("/activity/favicons/brios.png");
     expect(markup).toContain('href="/"');
-    expect(markup).toContain("Home");
+    expect(markup).toContain("the site");
+    expect(markup).not.toContain("Home");
     expect(markup).not.toContain("a page");
   });
 
@@ -62,6 +64,8 @@ describe("ActivityRow", () => {
       />,
     );
 
+    expect(markup).toContain("Someone from India read");
+    expect(markup).not.toContain("Visit from");
     expect(markup).toContain("How I&#x27;m Feeling About AI in August 2026");
     expect(markup).not.toContain("How Im Feeling About Ai in August 2026");
     expect(markup).toContain('href="/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS"');
@@ -183,6 +187,8 @@ describe("ActivityRow", () => {
       />,
     );
 
+    expect(markup).toContain("Someone from United States viewed");
+    expect(markup).not.toContain("Visit from");
     expect(markup).toContain("Hacker News");
     expect(markup).toContain('href="/hn"');
     expect(markup).not.toContain("a Hacker News story");
@@ -219,6 +225,8 @@ describe("ActivityRow", () => {
       />,
     );
 
+    expect(markup).toContain("Someone from United States read");
+    expect(markup).not.toContain("Visit from");
     expect(markup).toContain(">Some HN Story<");
     expect(markup).toContain('href="/hn/42991019"');
     expect(markup).not.toContain("a Hacker News story");
@@ -236,6 +244,8 @@ describe("ActivityRow", () => {
       />,
     );
 
+    expect(markup).toContain("Someone from China read");
+    expect(markup).not.toContain("Visit from");
     expect(markup).toContain("a Hacker News story");
     expect(markup).toContain('href="/hn/46993596"');
     expect(markup).not.toContain(">46993596<");
@@ -273,7 +283,8 @@ describe("ActivityRow", () => {
     );
 
     expect(visit).toContain("/activity/favicons/tax-ui.png");
-    expect(visit).toContain("Visit from United States");
+    expect(visit).toContain("Someone from United States viewed");
+    expect(visit).not.toContain("Visit from");
     expect(visit).not.toContain("🇺🇸");
     expect(download).toContain("/activity/favicons/design-details.png");
     expect(download).toContain("Someone downloaded");
@@ -283,7 +294,8 @@ describe("ActivityRow", () => {
     expect(download).toContain('target="_blank"');
     expect(download).toContain("noopener noreferrer");
     expect(unknown).not.toContain("/activity/favicons/");
-    expect(unknown).toContain("Visit from United States");
+    expect(unknown).toContain("Someone from United States viewed the site");
+    expect(unknown).not.toContain("Visit from");
     expect(unknown).not.toContain("🇺🇸");
   });
 
@@ -292,7 +304,8 @@ describe("ActivityRow", () => {
       <ActivityRow event={event({ summary: "Visit from TW", meta: { country: "TW" } })} />,
     );
     expect(markup).not.toContain("🇹🇼");
-    expect(markup).toContain("Visit from Taiwan");
+    expect(markup).toContain("Someone from Taiwan viewed the site");
+    expect(markup).not.toContain("Visit from");
   });
 
   test("uses the globe and mysterious-place copy when a visit has no country", () => {
@@ -305,8 +318,10 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone visited from a mysterious place on earth");
-    expect(markup).toContain("Home");
+    expect(markup).toContain("Someone from a mysterious place on earth viewed");
+    expect(markup).toContain("the site");
+    expect(markup).not.toContain("Someone visited from a mysterious place on earth");
+    expect(markup).not.toContain("Home");
     expect(markup).not.toContain(">Visit<");
     expect(markup).not.toContain("🇮🇳");
   });
@@ -343,7 +358,8 @@ describe("ActivityRow", () => {
     expect(like).not.toContain("Someone liked Grok Bot first impressions");
     expect(like).toContain('href="/writing/grok-bot-first-impressions"');
     expect(visit).not.toContain(heartPath);
-    expect(visit).toContain("Visit from India");
+    expect(visit).toContain("Someone from India read");
+    expect(visit).not.toContain("Visit from");
     expect(visit).not.toContain("🇮🇳");
     expect(visit).toContain("/activity/favicons/brios.png");
     expect(like).not.toContain("/activity/favicons/");
@@ -771,7 +787,7 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("shiori-icon.png");
-    expect(markup).toContain("Someone saved a link");
+    expect(markup).toContain("Someone saved a link on");
     expect(markup).not.toContain("Someone saved a link on Shiori");
     expect(markup).toContain(">Shiori<");
     expect(markup).toContain('href="https://www.shiori.sh"');
@@ -784,7 +800,7 @@ describe("ActivityRow", () => {
       {
         type: "link_clicked" as const,
         summary: "Someone clicked a link on Shiori",
-        stripped: "Someone clicked a link",
+        stripped: "Someone clicked a link on",
       },
       {
         type: "signed_up" as const,
@@ -844,12 +860,14 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(staff).toContain("Visit from United States");
+    expect(staff).toContain("Someone from United States viewed");
+    expect(staff).not.toContain("Visit from");
     expect(staff).not.toContain("🇺🇸");
     expect(staff).toContain(">Staff Design<");
     expect(staff).toContain('href="https://staff.design"');
     expect(staff).toContain('target="_blank"');
-    expect(details).toContain("Visit from San Francisco");
+    expect(details).toContain("Someone from San Francisco");
+    expect(details).not.toContain("Visit from");
     expect(details).toContain(">Design Details<");
     expect(details).toContain('href="https://designdetails.fm"');
     expect(details).toContain('target="_blank"');
@@ -872,7 +890,8 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Visit from Germany");
+    expect(markup).toContain("Someone from Germany viewed");
+    expect(markup).not.toContain("Visit from");
     expect(markup).not.toContain("🇩🇪");
     expect(markup).toContain(">Karla Mickens Cole<");
     expect(markup).toContain('href="https://staff.design/karla-mickens-cole"');
@@ -909,8 +928,9 @@ describe("ActivityRow", () => {
     expect(like).toContain('href="/writing/grok-bot-first-impressions"');
     expect(like).not.toContain(">briOS<");
     expect(like).not.toContain('target="_blank"');
-    expect(visit).toContain(">Home<");
+    expect(visit).toContain(">the site<");
     expect(visit).toContain('href="/"');
+    expect(visit).not.toContain(">Home<");
     expect(visit).not.toContain(">briOS<");
     expect(visit).not.toContain('target="_blank"');
   });
@@ -929,7 +949,7 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("shiori-icon.png");
-    expect(markup).toContain("Someone clicked a link");
+    expect(markup).toContain("Someone clicked a link on");
     expect(markup).not.toContain("Someone clicked a link on Shiori");
     expect(markup).toContain(">Shiori<");
     expect(markup).toContain('href="https://www.shiori.sh"');
@@ -963,12 +983,13 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Visit from Spring Lake, North Carolina, United States");
+    expect(markup).toContain("Someone from Spring Lake, North Carolina, United States viewed");
+    expect(markup).not.toContain("Visit from");
     expect(markup).toContain("an AMA question");
     expect(markup).toContain('href="/ama"');
     expect(markup).not.toContain("2f2c711c-0ceb-810d-899d-e5feb99e70f4");
     expect(markup).toMatch(
-      /Visit from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*>6</,
+      /Someone from Spring Lake[\s\S]*href="\/ama"[^>]*>an AMA question[\s\S]*>6</,
     );
 
     const single = renderToStaticMarkup(
@@ -1001,7 +1022,8 @@ describe("ActivityFeed", () => {
       />,
     );
 
-    expect(markup).toContain("Visit from India");
+    expect(markup).toContain("Someone from India viewed the site");
+    expect(markup).not.toContain("Visit from");
     expect(markup).not.toContain("🇮🇳");
     expect(markup).not.toContain(">Event<");
     expect(markup).not.toContain(">Time<");
@@ -1033,8 +1055,9 @@ describe("ActivityFeed", () => {
       />,
     );
 
-    expect(markup).toContain("Visit from India");
-    expect(markup).toContain("Visit from San Francisco");
+    expect(markup).toContain("Someone from India viewed");
+    expect(markup).toContain("Someone from San Francisco");
+    expect(markup).not.toContain("Visit from");
     expect(markup).toContain("Someone liked");
   });
 

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ANONYMOUS_VISIT_SUMMARY,
   formatVisitSummary,
   geoFromVisitMeta,
   normalizeCountryCode,
@@ -503,7 +502,7 @@ export function activitySectionFromPath(pathname: string | undefined): string {
 
 /** Smart section phrase for stacked visit subtitles — never a raw id. */
 export function activitySectionPhrase(section: string): string {
-  if (!section || section === "home" || isProtocolSegment(section)) return "Home";
+  if (!section || section === "home" || isProtocolSegment(section)) return SITE_VISIT_LABEL;
   if (section === "ama") return "an AMA question";
   const known = KNOWN_PATH_TITLES[`/${section}`];
   if (known) return known;
@@ -838,6 +837,113 @@ function publicPullRequestHref(event: ActivityEvent): string | undefined {
   return typeof metaHref === "string" && metaHref ? metaHref : undefined;
 }
 
+/** Linked fallback when a visit has no real page title. Never “Home”. */
+export const SITE_VISIT_LABEL = "the site";
+
+/** Location words for visits with no usable geo. No flag. */
+export const MYSTERIOUS_PLACE_LOCATION = "a mysterious place on earth";
+
+export type VisitActivityVerb = "read" | "viewed";
+
+/** `read` for writing, TIL, and HN stories; `viewed` for everything else. */
+export function visitVerbFromPath(pathname: string | undefined): VisitActivityVerb {
+  if (!pathname) return "viewed";
+  if (cmsPostRefFromPath(pathname)) return "read";
+  if (hnStoryIdFromPath(pathname)) return "read";
+  return "viewed";
+}
+
+function isUsableVisitTitle(label: string | undefined): boolean {
+  const trimmed = label?.trim();
+  if (!trimmed) return false;
+  if (trimmed === "Home" || trimmed === "a page") return false;
+  if (looksLikeIdentifier(trimmed)) return false;
+  return true;
+}
+
+function locationFromVisitText(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  if (/mysterious place on earth/i.test(trimmed)) return MYSTERIOUS_PLACE_LOCATION;
+
+  const visitFrom = /^(?:First\s+)?Visit from\s+(.+)$/i.exec(trimmed);
+  if (visitFrom?.[1]) return visitFrom[1].trim();
+
+  const someoneVisited = /^Someone visited from\s+(.+)$/i.exec(trimmed);
+  if (someoneVisited?.[1]) return someoneVisited[1].trim();
+
+  const someoneFromVerb = /^Someone from\s+(.+?)\s+(?:read|viewed)(?:\s+the site)?$/i.exec(trimmed);
+  if (someoneFromVerb?.[1]) return someoneFromVerb[1].trim();
+
+  const someoneFrom = /^Someone from\s+(.+)$/i.exec(trimmed);
+  if (someoneFrom?.[1]) return someoneFrom[1].trim();
+
+  return undefined;
+}
+
+/** City / region / country, or the mysterious-place words. Display only. */
+export function visitLocationPhrase(event: ActivityEvent): string {
+  const geo = geoFromVisitMeta(event.meta);
+  const hasLocation = Boolean(geo.country || geo.city || geo.countryName);
+  if (hasLocation) {
+    return (
+      locationFromVisitText(visitDisplaySummary(formatVisitSummary(geo))) ??
+      MYSTERIOUS_PLACE_LOCATION
+    );
+  }
+
+  const storedText = visitDisplaySummary(event.summary);
+  if (!storedText || storedText === "Visit") return MYSTERIOUS_PLACE_LOCATION;
+  return locationFromVisitText(storedText) ?? MYSTERIOUS_PLACE_LOCATION;
+}
+
+export function formatVisitRowSummary(
+  location: string,
+  verb: VisitActivityVerb,
+  hasTitle: boolean,
+): string {
+  if (!hasTitle) return `Someone from ${location} viewed the site`;
+  return `Someone from ${location} ${verb}`;
+}
+
+function visitSubjectPath(event: ActivityEvent): string | undefined {
+  if (event.subject?.href) return event.subject.href;
+  const path = event.meta?.path;
+  return typeof path === "string" && path ? path : undefined;
+}
+
+function visitActivityRow(event: ActivityEvent): {
+  summary: string;
+  flag?: string;
+  icon?: string;
+  href?: string;
+  label?: string;
+} {
+  const path = visitSubjectPath(event);
+  const row = attachSourceMetadata(event, {
+    summary: event.summary,
+    href: path,
+    label: displaySubjectLabel(event.subject?.label, path),
+  });
+  const location = visitLocationPhrase(event);
+  const verb = visitVerbFromPath(row.href ?? path);
+  if (isUsableVisitTitle(row.label)) {
+    return { ...row, summary: formatVisitRowSummary(location, verb, true) };
+  }
+  if (row.href) {
+    return {
+      ...row,
+      summary: formatVisitRowSummary(location, "viewed", true),
+      label: SITE_VISIT_LABEL,
+    };
+  }
+  return {
+    ...row,
+    summary: formatVisitRowSummary(location, "viewed", false),
+    label: undefined,
+  };
+}
+
 /** Real PR title, or `repo#number` / “a pull request”. Never a site path title. */
 function publicPullRequestLabel(event: ActivityEvent): string {
   const stored =
@@ -880,28 +986,8 @@ export function getActivityRow(event: ActivityEvent): {
     });
   }
 
-  if (event.type === "visit") {
-    const geo = geoFromVisitMeta(event.meta);
-    const hasLocation = Boolean(geo.country || geo.city || geo.countryName);
-    const storedText = visitDisplaySummary(event.summary);
-    const summary = hasLocation
-      ? visitDisplaySummary(formatVisitSummary(geo))
-      : !storedText || storedText === "Visit"
-        ? ANONYMOUS_VISIT_SUMMARY
-        : storedText;
-    return attachSourceMetadata(event, {
-      summary,
-      href: event.subject?.href,
-      label: displaySubjectLabel(event.subject?.label, event.subject?.href),
-    });
-  }
-
-  if (event.type === "visit_country_first") {
-    return attachSourceMetadata(event, {
-      summary: visitDisplaySummary(event.summary),
-      href: event.subject?.href,
-      label: displaySubjectLabel(event.subject?.label, event.subject?.href),
-    });
+  if (event.type === "visit" || event.type === "visit_country_first") {
+    return visitActivityRow(event);
   }
 
   if (event.type === "like") {
@@ -917,8 +1003,12 @@ export function getActivityRow(event: ActivityEvent): {
     });
   }
 
-  if (event.source === "shiori" && (event.type === "link_saved" || event.type === "link_clicked")) {
-    return attachSourceMetadata(event, { summary: event.summary });
+  if (event.source === "shiori" && event.type === "link_saved") {
+    return attachSourceMetadata(event, { summary: "Someone saved a link on" });
+  }
+
+  if (event.source === "shiori" && event.type === "link_clicked") {
+    return attachSourceMetadata(event, { summary: "Someone clicked a link on" });
   }
 
   return attachSourceMetadata(event, {

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -843,14 +843,49 @@ export const SITE_VISIT_LABEL = "the site";
 /** Location words for visits with no usable geo. No flag. */
 export const MYSTERIOUS_PLACE_LOCATION = "a mysterious place on earth";
 
-export type VisitActivityVerb = "read" | "viewed";
+export type VisitActivityVerb = "read" | "viewed" | "visited" | "listened to";
 
-/** `read` for writing, TIL, and HN stories; `viewed` for everything else. */
-export function visitVerbFromPath(pathname: string | undefined): VisitActivityVerb {
-  if (!pathname) return "viewed";
-  if (cmsPostRefFromPath(pathname)) return "read";
-  if (hnStoryIdFromPath(pathname)) return "read";
+const VISIT_SENTENCE_VERB_RE = "(?:listened to|read|viewed|visited)";
+
+function isSiteHomePath(source: string, pathname: string | undefined): boolean {
+  if (!pathname?.trim()) return true;
+  const path = normalizeActivityPath(pathnameFromHref(pathname));
+  if (path === "/") return true;
+  return isSourceHomeHref(source, pathname);
+}
+
+/**
+ * Verb from the event source plus the path they opened.
+ * Site homes → visited; briOS listings → viewed; posts/stories/interviews → read;
+ * Design Details episodes → listened to.
+ */
+export function visitVerbFromPath(
+  pathname: string | undefined,
+  source: string = ACTIVITY_SOURCE_BRIOS,
+): VisitActivityVerb {
+  const path = pathname ? normalizeActivityPath(pathnameFromHref(pathname)) : "";
+  const atHome = isSiteHomePath(source, pathname);
+
+  if (source === "design-details") {
+    return atHome ? "visited" : "listened to";
+  }
+  if (source === "staff-design") {
+    return atHome ? "visited" : "read";
+  }
+  if (source === "tax-ui") {
+    return atHome ? "visited" : "viewed";
+  }
+
+  if (path === "/design-details") return "visited";
+  if (path.startsWith("/design-details/")) return "listened to";
+  if (cmsPostRefFromPath(pathname ?? path)) return "read";
+  if (hnStoryIdFromPath(pathname ?? path)) return "read";
+  if (atHome) return "visited";
   return "viewed";
+}
+
+function siteFallbackVerb(verb: VisitActivityVerb): "visited" | "viewed" {
+  return verb === "visited" ? "visited" : "viewed";
 }
 
 function isUsableVisitTitle(label: string | undefined): boolean {
@@ -872,7 +907,10 @@ function locationFromVisitText(text: string): string | undefined {
   const someoneVisited = /^Someone visited from\s+(.+)$/i.exec(trimmed);
   if (someoneVisited?.[1]) return someoneVisited[1].trim();
 
-  const someoneFromVerb = /^Someone from\s+(.+?)\s+(?:read|viewed)(?:\s+the site)?$/i.exec(trimmed);
+  const someoneFromVerb = new RegExp(
+    `^Someone from\\s+(.+?)\\s+${VISIT_SENTENCE_VERB_RE}(?:\\s+the site)?$`,
+    "i",
+  ).exec(trimmed);
   if (someoneFromVerb?.[1]) return someoneFromVerb[1].trim();
 
   const someoneFrom = /^Someone from\s+(.+)$/i.exec(trimmed);
@@ -902,7 +940,7 @@ export function formatVisitRowSummary(
   verb: VisitActivityVerb,
   hasTitle: boolean,
 ): string {
-  if (!hasTitle) return `Someone from ${location} viewed the site`;
+  if (!hasTitle) return `Someone from ${location} ${siteFallbackVerb(verb)} the site`;
   return `Someone from ${location} ${verb}`;
 }
 
@@ -926,20 +964,28 @@ function visitActivityRow(event: ActivityEvent): {
     label: displaySubjectLabel(event.subject?.label, path),
   });
   const location = visitLocationPhrase(event);
-  const verb = visitVerbFromPath(row.href ?? path);
+  const verb = visitVerbFromPath(row.href ?? path, event.source);
   if (isUsableVisitTitle(row.label)) {
     return { ...row, summary: formatVisitRowSummary(location, verb, true) };
   }
+  if (verb === "listened to") {
+    return {
+      ...row,
+      summary: formatVisitRowSummary(location, verb, true),
+      label: "a Design Details episode",
+    };
+  }
+  const fallbackVerb = siteFallbackVerb(verb);
   if (row.href) {
     return {
       ...row,
-      summary: formatVisitRowSummary(location, "viewed", true),
+      summary: formatVisitRowSummary(location, fallbackVerb, true),
       label: SITE_VISIT_LABEL,
     };
   }
   return {
     ...row,
-    summary: formatVisitRowSummary(location, "viewed", false),
+    summary: formatVisitRowSummary(location, fallbackVerb, false),
     label: undefined,
   };
 }

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -444,7 +444,7 @@ describe("recordVisit", () => {
       title: "Grok Bot First Impressions",
     });
     expect(getActivityRow(event!)).toEqual({
-      summary: "Visit from India",
+      summary: "Someone from India read",
       href: "/writing/grok-bot-first-impressions",
       label: "Grok Bot First Impressions",
     });
@@ -715,7 +715,7 @@ describe("recordVisit", () => {
     expect(event?.summary).toBe(ANONYMOUS_VISIT_SUMMARY);
     expect(event?.meta).toEqual({ path: "/writing", title: "Writing" });
     expect(getActivityRow(event!)).toEqual({
-      summary: ANONYMOUS_VISIT_SUMMARY,
+      summary: "Someone from a mysterious place on earth viewed",
       href: "/writing",
       label: "Writing",
     });
@@ -736,9 +736,9 @@ describe("recordVisit", () => {
       subject: { kind: "home", label: "Home", href: "/" },
     });
     expect(row).toEqual({
-      summary: ANONYMOUS_VISIT_SUMMARY,
+      summary: "Someone from a mysterious place on earth viewed",
       href: "/",
-      label: "Home",
+      label: "the site",
     });
   });
 
@@ -756,7 +756,7 @@ describe("recordVisit", () => {
       idempotency_key: "old-located",
       subject: { kind: "writing", label: "Writing", href: "/writing" },
     });
-    expect(row.summary).toBe("Visit from France");
+    expect(row.summary).toBe("Someone from France viewed");
   });
 
   test("keeps the existing summary when the country has no flag", async () => {
@@ -784,7 +784,7 @@ describe("recordVisit", () => {
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "Visit from India",
+      summary: "Someone from India viewed the site",
     });
     expect(row.summary).not.toMatch(/\p{Regional_Indicator}/u);
   });
@@ -804,7 +804,7 @@ describe("recordVisit", () => {
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "First visit from IN",
+      summary: "Someone from India viewed the site",
     });
   });
 
@@ -947,7 +947,7 @@ describe("HMAC download ingest", () => {
     expect(event?.actor).toBeUndefined();
     expect(JSON.stringify(event)).not.toMatch(/https?:\/\//);
     expect(getActivityRow(event!)).toEqual({
-      summary: "Someone clicked a link",
+      summary: "Someone clicked a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -969,7 +969,7 @@ describe("HMAC download ingest", () => {
     expect(result.ok && !result.duplicate).toBe(true);
     const row = getActivityRow((await store.getTail(1))[0]!);
     expect(row).toEqual({
-      summary: "Someone clicked a link",
+      summary: "Someone clicked a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -1491,8 +1491,10 @@ describe("getActivityRow page titles", () => {
       subject: { kind: "home", label: "a page", href: "/" },
       meta: { path: "/", title: "a page", country: "FR" },
     });
-    expect(row.label).toBe("Home");
+    expect(row.label).toBe("the site");
     expect(row.href).toBe("/");
+    expect(row.summary).toBe("Someone from France viewed");
+    expect(row.summary).not.toContain("Visit from");
   });
 
   test("strips a stored short id from a writing visit without rewriting Redis", () => {
@@ -1742,6 +1744,118 @@ describe("getActivityRow page titles", () => {
   });
 });
 
+describe("getActivityRow visit sentences", () => {
+  test("uses Someone from and read for a San Francisco writing visit", () => {
+    const row = getActivityRow({
+      v: 1,
+      id: "sf-writing",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "brios",
+      type: "visit",
+      speed: "signal",
+      summary: "🇺🇸 Visit from San Francisco, California, United States",
+      visibility: "public",
+      idempotency_key: "sf-writing",
+      subject: {
+        kind: "writing",
+        label: "How I'm Feeling About AI in August 2026",
+        href: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+      },
+      meta: {
+        country: "US",
+        country_name: "United States",
+        region: "CA",
+        region_name: "California",
+        city: "San Francisco",
+        path: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+      },
+    });
+
+    expect(row.summary.startsWith("Someone from")).toBe(true);
+    expect(row.summary).toBe("Someone from San Francisco, California, United States read");
+    expect(row.summary).toContain("read");
+    expect(row.summary).not.toContain("viewed");
+    expect(row.summary).not.toContain("Visit from");
+    expect(row.label).toBe("How I'm Feeling About AI in August 2026");
+  });
+
+  test("uses viewed for stack and home visits", () => {
+    const stack = getActivityRow(
+      visitRowEvent(
+        { kind: "stack", label: "Stack", href: "/stack" },
+        { meta: { country: "US", path: "/stack" } },
+      ),
+    );
+    expect(stack.summary).toBe("Someone from United States viewed");
+    expect(stack.summary).toContain("viewed");
+    expect(stack.summary).not.toContain("read");
+    expect(stack.summary).not.toContain("Visit from");
+    expect(stack.label).toBe("Stack");
+
+    const home = getActivityRow(
+      visitRowEvent(
+        { kind: "home", label: "Home", href: "/" },
+        { meta: { country: "CN", path: "/", title: "Home" } },
+      ),
+    );
+    expect(home.summary).toBe("Someone from China viewed");
+    expect(home.summary).toContain("viewed");
+    expect(home.summary).not.toContain("Visit from");
+    expect(home.label).toBe("the site");
+    expect(home.label).not.toBe("Home");
+  });
+
+  test("views the HN index and reads an HN story", () => {
+    const index = getActivityRow(
+      visitRowEvent(
+        { kind: "page", label: "Hacker News", href: "/hn" },
+        { meta: { country: "US", path: "/hn" } },
+      ),
+    );
+    expect(index.summary).toBe("Someone from United States viewed");
+    expect(index.summary).toContain("viewed");
+    expect(index.summary).not.toContain("read");
+    expect(index.summary).not.toContain("Visit from");
+    expect(index.label).toBe("Hacker News");
+
+    const story = getActivityRow(
+      visitRowEvent(
+        { kind: "page", label: "Some HN Story", href: "/hn/42991019" },
+        { meta: { country: "CN", path: "/hn/42991019" } },
+      ),
+    );
+    expect(story.summary).toBe("Someone from China read");
+    expect(story.summary).toContain("read");
+    expect(story.summary).not.toContain("viewed");
+    expect(story.summary).not.toContain("Visit from");
+    expect(story.label).toBe("Some HN Story");
+  });
+
+  test("does not leave Visit from on a recovered Redis visit row", () => {
+    const row = getActivityRow({
+      v: 1,
+      id: "old-visit-copy",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "brios",
+      type: "visit",
+      speed: "signal",
+      summary: "Visit from China",
+      visibility: "public",
+      idempotency_key: "old-visit-copy",
+      subject: {
+        kind: "writing",
+        label: "How I'm Feeling About AI in August 2026",
+        href: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+      },
+    });
+    expect(row.summary).toBe("Someone from China read");
+    expect(row.summary).not.toContain("Visit from");
+    expect(row.label).toBe("How I'm Feeling About AI in August 2026");
+  });
+});
+
 describe("getActivityRow source metadata", () => {
   function rowEvent(overrides: Partial<ActivityEvent>): ActivityEvent {
     return {
@@ -1761,7 +1875,7 @@ describe("getActivityRow source metadata", () => {
 
   test("lifts Shiori out of save/click/signup/subscribe/download summaries", () => {
     expect(getActivityRow(rowEvent({ type: "link_saved" }))).toEqual({
-      summary: "Someone saved a link",
+      summary: "Someone saved a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -1774,7 +1888,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Someone clicked a link",
+      summary: "Someone clicked a link on",
       href: "https://www.shiori.sh",
       label: "Shiori",
     });
@@ -1830,7 +1944,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Visit from United States",
+      summary: "Someone from United States viewed",
       href: "https://designdetails.fm",
       label: "Design Details",
     });
@@ -1853,7 +1967,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Visit from Germany",
+      summary: "Someone from Germany viewed",
       href: "/karla-mickens-cole",
       label: "Karla Mickens Cole",
     });
@@ -1911,7 +2025,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Visit from India",
+      summary: "Someone from India read",
       href: "/writing/grok-bot-first-impressions",
       label: "Grok Bot first impressions",
     });

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -736,7 +736,7 @@ describe("recordVisit", () => {
       subject: { kind: "home", label: "Home", href: "/" },
     });
     expect(row).toEqual({
-      summary: "Someone from a mysterious place on earth viewed",
+      summary: "Someone from a mysterious place on earth visited",
       href: "/",
       label: "the site",
     });
@@ -784,7 +784,7 @@ describe("recordVisit", () => {
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "Someone from India viewed the site",
+      summary: "Someone from India visited the site",
     });
     expect(row.summary).not.toMatch(/\p{Regional_Indicator}/u);
   });
@@ -804,7 +804,7 @@ describe("recordVisit", () => {
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "Someone from India viewed the site",
+      summary: "Someone from India visited the site",
     });
   });
 
@@ -1493,7 +1493,7 @@ describe("getActivityRow page titles", () => {
     });
     expect(row.label).toBe("the site");
     expect(row.href).toBe("/");
-    expect(row.summary).toBe("Someone from France viewed");
+    expect(row.summary).toBe("Someone from France visited");
     expect(row.summary).not.toContain("Visit from");
   });
 
@@ -1780,7 +1780,7 @@ describe("getActivityRow visit sentences", () => {
     expect(row.label).toBe("How I'm Feeling About AI in August 2026");
   });
 
-  test("uses viewed for stack and home visits", () => {
+  test("views stack and visits home", () => {
     const stack = getActivityRow(
       visitRowEvent(
         { kind: "stack", label: "Stack", href: "/stack" },
@@ -1799,8 +1799,9 @@ describe("getActivityRow visit sentences", () => {
         { meta: { country: "CN", path: "/", title: "Home" } },
       ),
     );
-    expect(home.summary).toBe("Someone from China viewed");
-    expect(home.summary).toContain("viewed");
+    expect(home.summary).toBe("Someone from China visited");
+    expect(home.summary).toContain("visited");
+    expect(home.summary).not.toContain("read Home");
     expect(home.summary).not.toContain("Visit from");
     expect(home.label).toBe("the site");
     expect(home.label).not.toBe("Home");
@@ -1853,6 +1854,121 @@ describe("getActivityRow visit sentences", () => {
     expect(row.summary).toBe("Someone from China read");
     expect(row.summary).not.toContain("Visit from");
     expect(row.label).toBe("How I'm Feeling About AI in August 2026");
+  });
+
+  test("listens to a Design Details episode and visits the show home", () => {
+    const episode = getActivityRow(
+      visitRowEvent(
+        { kind: "page", label: "On Leaving", href: "/episodes/on-leaving" },
+        {
+          source: "design-details",
+          summary: "🇨🇳 Visit from China",
+          meta: { country: "CN", path: "/episodes/on-leaving", title: "On Leaving" },
+        },
+      ),
+    );
+    expect(episode.summary).toBe("Someone from China listened to");
+    expect(episode.summary).not.toContain("visited");
+    expect(episode.summary).not.toContain("listened to Design Details");
+    expect(episode.summary).not.toContain("Visit from");
+    expect(episode.label).toBe("On Leaving");
+    expect(episode.href).toBe("/episodes/on-leaving");
+
+    const home = getActivityRow(
+      visitRowEvent(
+        { kind: "home", label: "Home", href: "/" },
+        {
+          source: "design-details",
+          summary: "🇨🇳 Visit from China",
+          meta: { country: "CN", path: "/", title: "Home" },
+        },
+      ),
+    );
+    expect(home.summary).toBe("Someone from China visited");
+    expect(home.summary).not.toContain("listened to");
+    expect(home.summary).not.toContain("Visit from");
+    expect(home.label).toBe("Design Details");
+    expect(home.href).toBe("https://designdetails.fm");
+  });
+
+  test("listens to a briOS Design Details episode and visits the index", () => {
+    const episode = getActivityRow(
+      visitRowEvent(
+        { kind: "design_details", label: "On Leaving", href: "/design-details/on-leaving" },
+        { meta: { country: "CN", path: "/design-details/on-leaving" } },
+      ),
+    );
+    expect(episode.summary).toBe("Someone from China listened to");
+    expect(episode.label).toBe("On Leaving Design Details");
+    expect(episode.summary).not.toContain("listened to Design Details");
+
+    const index = getActivityRow(
+      visitRowEvent(
+        { kind: "design_details", label: "Design Details", href: "/design-details" },
+        { meta: { country: "CN", path: "/design-details" } },
+      ),
+    );
+    expect(index.summary).toBe("Someone from China visited");
+    expect(index.summary).not.toContain("listened to");
+    expect(index.label).toBe("Design Details");
+  });
+
+  test("reads a staff.design interview and visits the staff.design home", () => {
+    const interview = getActivityRow(
+      visitRowEvent(
+        { kind: "page", label: "Karla Mickens Cole", href: "/karla-mickens-cole" },
+        {
+          source: "staff-design",
+          summary: "🇩🇪 Visit from Germany",
+          meta: { country: "DE", path: "/karla-mickens-cole", title: "Karla Mickens Cole" },
+        },
+      ),
+    );
+    expect(interview.summary).toBe("Someone from Germany read");
+    expect(interview.summary).not.toContain("visited");
+    expect(interview.summary).not.toContain("Visit from");
+    expect(interview.label).toBe("Karla Mickens Cole");
+
+    const home = getActivityRow(
+      visitRowEvent(
+        { kind: "home", label: "Home", href: "/" },
+        {
+          source: "staff-design",
+          summary: "🇺🇸 Visit from United States",
+          meta: { country: "US", path: "/", title: "Home" },
+        },
+      ),
+    );
+    expect(home.summary).toBe("Someone from United States visited");
+    expect(home.summary).not.toContain("read");
+    expect(home.label).toBe("Staff Design");
+    expect(home.href).toBe("https://staff.design");
+  });
+
+  test("views an app dissection post and visits tax-ui home", () => {
+    const teardown = getActivityRow(
+      visitRowEvent(
+        { kind: "app_dissection", label: "Secret for iOS", href: "/app-dissection/secret-for-ios" },
+        { meta: { country: "FR", path: "/app-dissection/secret-for-ios" } },
+      ),
+    );
+    expect(teardown.summary).toBe("Someone from France viewed");
+    expect(teardown.summary).not.toContain("read");
+    expect(teardown.label).toBe("Secret for iOS App Dissection");
+
+    const taxUi = getActivityRow(
+      visitRowEvent(
+        { kind: "home", label: "Home", href: "/" },
+        {
+          source: "tax-ui",
+          summary: "🇺🇸 Visit from United States",
+          meta: { country: "US", path: "/" },
+        },
+      ),
+    );
+    expect(taxUi.summary).toBe("Someone from United States visited");
+    expect(taxUi.label).toBe("Tax UI");
+    expect(taxUi.href).toBe("https://tax-ui.brianlovin.com/");
   });
 });
 
@@ -1944,7 +2060,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Someone from United States viewed",
+      summary: "Someone from United States visited",
       href: "https://designdetails.fm",
       label: "Design Details",
     });
@@ -1967,7 +2083,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Someone from Germany viewed",
+      summary: "Someone from Germany read",
       href: "/karla-mickens-cole",
       label: "Karla Mickens Cole",
     });

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -76,6 +76,7 @@ export type {
   ActivityVisibility,
   LikeActivityPayload,
   LikeActivityTarget,
+  VisitActivityVerb,
 } from "./activity-shared";
 export {
   ACTIVITY_ENVELOPE_VERSION,
@@ -102,6 +103,7 @@ export {
   formatActivityTitle,
   formatDownloadSummary,
   formatTrackedEventsLabel,
+  formatVisitRowSummary,
   getActivityRow,
   getCaffeineIcon,
   getMergedPullRequestDiff,
@@ -122,6 +124,7 @@ export {
   looksLikeDehyphenatedSlug,
   looksLikeIdentifier,
   looksLikeShortId,
+  MYSTERIOUS_PLACE_LOCATION,
   normalizeCaffeineDrink,
   pathnameFromHref,
   resolveActivitySourceHref,
@@ -130,8 +133,11 @@ export {
   sanitizeVisitTitle,
   shouldLookupCmsPostTitle,
   shouldRecordVisit,
+  SITE_VISIT_LABEL,
   stripSiteTitleSuffix,
   stripTrailingShortIdToken,
+  visitLocationPhrase,
+  visitVerbFromPath,
 } from "./activity-shared";
 
 export type IngestResult =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visit rows on `/activity` now read like something a person did. The verb comes from the **source plus the path they opened**, so the sentence parses out loud.

`Someone from {location} {verb} {title}`

| What they opened | Verb |
|---|---|
| Writing, TIL, HN story, staff.design interview | read |
| Design Details **episode** | listened to |
| Site home (briOS, Design Details index, staff.design, tax-ui) | visited |
| Listing/index on brianlovin.com (stack, sites, `/hn`, AMA, listening, bookmarks, app-dissection index) | viewed |
| App dissection **post** | viewed |
| Download | downloaded |
| Like | liked |
| Shiori save / click | saved / clicked a link on Shiori |
| GitHub / caffeine / digest | unchanged |

Does not say “read Home” or “listened to Design Details” for a marketing home. No usable title → `visited/viewed the site`.

Display-only in `getActivityRow`. Stored Redis summaries stay `Visit from …`. No like +N others popover. No layout changes.

Merged latest `main` (Shiori “on” + rollup chip). The only conflict was two equivalent Shiori test assertions; kept the full `Someone … on` sentence.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c956d1fe-05e1-4d82-ab57-c9e2b9c3f80e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c956d1fe-05e1-4d82-ab57-c9e2b9c3f80e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

