### PR TITLE
Stop recording /dev and asset-like activity visits

### DIFF
--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -250,6 +250,8 @@ export function isActivityPath(pathname: string): boolean {
 }
 
 const CRAWLER_PROBE_PATHS = new Set(["/robots.txt", "/sitemap.xml", "/favicon.ico"]);
+const VISIT_ASSET_EXTENSION_RE =
+  /\.(?:png|svg|ico|jpg|jpeg|webp|gif|txt|xml|json|map|css|js|woff2?)$/i;
 
 function isCrawlerProbePath(pathname: string): boolean {
   if (CRAWLER_PROBE_PATHS.has(pathname)) return true;
@@ -257,12 +259,20 @@ function isCrawlerProbePath(pathname: string): boolean {
   return pathname === "/.well-known" || pathname.startsWith("/.well-known/");
 }
 
+function isDevPath(pathname: string): boolean {
+  return pathname === "/dev" || pathname.startsWith("/dev/");
+}
+
+function isAssetLikePath(pathname: string): boolean {
+  return VISIT_ASSET_EXTENSION_RE.test(pathname);
+}
+
 export function shouldRecordVisit(pathname: string): boolean {
   const path = pathname.split("?")[0] ?? pathname;
   if (!path || path.startsWith("/api/") || path.startsWith("/_next/")) {
     return false;
   }
-  if (isCrawlerProbePath(path)) {
+  if (isDevPath(path) || isAssetLikePath(path) || isCrawlerProbePath(path)) {
     return false;
   }
   return !isActivityPath(path);

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -2358,6 +2358,13 @@ describe("shouldRecordVisit / likeMetaFromRequest", () => {
     expect(shouldRecordVisit("/.well-known/security.txt")).toBe(false);
   });
 
+  test("skips /dev routes and still records real pages", () => {
+    expect(shouldRecordVisit("/dev/staff-icon")).toBe(false);
+    expect(shouldRecordVisit("/dev")).toBe(false);
+    expect(shouldRecordVisit("/favicon.ico")).toBe(false);
+    expect(shouldRecordVisit("/writing/something")).toBe(true);
+  });
+
   test("builds like meta from the referer and skips /activity", () => {
     const writing = likeMetaFromRequest(
       new Request("https://brianlovin.com/api/likes/1", {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visit ingest was recording guessed internal paths like `/dev/staff-icon` (a 404) as human page views. That showed up in the activity feed as “someone viewed staff icon.”

`shouldRecordVisit` already dropped `/api/`, `/_next/`, `/activity`, crawler probes, and `/.well-known`. It did not drop `/dev/*` or generic asset/file paths.

## Change
- Ignore `/dev` and anything under `/dev/`.
- Ignore file-like paths with extensions such as `.png`, `.svg`, `.ico`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.txt`, `.xml`, `.json`, `.map`, `.css`, `.js`, `.woff`, `.woff2`.
- Keep the existing ignores.
- Client visit pings already go through the same helper, so they stay in sync.

## Tests
Added ingest assertions:
- `/dev/staff-icon` → false
- `/dev` → false
- `/favicon.ico` still false
- `/writing/something` still true

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97243630-385c-4c74-863a-d1a66e54f55d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97243630-385c-4c74-863a-d1a66e54f55d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

