### PR TITLE
Pulse arriving activity rows and prefix rollup counts with ×

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -236,7 +236,7 @@
   }
   @keyframes activity-rollup-pulse {
     0%,
-    55% {
+    15% {
       background-color: var(--background-color-secondary);
     }
     100% {
@@ -244,7 +244,7 @@
     }
   }
   .activity-rollup-pulse {
-    animation: activity-rollup-pulse 550ms ease-out forwards;
+    animation: activity-rollup-pulse 1.5s ease-out forwards;
   }
   @media (prefers-reduced-motion: reduce) {
     .activity-rollup-pulse {

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -351,6 +351,19 @@ function pruneEnterDelays(delays: Map<string, number>, liveKeys: Set<string>): M
   return changed ? next : delays;
 }
 
+function mergeEnterDelays(
+  current: Map<string, number>,
+  pending: Map<string, number>,
+  liveKeys: Set<string>,
+): Map<string, number> {
+  let next = current;
+  if (pending.size > 0) {
+    next = new Map(current);
+    for (const [key, delay] of pending) next.set(key, delay);
+  }
+  return pruneEnterDelays(next, liveKeys);
+}
+
 function ActivityStackList({
   stacks,
   pulseKey,
@@ -366,19 +379,12 @@ function ActivityStackList({
   const [seenKeys, setSeenKeys] = useState<Set<string> | null>(null);
   const [enterDelays, setEnterDelays] = useState<Map<string, number>>(() => new Map());
   const { seen, delays: pending } = nextActivityEnterState(keys, seenKeys);
-  const enterPulseKeys = useEnterPulseKeys(canAnimate ? [...pending.keys()] : [], canAnimate);
+  const nextDelays = mergeEnterDelays(enterDelays, pending, liveKeys);
+  const enterPulseKeys = useEnterPulseKeys(canAnimate ? [...nextDelays.keys()] : [], canAnimate);
 
   let nextSeen = seen;
-  let nextDelays = enterDelays;
-
-  if (pending.size > 0) {
-    nextDelays = new Map(enterDelays);
-    for (const [key, delay] of pending) nextDelays.set(key, delay);
-  }
-
   const prunedSeen = new Set([...nextSeen].filter((key) => liveKeys.has(key)));
   if (prunedSeen.size !== nextSeen.size) nextSeen = prunedSeen;
-  nextDelays = pruneEnterDelays(nextDelays, liveKeys);
 
   if (nextSeen !== seenKeys) setSeenKeys(nextSeen);
   if (nextDelays !== enterDelays) setEnterDelays(nextDelays);

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
-import { type ReactNode, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 
 import { Activity } from "@/components/icons/Activity";
 import { Github } from "@/components/icons/Github";
@@ -241,7 +241,7 @@ export function ActivityRow({
             data-count={count}
             className="text-tertiary border-secondary shrink-0 -translate-y-[2px] rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
           >
-            <SlotDigits value={count} />
+            ×<SlotDigits value={count} />
           </span>
         ) : null}
         {diff ? (
@@ -282,8 +282,52 @@ export function ActivityTrackedCount({ count }: { count: number }) {
   );
 }
 
-const ROLLUP_PULSE_MS = 550;
+const ROLLUP_PULSE_MS = 1500;
 const LIST_MOTION = { duration: 0.14, ease: [0.2, 0, 0, 1] } as const;
+
+function useEnterPulseKeys(incoming: string[], enabled: boolean): Set<string> {
+  const [keys, setKeys] = useState<Set<string>>(() => new Set());
+  const timersRef = useRef<Map<string, number>>(new Map());
+
+  let next = keys;
+  if (enabled && incoming.length > 0) {
+    const merged = new Set(keys);
+    let added = false;
+    for (const key of incoming) {
+      if (!merged.has(key)) {
+        merged.add(key);
+        added = true;
+      }
+    }
+    if (added) next = merged;
+  }
+  if (next !== keys) setKeys(next);
+
+  useEffect(() => {
+    for (const key of next) {
+      if (timersRef.current.has(key)) continue;
+      const timeout = window.setTimeout(() => {
+        timersRef.current.delete(key);
+        setKeys((current) => {
+          if (!current.has(key)) return current;
+          const remaining = new Set(current);
+          remaining.delete(key);
+          return remaining;
+        });
+      }, ROLLUP_PULSE_MS);
+      timersRef.current.set(key, timeout);
+    }
+  }, [next]);
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const id of timers.values()) window.clearTimeout(id);
+    };
+  }, []);
+
+  return next;
+}
 
 function subscribeNoop(): () => void {
   return () => {};
@@ -321,8 +365,9 @@ function ActivityStackList({
   const liveKeys = new Set(keys);
   const [seenKeys, setSeenKeys] = useState<Set<string> | null>(null);
   const [enterDelays, setEnterDelays] = useState<Map<string, number>>(() => new Map());
-
   const { seen, delays: pending } = nextActivityEnterState(keys, seenKeys);
+  const enterPulseKeys = useEnterPulseKeys(canAnimate ? [...pending.keys()] : [], canAnimate);
+
   let nextSeen = seen;
   let nextDelays = enterDelays;
 
@@ -369,7 +414,7 @@ function ActivityStackList({
                 sectionLabel={stack.sectionLabel}
                 href={stack.href}
                 likeTargets={stack.likeTargets}
-                pulse={pulseKey === reactKey}
+                pulse={pulseKey === reactKey || enterPulseKeys.has(reactKey)}
               />
             </motion.div>
           );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two small `/activity` feed visual tweaks.

## Rollup count badge
Stacked-event chips now read as `×12` instead of `12`, so the badge is clearly “that event times N”. Same chip styling and 2px nudge; rollup math is unchanged.

## Enter pulse
Previously only incrementing rollups flashed. New rows that animate in while you are watching now get the same secondary-background pulse, fading to transparent over 1.5s.

- First page load still insta-loads with no stagger and no pulse
- Incrementing an existing rollup still pulses
- Rows already on screen do not re-pulse
- Reduced motion still skips the animation

Uses the existing `activity-rollup-pulse` overlay; the fade is lengthened from 550ms to 1.5s so enter and increment feel the same.

Merged latest `main` (oldest-first enter stagger and `/stack` keyline alignment). The only conflict was a duplicate `ActivityRow` body: kept main’s layout and the `×` prefix.

[Activity feed rollup chips showing ×N](https://cursor.com/agents/bc-c22a6bea-0869-46ba-8305-48005ed4dd8a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_feed_times_badges_closeup.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c22a6bea-0869-46ba-8305-48005ed4dd8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c22a6bea-0869-46ba-8305-48005ed4dd8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

