### PR TITLE
Aim the activity globe from row clicks and give markers depth

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -253,27 +253,23 @@
   }
   .activity-globe-orb {
     position: absolute;
-    left: anchor(center);
-    top: anchor(center);
-    translate: -50% -50%;
+    left: 0;
+    top: 0;
+    z-index: 1;
     pointer-events: none;
-    width: 0.75rem;
-    height: 0.75rem;
+    width: 0.875rem;
+    height: 0.875rem;
     border-radius: 9999px;
-    background: radial-gradient(circle at 32% 28%, #ffd0c0 0%, #fc532a 46%, #7a1a0c 100%);
+    background: radial-gradient(circle at 30% 26%, #ffe0d4 0%, #fc532a 48%, #6a1408 100%);
     box-shadow:
-      0 0 10px rgba(252, 83, 42, 0.5),
-      0 1px 2px rgba(0, 0, 0, 0.28),
-      inset 0 -1px 2px rgba(80, 10, 0, 0.45);
-    opacity: calc(0.16 + var(--orb-facing, 0) * 0.84);
-    transform: scale(calc(0.36 + var(--orb-facing, 0) * 0.74));
-    filter: blur(calc((1 - var(--orb-facing, 0)) * 1.25px));
-    will-change: opacity, transform, filter;
-  }
-  @supports not (anchor-name: --x) {
-    .activity-globe-orb {
-      display: none;
-    }
+      0 0 12px rgba(252, 83, 42, 0.55),
+      0 1px 2px rgba(0, 0, 0, 0.3),
+      inset 0 -2px 3px rgba(60, 8, 0, 0.5),
+      inset 0 1px 2px rgba(255, 255, 255, 0.35);
+    opacity: calc(0.12 + var(--orb-facing, 0) * 0.88);
+    transform: translate(-50%, -50%) scale(calc(0.32 + var(--orb-facing, 0) * 0.78));
+    filter: blur(calc((1 - var(--orb-facing, 0)) * 1.4px));
+    will-change: left, top, opacity, transform, filter;
   }
   @keyframes zoom-in {
     from {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -251,6 +251,30 @@
       animation: none;
     }
   }
+  .activity-globe-orb {
+    position: absolute;
+    left: anchor(center);
+    top: anchor(center);
+    translate: -50% -50%;
+    pointer-events: none;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 9999px;
+    background: radial-gradient(circle at 32% 28%, #ffd0c0 0%, #fc532a 46%, #7a1a0c 100%);
+    box-shadow:
+      0 0 10px rgba(252, 83, 42, 0.5),
+      0 1px 2px rgba(0, 0, 0, 0.28),
+      inset 0 -1px 2px rgba(80, 10, 0, 0.45);
+    opacity: calc(0.16 + var(--orb-facing, 0) * 0.84);
+    transform: scale(calc(0.36 + var(--orb-facing, 0) * 0.74));
+    filter: blur(calc((1 - var(--orb-facing, 0)) * 1.25px));
+    will-change: opacity, transform, filter;
+  }
+  @supports not (anchor-name: --x) {
+    .activity-globe-orb {
+      display: none;
+    }
+  }
   @keyframes zoom-in {
     from {
       transform: scale(0.95);

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -2,9 +2,17 @@
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
-import { type ReactNode, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
-import { ActivityGlobe } from "@/components/ActivityGlobe";
+import { ActivityGlobe, type ActivityGlobeAimRequest } from "@/components/ActivityGlobe";
 import { Activity } from "@/components/icons/Activity";
 import { Github } from "@/components/icons/Github";
 import { Heart } from "@/components/icons/Heart";
@@ -15,7 +23,12 @@ import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { SlotDigits } from "@/components/SlotDigits";
 import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
-import type { ActivityEvent, ActivityLikeTarget, ActivityRollup } from "@/lib/activity";
+import {
+  type ActivityEvent,
+  activityEventLocation,
+  type ActivityLikeTarget,
+  type ActivityRollup,
+} from "@/lib/activity";
 import {
   activityStackReactKey,
   nextActivityEnterState,
@@ -33,6 +46,7 @@ import {
   resolveActivitySourceHref,
 } from "@/lib/activity-shared";
 import { useActivity } from "@/lib/hooks/useActivity";
+import { cn } from "@/lib/utils";
 
 function ActivitySourceFavicon({ src }: { src: string }) {
   const [failed, setFailed] = useState(false);
@@ -178,6 +192,7 @@ export function ActivityRow({
   href: hrefOverride,
   pulse = false,
   likeTargets: likeTargetsProp,
+  onAimGlobe,
 }: {
   event: ActivityEvent;
   count?: number;
@@ -185,6 +200,7 @@ export function ActivityRow({
   href?: string;
   pulse?: boolean;
   likeTargets?: ActivityLikeTarget[];
+  onAimGlobe?: (event: ActivityEvent) => void;
 }) {
   const row = getActivityRow(event);
   const homeUrl = activitySourceUrl(event.source);
@@ -202,6 +218,7 @@ export function ActivityRow({
   const context = isLike ? likeTitle : (label ?? (href || undefined));
   const diff = event.type === "pr_merged" ? getMergedPullRequestDiff(event.meta) : null;
   const showCountChip = count > 1 && !(isLike && othersCount > 0);
+  const canAimGlobe = Boolean(onAimGlobe && activityEventLocation(event));
 
   if (isLike && likeTargets.length === 0) {
     return null;
@@ -210,7 +227,18 @@ export function ActivityRow({
   return (
     <div
       data-rollup-pulse={pulse ? "" : undefined}
-      className="group hover:bg-secondary relative isolate flex items-center gap-3 px-4 py-3 md:py-2 md:dark:hover:bg-white/5"
+      className={cn(
+        "group hover:bg-secondary relative isolate flex items-center gap-3 px-4 py-3 md:py-2 md:dark:hover:bg-white/5",
+        canAimGlobe && "cursor-pointer",
+      )}
+      onClick={
+        canAimGlobe
+          ? (click) => {
+              if (click.target instanceof Element && click.target.closest("a")) return;
+              onAimGlobe?.(event);
+            }
+          : undefined
+      }
     >
       {pulse ? (
         <span
@@ -373,9 +401,11 @@ function mergeEnterDelays(
 function ActivityStackList({
   stacks,
   pulseKey,
+  onAimGlobe,
 }: {
   stacks: ActivityRollup[];
   pulseKey: string | null;
+  onAimGlobe?: (event: ActivityEvent) => void;
 }) {
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
@@ -427,6 +457,7 @@ function ActivityStackList({
                 href={stack.href}
                 likeTargets={stack.likeTargets}
                 pulse={pulseKey === reactKey || enterPulseKeys.has(reactKey)}
+                onAimGlobe={onAimGlobe}
               />
             </motion.div>
           );
@@ -475,6 +506,12 @@ export function ActivityFeed({
   const { events, count } = useActivity(initialEvents, initialCount);
   const stacks = useMemo(() => rollupActivityEvents(events), [events]);
   const pulseKey = useRollupPulse(stacks);
+  const [globeAim, setGlobeAim] = useState<ActivityGlobeAimRequest | null>(null);
+  const handleAimGlobe = useCallback((event: ActivityEvent) => {
+    const location = activityEventLocation(event);
+    if (!location) return;
+    setGlobeAim((current) => ({ location, nonce: (current?.nonce ?? 0) + 1 }));
+  }, []);
 
   const topBarContent = useMemo(() => <ActivityTrackedCount count={count} />, [count]);
   useTopBarActions(topBarContent);
@@ -489,14 +526,14 @@ export function ActivityFeed({
             </p>
           ) : (
             <>
-              <ActivityStackList stacks={stacks} pulseKey={pulseKey} />
+              <ActivityStackList stacks={stacks} pulseKey={pulseKey} onAimGlobe={handleAimGlobe} />
               <p className="text-tertiary p-32 text-center text-sm">
                 Older activity is dust in the wind...
               </p>
             </>
           )}
         </div>
-        <ActivityGlobe events={events} />
+        <ActivityGlobe events={events} aim={globeAim} />
       </div>
     </ListDetailWrapper>
   );

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -2,25 +2,49 @@
 
 import createGlobe from "cobe";
 import { useReducedMotion } from "motion/react";
-import { type RefObject, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 
 import type { ActivityEvent } from "@/lib/activity";
-import { activityGlobeMarkers } from "@/lib/activity-geo";
+import { activityGlobeMarkers, type ActivityLatLng } from "@/lib/activity-geo";
+import {
+  globeDiameterFromHeight,
+  globeMarkerFacing,
+  latLngToGlobePose,
+  shortestAngleDelta,
+} from "@/lib/activity-globe";
 import { cn } from "@/lib/utils";
 
-const GLOBE_SIZE = 480;
 const IDLE_SPIN = 0.003;
 const VELOCITY_EASE = 0.035;
 const DRAG_ANGLE_SCALE = 0.005;
 const DRAG_THRESHOLD_PX = 6;
 const THETA_LIMIT = Math.PI / 2 - 0.08;
 const MIN_FEED_WIDTH = 720;
+const MARKER_ELEVATION = 0.03;
+const AIM_MS_MIN = 600;
+const AIM_MS_MAX = 850;
+const HANG_RIGHT = 0.333;
+const HANG_BOTTOM = 0.367;
 
 const MARKER_COLOR: [number, number, number] = [252 / 255, 83 / 255, 42 / 255];
 const LIGHT_BASE: [number, number, number] = [1, 1, 1];
 const LIGHT_GLOW: [number, number, number] = [0.95, 0.95, 0.95];
 const DARK_BASE: [number, number, number] = [0.3, 0.3, 0.3];
 const DARK_GLOW: [number, number, number] = [0.12, 0.12, 0.12];
+
+export type ActivityGlobeAimRequest = {
+  location: ActivityLatLng;
+  nonce: number;
+};
+
+type AimState = {
+  fromPhi: number;
+  fromTheta: number;
+  dPhi: number;
+  dTheta: number;
+  start: number;
+  duration: number;
+};
 
 function subscribeDark(onChange: () => void): () => void {
   const observer = new MutationObserver(onChange);
@@ -36,28 +60,22 @@ function useIsDark(): boolean {
   return useSyncExternalStore(subscribeDark, isDarkClass, () => false);
 }
 
-function useFeedHasRoom(hostRef: RefObject<HTMLDivElement | null>): boolean {
-  const [hasRoom, setHasRoom] = useState(true);
-
-  useEffect(() => {
-    const host = hostRef.current?.parentElement;
-    if (!host) return;
-
-    const update = () => {
-      setHasRoom(host.clientWidth >= MIN_FEED_WIDTH);
-    };
-    update();
-
-    const observer = new ResizeObserver(update);
-    observer.observe(host);
-    return () => observer.disconnect();
-  }, [hostRef]);
-
-  return hasRoom;
-}
-
 function clampTheta(value: number): number {
   return Math.min(THETA_LIMIT, Math.max(-THETA_LIMIT, value));
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - (1 - t) ** 3;
+}
+
+function readPaneSize(host: HTMLElement | null): { hasRoom: boolean; size: number } {
+  const width =
+    host?.clientWidth ?? (typeof window === "undefined" ? MIN_FEED_WIDTH : window.innerWidth);
+  const height = host?.clientHeight || (typeof window === "undefined" ? 960 : window.innerHeight);
+  return {
+    hasRoom: width >= MIN_FEED_WIDTH,
+    size: globeDiameterFromHeight(height),
+  };
 }
 
 function scrollFeedFromOverlay(overlay: HTMLElement, deltaY: number): void {
@@ -67,27 +85,37 @@ function scrollFeedFromOverlay(overlay: HTMLElement, deltaY: number): void {
   }
 }
 
-export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
+export function ActivityGlobe({
+  events,
+  aim,
+}: {
+  events: ActivityEvent[];
+  aim?: ActivityGlobeAimRequest | null;
+}) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const globeRef = useRef<ReturnType<typeof createGlobe> | null>(null);
   const phiRef = useRef(0);
   const thetaRef = useRef(0.22);
   const velocityRef = useRef(IDLE_SPIN);
   const thetaVelocityRef = useRef(0);
   const draggingRef = useRef(false);
   const pendingRef = useRef(false);
+  const aimingRef = useRef<AimState | null>(null);
   const lastXRef = useRef(0);
   const lastYRef = useRef(0);
   const lastTRef = useRef(0);
+  const orbElsRef = useRef(new Map<string, HTMLDivElement>());
   const isDark = useIsDark();
   const prefersReducedMotion = useReducedMotion() === true;
-  const hasRoom = useFeedHasRoom(overlayRef);
+  const [layout, setLayout] = useState(() => readPaneSize(null));
   const [grabbing, setGrabbing] = useState(false);
 
   const markers = useMemo(() => activityGlobeMarkers(events), [events]);
   const markersRef = useRef(markers);
   const themeRef = useRef({ isDark, prefersReducedMotion });
+  const sizeRef = useRef(layout.size);
 
   useEffect(() => {
     markersRef.current = markers;
@@ -98,12 +126,76 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
   }, [isDark, prefersReducedMotion]);
 
   useEffect(() => {
+    sizeRef.current = layout.size;
+  }, [layout.size]);
+
+  useEffect(() => {
+    const host = overlayRef.current?.parentElement;
+    if (!host) return;
+
+    const update = () => {
+      setLayout(readPaneSize(host));
+    };
+    update();
+
+    const observer = new ResizeObserver(update);
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
     if (prefersReducedMotion) {
       velocityRef.current = 0;
-    } else if (!draggingRef.current) {
+      aimingRef.current = null;
+    } else if (!draggingRef.current && !aimingRef.current) {
       velocityRef.current = IDLE_SPIN;
     }
   }, [prefersReducedMotion]);
+
+  const applyOrbFacing = useCallback(() => {
+    const phi = phiRef.current;
+    const theta = thetaRef.current;
+    for (const marker of markersRef.current) {
+      const el = orbElsRef.current.get(marker.id);
+      if (!el) continue;
+      const facing = globeMarkerFacing(marker.location[0], marker.location[1], phi, theta);
+      el.style.setProperty("--orb-facing", facing.toFixed(3));
+    }
+  }, []);
+
+  const aimAt = useCallback<ActivityGlobeAim>(
+    (location) => {
+      const pose = latLngToGlobePose(location.lat, location.lng);
+      const dPhi = shortestAngleDelta(phiRef.current, pose.phi);
+      const dTheta = clampTheta(pose.theta) - thetaRef.current;
+      velocityRef.current = 0;
+      thetaVelocityRef.current = 0;
+
+      if (themeRef.current.prefersReducedMotion) {
+        aimingRef.current = null;
+        phiRef.current += dPhi;
+        thetaRef.current = clampTheta(pose.theta);
+        applyOrbFacing();
+        return;
+      }
+
+      const distance = Math.hypot(dPhi, dTheta);
+      aimingRef.current = {
+        fromPhi: phiRef.current,
+        fromTheta: thetaRef.current,
+        dPhi,
+        dTheta,
+        start: performance.now(),
+        duration: Math.round(AIM_MS_MIN + Math.min(AIM_MS_MAX - AIM_MS_MIN, distance * 180)),
+      };
+    },
+    [applyOrbFacing],
+  );
+
+  useEffect(() => {
+    if (!aim) return;
+    aimAt(aim.location);
+  }, [aim, aimAt]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -112,10 +204,11 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
 
     const dpr = Math.min(2, window.devicePixelRatio || 1);
     const dark = themeRef.current.isDark;
+    const size = sizeRef.current;
     const globe = createGlobe(canvas, {
       devicePixelRatio: dpr,
-      width: GLOBE_SIZE,
-      height: GLOBE_SIZE,
+      width: size,
+      height: size,
       phi: phiRef.current,
       theta: thetaRef.current,
       dark: dark ? 1 : 0,
@@ -126,13 +219,28 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
       markerColor: MARKER_COLOR,
       glowColor: dark ? DARK_GLOW : LIGHT_GLOW,
       markers: markersRef.current,
+      markerElevation: MARKER_ELEVATION,
       scale: 1,
       offset: [0, 0],
     });
+    globeRef.current = globe;
+
     let frame = 0;
     const onRender = () => {
       const { isDark: nextDark, prefersReducedMotion: reduced } = themeRef.current;
-      if (!draggingRef.current) {
+      const aim = aimingRef.current;
+
+      if (aim) {
+        const t = Math.min(1, (performance.now() - aim.start) / aim.duration);
+        const eased = easeOutCubic(t);
+        phiRef.current = aim.fromPhi + aim.dPhi * eased;
+        thetaRef.current = clampTheta(aim.fromTheta + aim.dTheta * eased);
+        if (t >= 1) {
+          aimingRef.current = null;
+          velocityRef.current = reduced ? 0 : IDLE_SPIN;
+          thetaVelocityRef.current = 0;
+        }
+      } else if (!draggingRef.current) {
         if (reduced) {
           velocityRef.current = 0;
           thetaVelocityRef.current = 0;
@@ -153,12 +261,14 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
         baseColor: nextDark ? DARK_BASE : LIGHT_BASE,
         glowColor: nextDark ? DARK_GLOW : LIGHT_GLOW,
       });
+      applyOrbFacing();
       frame = window.requestAnimationFrame(onRender);
     };
     frame = window.requestAnimationFrame(onRender);
 
     return () => {
       window.cancelAnimationFrame(frame);
+      globeRef.current = null;
       globe.destroy();
       if (wrap && canvas.parentElement && canvas.parentElement !== wrap) {
         const extra = canvas.parentElement;
@@ -166,9 +276,14 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
         extra.remove();
       }
     };
-  }, []);
+  }, [applyOrbFacing]);
+
+  useEffect(() => {
+    globeRef.current?.update({ width: layout.size, height: layout.size });
+  }, [layout.size]);
 
   function beginDrag(clientX: number, clientY: number): void {
+    aimingRef.current = null;
     draggingRef.current = true;
     pendingRef.current = false;
     lastXRef.current = clientX;
@@ -209,10 +324,16 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
     }
   }
 
+  const hangRight = Math.round(layout.size * HANG_RIGHT);
+  const hangBottom = Math.round(layout.size * HANG_BOTTOM);
+
   return (
     <div
       ref={overlayRef}
-      className={cn("pointer-events-none absolute inset-0 z-10 hidden", hasRoom && "lg:block")}
+      className={cn(
+        "pointer-events-none absolute inset-0 z-10 hidden",
+        layout.hasRoom && "lg:block",
+      )}
       aria-hidden
     >
       <div
@@ -221,11 +342,20 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
           "dark:bg-[radial-gradient(ellipse_100%_90%_at_100%_100%,#000_0%,#000_32%,transparent_72%)]",
         )}
       />
-      <div ref={wrapRef} className="absolute -right-40 -bottom-44 size-[480px]">
+      <div
+        ref={wrapRef}
+        className="absolute"
+        style={{
+          width: layout.size,
+          height: layout.size,
+          right: -hangRight,
+          bottom: -hangBottom,
+        }}
+      >
         <canvas
           ref={canvasRef}
-          width={GLOBE_SIZE * 2}
-          height={GLOBE_SIZE * 2}
+          width={layout.size * 2}
+          height={layout.size * 2}
           className={cn(
             "pointer-events-auto size-full touch-none select-none",
             grabbing ? "cursor-grabbing" : "cursor-grab",
@@ -263,6 +393,21 @@ export function ActivityGlobe({ events }: { events: ActivityEvent[] }) {
           onPointerUp={endDrag}
           onPointerCancel={endDrag}
         />
+        {markers.map((marker) => (
+          <div
+            key={marker.id}
+            ref={(node) => {
+              if (node) orbElsRef.current.set(marker.id, node);
+              else orbElsRef.current.delete(marker.id);
+            }}
+            className="activity-globe-orb"
+            style={{
+              positionAnchor: `--cobe-${marker.id}`,
+              // COBE 2.0.1 sets this to "N" when facing (invalid → visible) and unsets it behind.
+              visibility: `var(--cobe-visible-${marker.id}, hidden)`,
+            }}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -163,8 +163,8 @@ export function ActivityGlobe({
     }
   }, []);
 
-  const aimAt = useCallback<ActivityGlobeAim>(
-    (location) => {
+  const aimAt = useCallback(
+    (location: ActivityLatLng) => {
       const pose = latLngToGlobePose(location.lat, location.lng);
       const dPhi = shortestAngleDelta(phiRef.current, pose.phi);
       const dTheta = clampTheta(pose.theta) - thetaRef.current;
@@ -397,15 +397,16 @@ export function ActivityGlobe({
           <div
             key={marker.id}
             ref={(node) => {
-              if (node) orbElsRef.current.set(marker.id, node);
-              else orbElsRef.current.delete(marker.id);
+              if (node) {
+                orbElsRef.current.set(marker.id, node);
+                node.style.setProperty("position-anchor", `--cobe-${marker.id}`);
+                // COBE 2.0.1 sets this to "N" when facing (invalid → visible) and unsets it behind.
+                node.style.setProperty("visibility", `var(--cobe-visible-${marker.id}, hidden)`);
+              } else {
+                orbElsRef.current.delete(marker.id);
+              }
             }}
             className="activity-globe-orb"
-            style={{
-              positionAnchor: `--cobe-${marker.id}`,
-              // COBE 2.0.1 sets this to "N" when facing (invalid → visible) and unsets it behind.
-              visibility: `var(--cobe-visible-${marker.id}, hidden)`,
-            }}
           />
         ))}
       </div>

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -7,9 +7,10 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import type { ActivityEvent } from "@/lib/activity";
 import { activityGlobeMarkers, type ActivityLatLng } from "@/lib/activity-geo";
 import {
+  GLOBE_MARKER_ELEVATION,
   globeDiameterFromHeight,
-  globeMarkerFacing,
   latLngToGlobePose,
+  projectGlobeMarker,
   shortestAngleDelta,
 } from "@/lib/activity-globe";
 import { cn } from "@/lib/utils";
@@ -20,7 +21,6 @@ const DRAG_ANGLE_SCALE = 0.005;
 const DRAG_THRESHOLD_PX = 6;
 const THETA_LIMIT = Math.PI / 2 - 0.08;
 const MIN_FEED_WIDTH = 720;
-const MARKER_ELEVATION = 0.03;
 const AIM_MS_MIN = 600;
 const AIM_MS_MAX = 850;
 const HANG_RIGHT = 0.333;
@@ -158,8 +158,16 @@ export function ActivityGlobe({
     for (const marker of markersRef.current) {
       const el = orbElsRef.current.get(marker.id);
       if (!el) continue;
-      const facing = globeMarkerFacing(marker.location[0], marker.location[1], phi, theta);
-      el.style.setProperty("--orb-facing", facing.toFixed(3));
+      const projected = projectGlobeMarker(
+        marker.location[0],
+        marker.location[1],
+        phi,
+        theta,
+        GLOBE_MARKER_ELEVATION,
+      );
+      el.style.left = `${(projected.x * 100).toFixed(3)}%`;
+      el.style.top = `${(projected.y * 100).toFixed(3)}%`;
+      el.style.setProperty("--orb-facing", projected.facing.toFixed(3));
     }
   }, []);
 
@@ -219,7 +227,7 @@ export function ActivityGlobe({
       markerColor: MARKER_COLOR,
       glowColor: dark ? DARK_GLOW : LIGHT_GLOW,
       markers: markersRef.current,
-      markerElevation: MARKER_ELEVATION,
+      markerElevation: GLOBE_MARKER_ELEVATION,
       scale: 1,
       offset: [0, 0],
     });
@@ -400,8 +408,6 @@ export function ActivityGlobe({
               if (node) {
                 orbElsRef.current.set(marker.id, node);
                 node.style.setProperty("position-anchor", `--cobe-${marker.id}`);
-                // COBE 2.0.1 sets this to "N" when facing (invalid → visible) and unsets it behind.
-                node.style.setProperty("visibility", `var(--cobe-visible-${marker.id}, hidden)`);
               } else {
                 orbElsRef.current.delete(marker.id);
               }

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import type { ActivityEvent } from "@/lib/activity";
 import { activityGlobeMarkers, type ActivityLatLng } from "@/lib/activity-geo";
 import {
+  GLOBE_HANG,
   GLOBE_MARKER_ELEVATION,
   globeDiameterFromHeight,
   latLngToGlobePose,
@@ -23,8 +24,6 @@ const THETA_LIMIT = Math.PI / 2 - 0.08;
 const MIN_FEED_WIDTH = 720;
 const AIM_MS_MIN = 600;
 const AIM_MS_MAX = 850;
-const HANG_RIGHT = 0.333;
-const HANG_BOTTOM = 0.367;
 
 const MARKER_COLOR: [number, number, number] = [252 / 255, 83 / 255, 42 / 255];
 const LIGHT_BASE: [number, number, number] = [1, 1, 1];
@@ -68,13 +67,18 @@ function easeOutCubic(t: number): number {
   return 1 - (1 - t) ** 3;
 }
 
+function paneHeight(host: HTMLElement | null): number {
+  const windowHeight = typeof window === "undefined" ? 960 : window.innerHeight;
+  const hostHeight = host?.clientHeight ?? 0;
+  return Math.max(hostHeight, windowHeight);
+}
+
 function readPaneSize(host: HTMLElement | null): { hasRoom: boolean; size: number } {
   const width =
-    host?.clientWidth ?? (typeof window === "undefined" ? MIN_FEED_WIDTH : window.innerWidth);
-  const height = host?.clientHeight || (typeof window === "undefined" ? 960 : window.innerHeight);
+    host?.clientWidth || (typeof window === "undefined" ? MIN_FEED_WIDTH : window.innerWidth);
   return {
     hasRoom: width >= MIN_FEED_WIDTH,
-    size: globeDiameterFromHeight(height),
+    size: globeDiameterFromHeight(paneHeight(host)),
   };
 }
 
@@ -131,16 +135,18 @@ export function ActivityGlobe({
 
   useEffect(() => {
     const host = overlayRef.current?.parentElement;
-    if (!host) return;
-
     const update = () => {
-      setLayout(readPaneSize(host));
+      setLayout(readPaneSize(host ?? overlayRef.current?.parentElement ?? null));
     };
     update();
 
     const observer = new ResizeObserver(update);
-    observer.observe(host);
-    return () => observer.disconnect();
+    if (host) observer.observe(host);
+    window.addEventListener("resize", update);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", update);
+    };
   }, []);
 
   useEffect(() => {
@@ -332,8 +338,7 @@ export function ActivityGlobe({
     }
   }
 
-  const hangRight = Math.round(layout.size * HANG_RIGHT);
-  const hangBottom = Math.round(layout.size * HANG_BOTTOM);
+  const hang = Math.round(layout.size * GLOBE_HANG);
 
   return (
     <div
@@ -356,8 +361,8 @@ export function ActivityGlobe({
         style={{
           width: layout.size,
           height: layout.size,
-          right: -hangRight,
-          bottom: -hangBottom,
+          right: -hang,
+          bottom: -hang,
         }}
       >
         <canvas

--- a/src/lib/activity-geo.ts
+++ b/src/lib/activity-geo.ts
@@ -42,9 +42,17 @@ export type ActivityLatLng = {
 };
 
 export type ActivityGlobeMarker = {
+  id: string;
   location: [number, number];
   size: number;
 };
+
+/** Stable CSS-safe id for COBE bindable markers (`--cobe-{id}`). */
+export function activityGlobeMarkerId(lat: number, lng: number): string {
+  const encode = (value: number): string =>
+    value.toFixed(1).replaceAll("-", "n").replaceAll(".", "d");
+  return `g${encode(lat)}x${encode(lng)}`;
+}
 
 /** Persist the same snake_case keys first-party visits store on event.meta. */
 export function activityGeoToMeta(geo: ActivityGeo): Record<string, string | number> {
@@ -649,7 +657,9 @@ export function activityGlobeMarkers(
     else buckets.set(key, { lat: loc.lat, lng: loc.lng, count: 1 });
   }
   return [...buckets.values()].map((bucket) => ({
-    location: [bucket.lat, bucket.lng],
-    size: Math.min(0.08, 0.028 + Math.log2(bucket.count) * 0.01),
+    id: activityGlobeMarkerId(bucket.lat, bucket.lng),
+    location: [bucket.lat, bucket.lng] as [number, number],
+    // Small WebGL discs: through-the-planet hint. DOM orbs carry facing depth.
+    size: Math.min(0.028, 0.01 + Math.log2(bucket.count) * 0.004),
   }));
 }

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { globeMarkerFacing, latLngToGlobePose, shortestAngleDelta } from "./activity-globe";
+import {
+  globeMarkerFacing,
+  latLngToGlobePose,
+  projectGlobeMarker,
+  shortestAngleDelta,
+} from "./activity-globe";
 
 describe("latLngToGlobePose", () => {
   test("uses the COBE phi/theta convention", () => {
@@ -23,6 +28,10 @@ describe("latLngToGlobePose", () => {
     for (const [lat, lng] of samples) {
       const { phi, theta } = latLngToGlobePose(lat, lng);
       expect(globeMarkerFacing(lat, lng, phi, theta)).toBeCloseTo(1);
+      const projected = projectGlobeMarker(lat, lng, phi, theta);
+      expect(projected.x).toBeCloseTo(0.5);
+      expect(projected.y).toBeCloseTo(0.5);
+      expect(projected.facing).toBeCloseTo(1);
     }
   });
 });

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { globeMarkerFacing, latLngToGlobePose, shortestAngleDelta } from "./activity-globe";
+
+describe("latLngToGlobePose", () => {
+  test("uses the COBE phi/theta convention", () => {
+    const origin = latLngToGlobePose(0, 0);
+    expect(origin.phi).toBeCloseTo(Math.PI - (0 - Math.PI / 2));
+    expect(origin.theta).toBeCloseTo(0);
+
+    const sf = latLngToGlobePose(37.77, -122.42);
+    expect(sf.phi).toBeCloseTo(Math.PI - ((-122.42 * Math.PI) / 180 - Math.PI / 2));
+    expect(sf.theta).toBeCloseTo((37.77 * Math.PI) / 180);
+  });
+
+  test("aimed pose puts the location at the camera apex", () => {
+    const samples: Array<[number, number]> = [
+      [0, 0],
+      [37.77, -122.42],
+      [-33.87, 151.21],
+      [51.51, -0.13],
+    ];
+    for (const [lat, lng] of samples) {
+      const { phi, theta } = latLngToGlobePose(lat, lng);
+      expect(globeMarkerFacing(lat, lng, phi, theta)).toBeCloseTo(1);
+    }
+  });
+});
+
+describe("shortestAngleDelta", () => {
+  test("takes the shortest path around the circle", () => {
+    expect(shortestAngleDelta(0, 0.2)).toBeCloseTo(0.2);
+    expect(shortestAngleDelta(0, -0.2)).toBeCloseTo(-0.2);
+    expect(shortestAngleDelta(0.1, Math.PI * 2 - 0.1)).toBeCloseTo(-0.2);
+    expect(shortestAngleDelta(Math.PI * 2 - 0.1, 0.1)).toBeCloseTo(0.2);
+    expect(Math.abs(shortestAngleDelta(0, Math.PI))).toBeCloseTo(Math.PI);
+  });
+
+  test("unwraps an accumulated idle-spin phi toward a canonical target", () => {
+    const target = latLngToGlobePose(0, 0).phi;
+    const spun = target + Math.PI * 2 * 3 + 0.4;
+    expect(shortestAngleDelta(spun, target)).toBeCloseTo(-0.4);
+  });
+});

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -1,0 +1,66 @@
+/** COBE camera pose and marker depth. Safe for client components. */
+
+export type GlobePose = {
+  phi: number;
+  theta: number;
+};
+
+/**
+ * COBE convention: rotate so `lat`/`lng` faces the camera.
+ * `phi = π - (lngRad - π/2)`, `theta = latRad`.
+ */
+export function latLngToGlobePose(lat: number, lng: number): GlobePose {
+  return {
+    phi: Math.PI - ((lng * Math.PI) / 180 - Math.PI / 2),
+    theta: (lat * Math.PI) / 180,
+  };
+}
+
+/** Shortest signed delta from `from` to `to` on the circle, in (-π, π]. */
+export function shortestAngleDelta(from: number, to: number): number {
+  const tau = Math.PI * 2;
+  let delta = ((to - from) % tau) + tau;
+  delta %= tau;
+  if (delta > Math.PI) delta -= tau;
+  return delta;
+}
+
+/** Same lat/lng → unit vector as cobe@2 `latLonTo3D`. */
+export function latLngToGlobePoint(lat: number, lng: number): [number, number, number] {
+  const latRad = (lat * Math.PI) / 180;
+  const lonRad = (lng * Math.PI) / 180 - Math.PI;
+  const cosLat = Math.cos(latRad);
+  return [-cosLat * Math.cos(lonRad), Math.sin(latRad), cosLat * Math.sin(lonRad)];
+}
+
+/** Same world-to-view rotation as cobe@2 marker projection. */
+export function rotateGlobePoint(
+  point: [number, number, number],
+  phi: number,
+  theta: number,
+): [number, number, number] {
+  const cx = Math.cos(theta);
+  const cy = Math.cos(phi);
+  const sx = Math.sin(theta);
+  const sy = Math.sin(phi);
+  const [x, y, z] = point;
+  return [cy * x + sy * z, sy * sx * x + cx * y - cy * sx * z, -sy * cx * x + sx * y + cy * cx * z];
+}
+
+/**
+ * 0 behind the limb, 1 at the camera-facing apex.
+ * COBE v2 `--cobe-visible-{id}` is only a boolean (`N` / unset); use this for depth.
+ */
+export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: number): number {
+  const [, , rz] = rotateGlobePoint(latLngToGlobePoint(lat, lng), phi, theta);
+  return Math.min(1, Math.max(0, rz));
+}
+
+export const GLOBE_SIZE_MIN = 240;
+export const GLOBE_SIZE_MAX = 456;
+
+/** Diameter ≈ 1/3 of the activity pane height, clamped for short and very tall viewports. */
+export function globeDiameterFromHeight(height: number): number {
+  if (!Number.isFinite(height) || height <= 0) return GLOBE_SIZE_MIN;
+  return Math.round(Math.min(GLOBE_SIZE_MAX, Math.max(GLOBE_SIZE_MIN, height / 3)));
+}

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -60,8 +60,11 @@ export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: 
 export const GLOBE_MESH_RADIUS = 0.8;
 export const GLOBE_MARKER_ELEVATION = 0.03;
 
-export const GLOBE_SIZE_MIN = 240;
-export const GLOBE_SIZE_MAX = 456;
+/** On-screen disc target. 240 was too timid; 1080p should read ~360px visible. */
+export const GLOBE_VISIBLE_MIN = 320;
+export const GLOBE_VISIBLE_MAX = 580;
+/** Fraction of the mesh that hangs off the corner — just enough to kiss the edge. */
+export const GLOBE_HANG = 0.12;
 
 /** Project a lat/lng onto the COBE canvas, matching v2 marker anchors. */
 export function projectGlobeMarker(
@@ -85,8 +88,19 @@ export function projectGlobeMarker(
   };
 }
 
-/** Diameter ≈ 1/3 of the activity pane height, clamped for short and very tall viewports. */
+/** Visible on-screen disc ≈ 1/3 of the activity pane / window height. */
+export function globeVisibleDiameterFromHeight(height: number): number {
+  if (!Number.isFinite(height) || height <= 0) return GLOBE_VISIBLE_MIN;
+  return Math.round(Math.min(GLOBE_VISIBLE_MAX, Math.max(GLOBE_VISIBLE_MIN, height / 3)));
+}
+
+/** Mesh size so that after `hang` is clipped, the remaining disc is `visible`. */
+export function globeMeshDiameter(visible: number, hang = GLOBE_HANG): number {
+  const fraction = Math.min(0.2, Math.max(0, hang));
+  return Math.round(visible / (1 - fraction));
+}
+
+/** Canvas diameter from pane height: visible 1/3, plus a small corner hang. */
 export function globeDiameterFromHeight(height: number): number {
-  if (!Number.isFinite(height) || height <= 0) return GLOBE_SIZE_MIN;
-  return Math.round(Math.min(GLOBE_SIZE_MAX, Math.max(GLOBE_SIZE_MIN, height / 3)));
+  return globeMeshDiameter(globeVisibleDiameterFromHeight(height));
 }

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -56,8 +56,34 @@ export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: 
   return Math.min(1, Math.max(0, rz));
 }
 
+/** Same mesh radius as cobe@2 (`GLOBE_R`). */
+export const GLOBE_MESH_RADIUS = 0.8;
+export const GLOBE_MARKER_ELEVATION = 0.03;
+
 export const GLOBE_SIZE_MIN = 240;
 export const GLOBE_SIZE_MAX = 456;
+
+/** Project a lat/lng onto the COBE canvas, matching v2 marker anchors. */
+export function projectGlobeMarker(
+  lat: number,
+  lng: number,
+  phi: number,
+  theta: number,
+  elevation = GLOBE_MARKER_ELEVATION,
+): { x: number; y: number; facing: number } {
+  const unit = latLngToGlobePoint(lat, lng);
+  const radius = GLOBE_MESH_RADIUS + elevation;
+  const [rx, ry] = rotateGlobePoint(
+    [unit[0] * radius, unit[1] * radius, unit[2] * radius],
+    phi,
+    theta,
+  );
+  return {
+    x: (rx + 1) / 2,
+    y: (-ry + 1) / 2,
+    facing: globeMarkerFacing(lat, lng, phi, theta),
+  };
+}
 
 /** Diameter ≈ 1/3 of the activity pane height, clamped for short and very tall viewports. */
 export function globeDiameterFromHeight(height: number): number {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three upgrades on the `/activity` globe from #2320. Branched from current `main` (includes the clipped + tilt globe and like geo from #2321).

## Click a row → spin to that event
- Clicking row chrome / icon / summary (not an `<a href>` title or source link) eases the globe so that event’s location faces the camera
- Uses existing `activityEventLocation` / `meta` — no new API
- Rows and stacks without a locatable event are ignored
- Shortest-path ease on phi/theta (~0.6–0.85s); idle spin and flick pause while aiming, then idle spin resumes
- `prefers-reduced-motion`: snap, no ease
- Wired through `ActivityFeed` → `ActivityStackList` → `ActivityRow`

## Dots with shape and depth
- Bindable COBE v2 markers (`id` + `markerElevation`)
- Small orange DOM orbs with a radial-gradient highlight, darker rim, and glow
- cobe@2.0.1’s `--cobe-visible-{id}` is a boolean (`N` / unset), not 0–1, so facing depth (scale / opacity / slight blur) and screen position are computed from the same camera rotation and applied each frame
- WebGL discs stay small as the through-the-planet hint so they don’t blob with the orbs
- New events still update markers without remounting the globe

## Size from viewport height (visible disc)
- The **on-screen** circle is ≈ 1/3 of the activity pane / window height (1080p → ~360px visible; taller panes scale up)
- Hang is a small corner kiss (~12% of the mesh), not a third of the sphere
- Mesh diameter is `visible / (1 − hang)` so clipping does not shrink the visible globe
- Height is the max of the pane and the window, so a short inner wrapper cannot collapse it
- Still clipped into the bottom-right; `update()` width/height on resize; still hidden below `lg` / when the column is too tight

[Activity globe sized so the visible disc is about one third of the viewport height](https://cursor.com/agents/bc-e84747dc-c592-4406-9614-f33be8a5570e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_globe_visible_third.webp)

## Tests
Unit tests for lat/lng → phi/theta, shortest-path aiming, and the aimed-point projection. No visual/chrome tests.

Does not change ingest, visit filtering, or activity copy.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e84747dc-c592-4406-9614-f33be8a5570e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e84747dc-c592-4406-9614-f33be8a5570e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

