### PR TITLE
Align activity feed keylines with /stack

### DIFF
--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -29,8 +29,10 @@ function ActivityFallback() {
         <div data-scrollable className="relative min-w-0 flex-1 overflow-auto">
           <div className="divide-secondary divide-y">
             {Array.from({ length: 8 }, (_, index) => (
-              <div key={index} className="flex items-center gap-3 px-4 py-3 md:gap-4">
-                <LoadingSkeleton className="size-6" />
+              <div key={index} className="flex items-center gap-3 px-4 py-3">
+                <div className="flex size-8 flex-none items-center justify-center">
+                  <LoadingSkeleton className="size-6" />
+                </div>
                 <LoadingSkeleton className="h-5 w-2/3" />
               </div>
             ))}

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -206,7 +206,7 @@ export function ActivityRow({
   return (
     <div
       data-rollup-pulse={pulse ? "" : undefined}
-      className="group hover:bg-secondary relative isolate flex items-center gap-3 px-4 py-3 md:gap-4 md:py-2 md:dark:hover:bg-white/5"
+      className="group hover:bg-secondary relative isolate flex items-center gap-3 px-4 py-3 md:py-2 md:dark:hover:bg-white/5"
     >
       {pulse ? (
         <span
@@ -215,42 +215,44 @@ export function ActivityRow({
           className="activity-rollup-pulse pointer-events-none absolute inset-0 z-0"
         />
       ) : null}
-      <div className="relative z-10 flex size-8 shrink-0 items-center justify-center">
-        <ActivityRowIcon event={event} icon={row.icon} />
+      <div className="relative z-10 flex min-w-0 flex-1 items-center gap-3">
+        <div className="flex size-8 flex-none items-center justify-center">
+          <ActivityRowIcon event={event} icon={row.icon} />
+        </div>
+        <p className="flex min-w-0 items-baseline gap-1.5">
+          <span className="min-w-0">
+            <span className="text-primary">{row.summary}</span>
+            {href && context ? (
+              <>
+                {" "}
+                <ActivityContextLink href={href}>{context}</ActivityContextLink>
+              </>
+            ) : context ? (
+              <span className="text-tertiary"> {context}</span>
+            ) : null}
+            {isLike && othersCount > 0 ? (
+              <>
+                {" "}
+                <LikeOthersTooltip targets={likeTargets} otherCount={othersCount} />
+              </>
+            ) : null}
+          </span>
+          {showCountChip ? (
+            <span
+              data-count={count}
+              className="text-tertiary border-secondary shrink-0 -translate-y-[2px] rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
+            >
+              <SlotDigits value={count} />
+            </span>
+          ) : null}
+          {diff ? (
+            <span className="shrink-0 text-sm tabular-nums">
+              <span className="text-green-600">+{diff.additions}</span>{" "}
+              <span className="text-red-500">-{diff.deletions}</span>
+            </span>
+          ) : null}
+        </p>
       </div>
-      <p className="relative z-10 flex min-w-0 items-baseline gap-1.5">
-        <span className="min-w-0">
-          <span className="text-primary">{row.summary}</span>
-          {href && context ? (
-            <>
-              {" "}
-              <ActivityContextLink href={href}>{context}</ActivityContextLink>
-            </>
-          ) : context ? (
-            <span className="text-tertiary"> {context}</span>
-          ) : null}
-          {isLike && othersCount > 0 ? (
-            <>
-              {" "}
-              <LikeOthersTooltip targets={likeTargets} otherCount={othersCount} />
-            </>
-          ) : null}
-        </span>
-        {showCountChip ? (
-          <span
-            data-count={count}
-            className="text-tertiary border-secondary shrink-0 -translate-y-[2px] rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
-          >
-            <SlotDigits value={count} />
-          </span>
-        ) : null}
-        {diff ? (
-          <span className="shrink-0 text-sm tabular-nums">
-            <span className="text-green-600">+{diff.additions}</span>{" "}
-            <span className="text-red-500">-{diff.deletions}</span>
-          </span>
-        ) : null}
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Activity event text sat 4px right of the top-bar breadcrumbs because rows used `md:gap-4` between the icon and the label. `/stack` already lines up: `px-4` + `size-8` icon + `gap-3` puts app names on the same 60px keyline as “Brian Lovin”, and the icon slot shares the menu-button’s right edge.

This reuses that name-column grouping on `/activity` (and the loading skeleton) instead of a one-off desktop gap.

## Testing
- `bun run lint`
- `bun test src/components/ActivityFeed.test.tsx`
- Visual check of `/activity` vs `/stack` keylines against the top bar

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7392eef-0c73-4256-b74a-848c31dee41f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7392eef-0c73-4256-b74a-848c31dee41f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

