### PR TITLE
Stagger activity feed batch entrances oldest-first

### DIFF
--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -38,7 +38,10 @@ export function activityStackReactKey(stack: Pick<ActivityRollup, "key" | "ancho
 export const ACTIVITY_ENTER_STAGGER_STEP = 0.05;
 export const ACTIVITY_ENTER_STAGGER_MAX = 0.4;
 
-/** Enter delays for keys that were not on screen last paint. First paint (`previous` null) is empty. */
+/**
+ * Enter delays for keys that were not on screen last paint. First paint (`previous` null) is empty.
+ * `keys` is newest-first; the oldest incoming key gets delay 0 so the batch streams in chronologically.
+ */
 export function activityEnterStaggerDelays(
   keys: string[],
   previous: Set<string> | null,
@@ -48,18 +51,18 @@ export function activityEnterStaggerDelays(
   const delays = new Map<string, number>();
   if (!previous) return delays;
 
-  let index = 0;
-  for (const key of keys) {
-    if (previous.has(key)) continue;
-    delays.set(key, Math.min(Number((index * step).toFixed(2)), max));
-    index += 1;
-  }
+  const incoming = keys.filter((key) => !previous.has(key));
+  const last = incoming.length - 1;
+  incoming.forEach((key, index) => {
+    const fromOldest = last - index;
+    delays.set(key, Math.min(Number((fromOldest * step).toFixed(2)), max));
+  });
   return delays;
 }
 
 /**
  * First committed key set is already on screen — no enter delays.
- * Later keys not in `previous` get stagger delays; existing keys do not.
+ * Later keys not in `previous` get oldest-first stagger delays; existing keys do not.
  */
 export function nextActivityEnterState(
   keys: string[],

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -2834,7 +2834,7 @@ describe("rollupActivityEvents", () => {
     expect(stacks[0]?.key).toBe(stacks[2]?.key);
   });
 
-  test("staggers only newly inserted keys, newest first, and caps the delay", () => {
+  test("staggers only newly inserted keys, oldest first, and caps the delay", () => {
     expect(activityEnterStaggerDelays(["a", "b"], null).size).toBe(0);
 
     const previous = new Set(["old-1", "old-2"]);
@@ -2843,18 +2843,19 @@ describe("rollupActivityEvents", () => {
       previous,
     );
     expect([...delays.entries()]).toEqual([
-      ["new-1", 0],
-      ["new-2", 0.05],
+      ["new-1", 0.2],
+      ["new-2", 0.15],
       ["new-3", 0.1],
-      ["new-4", 0.15],
-      ["new-5", 0.2],
+      ["new-4", 0.05],
+      ["new-5", 0],
     ]);
 
     const many = Array.from({ length: 16 }, (_, index) => `n-${index}`);
     const capped = activityEnterStaggerDelays(many, new Set());
-    expect(capped.get("n-0")).toBe(0);
-    expect(capped.get("n-8")).toBe(0.4);
-    expect(capped.get("n-15")).toBe(0.4);
+    expect(capped.get("n-15")).toBe(0);
+    expect(capped.get("n-8")).toBe(0.35);
+    expect(capped.get("n-7")).toBe(0.4);
+    expect(capped.get("n-0")).toBe(0.4);
     expect(capped.has("old-1")).toBe(false);
   });
 
@@ -2873,6 +2874,15 @@ describe("rollupActivityEvents", () => {
     expect(next.delays.has("old-1")).toBe(false);
     expect(next.delays.has("old-2")).toBe(false);
     expect(next.seen).toEqual(new Set(["new-1", "old-1", "old-2"]));
+  });
+
+  test("a batch of new stacks staggers oldest incoming first", () => {
+    const previous = new Set(["old-1"]);
+    const next = nextActivityEnterState(["newest", "middle", "oldest-new", "old-1"], previous);
+    expect(next.delays.get("oldest-new")).toBe(0);
+    expect(next.delays.get("middle")).toBe(0.05);
+    expect(next.delays.get("newest")).toBe(0.1);
+    expect(next.delays.has("old-1")).toBe(false);
   });
 
   test("keeps two public PR merges on the same repo as separate rows", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On `/activity`, when a batch of new events arrives while the feed is already on screen, the **most recent** event animated in first. Older events in the same batch then dropped in below it — the reverse of chronological streaming.

First page load was already instant (no stagger). Existing rows should not re-animate.

## Cause

`activityEnterStaggerDelays` walked the newest-first key list and assigned `index * 0.05s` to unseen keys. Index 0 is the newest row, so it got delay 0.

## Fix

Collect the incoming (unseen) keys, then assign delays from the **oldest** incoming key:

- oldest new row → delay 0
- newest new row → largest delay (still capped at 0.4s)

Existing keys are skipped. First paint (`previous === null`) still returns an empty delay map.

Animation timing and easing are unchanged.

## Test plan

- [x] Unit tests: incoming batch of 5 staggers oldest-first; cap still applies; first paint has no delays; already-visible keys do not get delays (`bun test src/lib/activity.test.ts` — 167 pass)
- [ ] Manual: watch `/activity` while a batch of events arrives — oldest new row should enter first, then newer rows above it

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae1d154e-1310-4666-90aa-559b6ae3f146?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae1d154e-1310-4666-90aa-559b6ae3f146&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

