### PR TITLE
Render same-location visits as one clustered block

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -1183,7 +1183,7 @@ describe("ActivityFeed", () => {
     expect(countryOnly).toContain("Stack");
   });
 
-  test("keeps every same-location visit row and says the place only on the newest", () => {
+  test("renders a same-location visit run as one block, oldest action first", () => {
     const markup = renderToStaticMarkup(
       <ActivityFeed
         initialEvents={[
@@ -1232,14 +1232,18 @@ describe("ActivityFeed", () => {
     );
 
     expect(markup.match(/Someone from San Francisco/g)?.length).toBe(1);
+    expect(markup).toContain("Someone from San Francisco, California");
+    expect(markup).not.toContain("United States");
     expect(markup).toContain("viewed");
     expect(markup).toContain("Listening");
     expect(markup).toContain("AMA");
     expect(markup).toContain("visited");
     expect(markup).toContain("the site");
+    expect(markup.indexOf("the site")).toBeLessThan(markup.indexOf("AMA"));
+    expect(markup.indexOf("AMA")).toBeLessThan(markup.indexOf("Listening"));
   });
 
-  test("a different location in the middle labels both visit runs", () => {
+  test("a different location in the middle labels two visit clusters", () => {
     const markup = renderToStaticMarkup(
       <ActivityFeed
         initialEvents={[
@@ -1292,7 +1296,7 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("AMA");
   });
 
-  test("a like does not join a consecutive visit location run", () => {
+  test("a like does not join a visit location cluster", () => {
     const markup = renderToStaticMarkup(
       <ActivityFeed
         initialEvents={[

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -15,10 +15,18 @@ import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { SlotDigits } from "@/components/SlotDigits";
 import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
-import type { ActivityEvent, ActivityLikeTarget, ActivityRollup } from "@/lib/activity";
+import type {
+  ActivityEvent,
+  ActivityFeedItem,
+  ActivityLikeTarget,
+  ActivityRollup,
+  ActivityVisitCluster,
+} from "@/lib/activity";
 import {
+  activityFeedItemCount,
+  activityFeedItemReactKey,
   activityStackReactKey,
-  markVisitLocationContinuations,
+  clusterVisitLocationRuns,
   nextActivityEnterState,
   rollupActivityEvents,
   shouldPulseActivityRollup,
@@ -172,6 +180,17 @@ function likeTargetsFromRow(
   return [{ title, ...(row.href ? { href: row.href } : {}) }];
 }
 
+function ActivityCountChip({ count }: { count: number }) {
+  return (
+    <span
+      data-count={count}
+      className="text-tertiary border-secondary shrink-0 -translate-y-[2px] rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
+    >
+      ×<SlotDigits value={count} />
+    </span>
+  );
+}
+
 export function ActivityRow({
   event,
   count = 1,
@@ -179,7 +198,6 @@ export function ActivityRow({
   href: hrefOverride,
   pulse = false,
   likeTargets: likeTargetsProp,
-  omitVisitLocation = false,
 }: {
   event: ActivityEvent;
   count?: number;
@@ -187,9 +205,8 @@ export function ActivityRow({
   href?: string;
   pulse?: boolean;
   likeTargets?: ActivityLikeTarget[];
-  omitVisitLocation?: boolean;
 }) {
-  const row = getActivityRow(event, { omitVisitLocation });
+  const row = getActivityRow(event);
   const homeUrl = activitySourceUrl(event.source);
   const isLike = event.type === "like";
   const likeTargets = likeTargetsFromRow(event, row, likeTargetsProp);
@@ -228,9 +245,7 @@ export function ActivityRow({
         </div>
         <p className="flex min-w-0 items-baseline gap-1.5">
           <span className="min-w-0">
-            <span className={omitVisitLocation ? "text-tertiary" : "text-primary"}>
-              {row.summary}
-            </span>
+            <span className="text-primary">{row.summary}</span>
             {href && context ? (
               <>
                 {" "}
@@ -246,14 +261,7 @@ export function ActivityRow({
               </>
             ) : null}
           </span>
-          {showCountChip ? (
-            <span
-              data-count={count}
-              className="text-tertiary border-secondary shrink-0 -translate-y-[2px] rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
-            >
-              ×<SlotDigits value={count} />
-            </span>
-          ) : null}
+          {showCountChip ? <ActivityCountChip count={count} /> : null}
           {diff ? (
             <span className="shrink-0 text-sm tabular-nums">
               <span className="text-green-600">+{diff.additions}</span>{" "}
@@ -261,6 +269,130 @@ export function ActivityRow({
             </span>
           ) : null}
         </p>
+      </div>
+    </div>
+  );
+}
+
+function VisitClusterRail() {
+  return (
+    <span
+      aria-hidden
+      className="text-tertiary pointer-events-none absolute inset-x-0 top-8 bottom-1 flex flex-col"
+    >
+      <span className="mx-auto w-px flex-1 bg-current opacity-50" />
+      <svg width="32" height="10" viewBox="0 0 32 10" className="overflow-visible">
+        <path
+          d="M16 0 V3 Q16 9 30 9"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+          strokeLinecap="round"
+        />
+      </svg>
+    </span>
+  );
+}
+
+function ActivityClusterAction({
+  stack,
+  pulse = false,
+}: {
+  stack: ActivityRollup;
+  pulse?: boolean;
+}) {
+  const row = getActivityRow(stack.latest, { omitVisitLocation: true });
+  const label = stack.sectionLabel ?? row.label;
+  const rawHref = stack.href ?? row.href;
+  const href = resolveActivitySourceHref(stack.latest.source, rawHref) ?? rawHref;
+  const context = label ?? (href || undefined);
+  const showCountChip = stack.count > 1;
+
+  return (
+    <li className="relative flex items-baseline gap-1.5">
+      {pulse ? (
+        <span
+          key={stack.latest.id}
+          aria-hidden
+          className="activity-rollup-pulse pointer-events-none absolute inset-0 z-0"
+        />
+      ) : null}
+      <span className="relative z-10 min-w-0">
+        <span className="text-tertiary">{row.summary}</span>
+        {href && context ? (
+          <>
+            {" "}
+            <ActivityContextLink href={href}>{context}</ActivityContextLink>
+          </>
+        ) : context ? (
+          <span className="text-tertiary"> {context}</span>
+        ) : null}
+      </span>
+      {showCountChip ? <ActivityCountChip count={stack.count} /> : null}
+    </li>
+  );
+}
+
+function ActivityVisitClusterBlock({
+  cluster,
+  pulse = false,
+  pulseActionKey = null,
+}: {
+  cluster: ActivityVisitCluster;
+  pulse?: boolean;
+  pulseActionKey?: string | null;
+}) {
+  const iconEvent = cluster.actions[0]?.latest ?? cluster.latest;
+  const showRail = cluster.actions.length > 1;
+
+  if (cluster.actions.length === 1) {
+    const stack = cluster.actions[0]!;
+    return (
+      <ActivityRow
+        event={stack.latest}
+        count={stack.count}
+        sectionLabel={stack.sectionLabel}
+        href={stack.href}
+        likeTargets={stack.likeTargets}
+        pulse={pulse}
+      />
+    );
+  }
+
+  return (
+    <div
+      data-rollup-pulse={pulse ? "" : undefined}
+      className="group hover:bg-secondary relative isolate px-4 py-3 md:py-2 md:dark:hover:bg-white/5"
+    >
+      {pulse ? (
+        <span
+          key={cluster.latest.id}
+          aria-hidden
+          className="activity-rollup-pulse pointer-events-none absolute inset-0 z-0"
+        />
+      ) : null}
+      <div className="relative z-10 flex items-start gap-3">
+        <div className="relative w-8 flex-none self-stretch">
+          <div className="flex size-8 items-center justify-center">
+            <ActivityRowIcon event={iconEvent} />
+          </div>
+          {showRail ? <VisitClusterRail /> : null}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-primary">{cluster.locationHeader}</p>
+          <ul className="mt-0.5 flex flex-col gap-0.5">
+            {cluster.actions.map((action) => {
+              const actionKey = activityStackReactKey(action);
+              return (
+                <ActivityClusterAction
+                  key={actionKey}
+                  stack={action}
+                  pulse={pulseActionKey === actionKey}
+                />
+              );
+            })}
+          </ul>
+        </div>
       </div>
     </div>
   );
@@ -376,16 +508,18 @@ function mergeEnterDelays(
 }
 
 function ActivityStackList({
-  stacks,
+  items,
   pulseKey,
+  pulseActionKey,
 }: {
-  stacks: ActivityRollup[];
+  items: ActivityFeedItem[];
   pulseKey: string | null;
+  pulseActionKey: string | null;
 }) {
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
   const canAnimate = hydrated && prefersReducedMotion !== true;
-  const keys = stacks.map(activityStackReactKey);
+  const keys = items.map(activityFeedItemReactKey);
   const liveKeys = new Set(keys);
   const [seenKeys, setSeenKeys] = useState<Set<string> | null>(null);
   const [enterDelays, setEnterDelays] = useState<Map<string, number>>(() => new Map());
@@ -403,10 +537,11 @@ function ActivityStackList({
   return (
     <div className="divide-secondary divide-y">
       <AnimatePresence initial={false}>
-        {stacks.map((stack) => {
-          const reactKey = activityStackReactKey(stack);
+        {items.map((item) => {
+          const reactKey = activityFeedItemReactKey(item);
           const delay = nextDelays.get(reactKey);
           const isEntering = canAnimate && delay !== undefined;
+          const pulse = pulseKey === reactKey || enterPulseKeys.has(reactKey);
 
           return (
             <motion.div
@@ -425,15 +560,22 @@ function ActivityStackList({
               }}
               className={isEntering ? "overflow-hidden" : "[clip-path:inset(0)]"}
             >
-              <ActivityRow
-                event={stack.latest}
-                count={stack.count}
-                sectionLabel={stack.sectionLabel}
-                href={stack.href}
-                likeTargets={stack.likeTargets}
-                omitVisitLocation={stack.omitVisitLocation}
-                pulse={pulseKey === reactKey || enterPulseKeys.has(reactKey)}
-              />
+              {item.type === "visit-cluster" ? (
+                <ActivityVisitClusterBlock
+                  cluster={item}
+                  pulse={pulse}
+                  pulseActionKey={pulseKey === reactKey ? pulseActionKey : null}
+                />
+              ) : (
+                <ActivityRow
+                  event={item.stack.latest}
+                  count={item.stack.count}
+                  sectionLabel={item.stack.sectionLabel}
+                  href={item.stack.href}
+                  likeTargets={item.stack.likeTargets}
+                  pulse={pulse}
+                />
+              )}
             </motion.div>
           );
         })}
@@ -442,13 +584,25 @@ function ActivityStackList({
   );
 }
 
-function useRollupPulse(stacks: ActivityRollup[]): string | null {
+function newestActionKey(item: ActivityFeedItem): string {
+  if (item.type === "row") return activityStackReactKey(item.stack);
+  const newest = item.actions[item.actions.length - 1]!;
+  return activityStackReactKey(newest);
+}
+
+function useRollupPulse(items: ActivityFeedItem[]): {
+  pulseKey: string | null;
+  pulseActionKey: string | null;
+} {
   const prefersReducedMotion = useReducedMotion();
-  const top = stacks[0];
-  const topReactKey = top ? activityStackReactKey(top) : null;
+  const top = items[0];
+  const topReactKey = top ? activityFeedItemReactKey(top) : null;
+  const topActionKey = top ? newestActionKey(top) : null;
+  const topCount = top ? activityFeedItemCount(top) : 0;
   const [seenTop, setSeenTop] = useState<{ key: string; count: number } | null>(null);
   const [pulseKey, setPulseKey] = useState<string | null>(null);
-  const nextSeen = topReactKey && top ? { key: topReactKey, count: top.count } : null;
+  const [pulseActionKey, setPulseActionKey] = useState<string | null>(null);
+  const nextSeen = topReactKey && top ? { key: topReactKey, count: topCount } : null;
   const shouldPulse =
     prefersReducedMotion !== true && shouldPulseActivityRollup(seenTop, nextSeen ?? undefined);
   const seenChanged = seenTop?.key !== nextSeen?.key || seenTop?.count !== nextSeen?.count;
@@ -457,18 +611,26 @@ function useRollupPulse(stacks: ActivityRollup[]): string | null {
     setSeenTop(nextSeen);
     if (shouldPulse && topReactKey) {
       setPulseKey(topReactKey);
+      setPulseActionKey(topActionKey);
     } else if (pulseKey && nextSeen?.key !== pulseKey) {
       setPulseKey(null);
+      setPulseActionKey(null);
     }
   }
 
   useEffect(() => {
     if (!pulseKey) return;
-    const timeout = window.setTimeout(() => setPulseKey(null), ROLLUP_PULSE_MS);
+    const timeout = window.setTimeout(() => {
+      setPulseKey(null);
+      setPulseActionKey(null);
+    }, ROLLUP_PULSE_MS);
     return () => window.clearTimeout(timeout);
-  }, [pulseKey, top?.count]);
+  }, [pulseKey, topCount]);
 
-  return shouldPulse && topReactKey ? topReactKey : pulseKey;
+  if (shouldPulse && topReactKey) {
+    return { pulseKey: topReactKey, pulseActionKey: topActionKey };
+  }
+  return { pulseKey, pulseActionKey };
 }
 
 export function ActivityFeed({
@@ -479,11 +641,8 @@ export function ActivityFeed({
   initialCount: number;
 }) {
   const { events, count } = useActivity(initialEvents, initialCount);
-  const stacks = useMemo(
-    () => markVisitLocationContinuations(rollupActivityEvents(events)),
-    [events],
-  );
-  const pulseKey = useRollupPulse(stacks);
+  const items = useMemo(() => clusterVisitLocationRuns(rollupActivityEvents(events)), [events]);
+  const { pulseKey, pulseActionKey } = useRollupPulse(items);
 
   const topBarContent = useMemo(() => <ActivityTrackedCount count={count} />, [count]);
   useTopBarActions(topBarContent);
@@ -498,7 +657,11 @@ export function ActivityFeed({
             </p>
           ) : (
             <>
-              <ActivityStackList stacks={stacks} pulseKey={pulseKey} />
+              <ActivityStackList
+                items={items}
+                pulseKey={pulseKey}
+                pulseActionKey={pulseActionKey}
+              />
               <p className="text-tertiary p-32 text-center text-sm">
                 Older activity is dust in the wind...
               </p>

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -8,12 +8,14 @@ import {
   type ActivityEvent,
   activitySectionFromPath,
   activitySectionPhrase,
+  formatVisitLocationHeader,
   getActivityRow,
   isAbsoluteHttpUrl,
   isHiddenLikeEvent,
   isHomeLikeTitle,
   isKnownActivitySection,
   visitLocationClusterKey,
+  visitLocationPhrase,
 } from "./activity-shared";
 
 export type ActivityLikeTarget = {
@@ -30,12 +32,40 @@ export type ActivityRollup = {
   sectionLabel: string;
   href?: string;
   likeTargets?: ActivityLikeTarget[];
-  /** Older same-location visit in a consecutive run — omit the someone/location prefix. */
-  omitVisitLocation?: boolean;
 };
+
+/** Consecutive same-location visit stacks, rendered as one block. Actions are oldest → newest. */
+export type ActivityVisitCluster = {
+  type: "visit-cluster";
+  locationKey: string;
+  locationHeader: string;
+  latest: ActivityEvent;
+  actions: ActivityRollup[];
+  /** Oldest event in the cluster — stable as newer actions append. */
+  anchorId: string;
+  count: number;
+};
+
+export type ActivityFeedItem = { type: "row"; stack: ActivityRollup } | ActivityVisitCluster;
 
 export function activityStackReactKey(stack: Pick<ActivityRollup, "key" | "anchorId">): string {
   return `${stack.key}:${stack.anchorId}`;
+}
+
+export function activityVisitClusterReactKey(
+  cluster: Pick<ActivityVisitCluster, "locationKey" | "anchorId">,
+): string {
+  return `visit-cluster:${cluster.locationKey}:${cluster.anchorId}`;
+}
+
+export function activityFeedItemReactKey(item: ActivityFeedItem): string {
+  return item.type === "visit-cluster"
+    ? activityVisitClusterReactKey(item)
+    : activityStackReactKey(item.stack);
+}
+
+export function activityFeedItemCount(item: ActivityFeedItem): number {
+  return item.type === "visit-cluster" ? item.count : item.stack.count;
 }
 
 export const ACTIVITY_ENTER_STAGGER_STEP = 0.05;
@@ -205,19 +235,45 @@ function stackHref(events: ActivityEvent[]): string | undefined {
 
 /**
  * Display pass over already-rolled-up stacks (newest first).
- * Consecutive visit-like rows that share a location key keep the full sentence
- * on the newest row and drop the someone/location prefix on older siblings.
- * Does not merge rows or change ×N rollup counts.
+ * Consecutive visit-like stacks that share a location key become one cluster.
+ * Actions inside a cluster are oldest → newest so a new same-place event appends
+ * at the bottom. A different location or a non-visit starts a new block.
+ * Does not change ×N rollup counts.
  */
-export function markVisitLocationContinuations(stacks: ActivityRollup[]): ActivityRollup[] {
-  let previousKey: string | undefined;
-  return stacks.map((stack) => {
-    const key = visitLocationClusterKey(stack.latest);
-    const omitVisitLocation = Boolean(key && key === previousKey);
-    previousKey = key;
-    if (stack.omitVisitLocation === omitVisitLocation) return stack;
-    if (!omitVisitLocation && stack.omitVisitLocation === undefined) return stack;
-    return { ...stack, omitVisitLocation };
+export function clusterVisitLocationRuns(stacks: ActivityRollup[]): ActivityFeedItem[] {
+  const items: Array<
+    | { type: "row"; stack: ActivityRollup }
+    | { type: "visit-cluster"; locationKey: string; newestFirst: ActivityRollup[] }
+  > = [];
+
+  for (const stack of stacks) {
+    const locationKey = visitLocationClusterKey(stack.latest);
+    const current = items[items.length - 1];
+    if (locationKey && current?.type === "visit-cluster" && current.locationKey === locationKey) {
+      current.newestFirst.push(stack);
+      continue;
+    }
+    if (locationKey) {
+      items.push({ type: "visit-cluster", locationKey, newestFirst: [stack] });
+      continue;
+    }
+    items.push({ type: "row", stack });
+  }
+
+  return items.map((item) => {
+    if (item.type === "row") return item;
+    const actions = [...item.newestFirst].reverse();
+    const newest = item.newestFirst[0]!;
+    const oldest = actions[0]!;
+    return {
+      type: "visit-cluster",
+      locationKey: item.locationKey,
+      locationHeader: formatVisitLocationHeader(visitLocationPhrase(newest.latest)),
+      latest: newest.latest,
+      actions,
+      anchorId: oldest.anchorId,
+      count: actions.reduce((total, action) => total + action.count, 0),
+    };
   });
 }
 

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -1013,6 +1013,10 @@ export function visitLocationClusterKey(event: ActivityEvent): string | undefine
   return visitLocationPhrase(event).toLowerCase();
 }
 
+export function formatVisitLocationHeader(location: string): string {
+  return `Someone from ${location}`;
+}
+
 export function formatVisitRowSummary(
   location: string,
   verb: VisitActivityVerb,
@@ -1021,7 +1025,7 @@ export function formatVisitRowSummary(
 ): string {
   const action = hasTitle ? verb : `${siteFallbackVerb(verb)} the site`;
   if (options?.omitLocation) return action;
-  return `Someone from ${location} ${action}`;
+  return `${formatVisitLocationHeader(location)} ${action}`;
 }
 
 function visitSubjectPath(event: ActivityEvent): string | undefined {

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -4,12 +4,14 @@ import {
   activityEnterStaggerDelays,
   type ActivityEvent,
   activityEventLocation,
+  activityFeedItemReactKey,
   activityRollupKey,
   activitySectionFromPath,
   activitySourceFaviconSrc,
   activitySourceUrl,
   activityStackReactKey,
   ANONYMOUS_VISIT_SUMMARY,
+  clusterVisitLocationRuns,
   countryCentroid,
   countryCodeToFlag,
   countryCodeToName,
@@ -33,7 +35,6 @@ import {
   likeMetaFromRequest,
   looksLikeIdentifier,
   looksLikeShortId,
-  markVisitLocationContinuations,
   nextActivityEnterState,
   pathnameFromHref,
   recordCaffeine,
@@ -3248,7 +3249,7 @@ describe("rollupActivityEvents", () => {
     expect(stacks[0]?.sectionLabel).not.toBe("https:");
   });
 
-  test("marks older same-location visit stacks as action-only siblings", () => {
+  test("clusters a same-location visit run as one block, oldest action first", () => {
     const sf = (id: string, href: string, label: string): ActivityEvent =>
       feedEvent({
         id,
@@ -3265,7 +3266,7 @@ describe("rollupActivityEvents", () => {
         },
       });
 
-    const stacks = markVisitLocationContinuations(
+    const items = clusterVisitLocationRuns(
       rollupActivityEvents([
         sf("sf-listening", "/listening", "Listening"),
         sf("sf-ama", "/ama", "AMA"),
@@ -3273,27 +3274,107 @@ describe("rollupActivityEvents", () => {
       ]),
     );
 
-    expect(stacks).toHaveLength(3);
-    expect(stacks.map((stack) => stack.count)).toEqual([1, 1, 1]);
-    expect(stacks[0]?.omitVisitLocation).toBeFalsy();
-    expect(stacks[1]?.omitVisitLocation).toBe(true);
-    expect(stacks[2]?.omitVisitLocation).toBe(true);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.type).toBe("visit-cluster");
+    if (items[0]?.type !== "visit-cluster") return;
+    expect(items[0].locationHeader).toBe("Someone from San Francisco, California");
+    expect(items[0].locationHeader).toContain("Someone from San Francisco");
+    expect(items[0].locationHeader).not.toContain("United States");
+    expect(items[0].actions).toHaveLength(3);
+    expect(items[0].actions.map((action) => action.latest.id)).toEqual([
+      "sf-home",
+      "sf-ama",
+      "sf-listening",
+    ]);
+    expect(items[0].count).toBe(3);
 
-    const rows = stacks.map((stack) =>
-      getActivityRow(stack.latest, { omitVisitLocation: stack.omitVisitLocation }),
+    const actions = items[0].actions.map((action) =>
+      getActivityRow(action.latest, { omitVisitLocation: true }),
     );
-    expect(rows[0]?.summary).toBe("Someone from San Francisco, California viewed");
-    expect(rows[0]?.summary).toContain("Someone from San Francisco");
-    expect(rows[0]?.label).toBe("Listening");
-    expect(rows[1]?.summary).toBe("viewed");
-    expect(rows[1]?.summary).not.toContain("Someone from");
-    expect(rows[1]?.label).toBe("AMA");
-    expect(rows[2]?.summary).toBe("visited");
-    expect(rows[2]?.summary).not.toContain("Someone from");
-    expect(rows[2]?.label).toBe("the site");
+    expect(actions[0]?.summary).toBe("visited");
+    expect(actions[0]?.label).toBe("the site");
+    expect(actions[1]?.summary).toBe("viewed");
+    expect(actions[1]?.label).toBe("AMA");
+    expect(actions[2]?.summary).toBe("viewed");
+    expect(actions[2]?.label).toBe("Listening");
+    expect(actions.every((row) => !row.summary.includes("Someone from"))).toBe(true);
   });
 
-  test("a different location in the middle starts a new labeled run", () => {
+  test("appends a new same-location visit at the bottom and keeps the cluster key", () => {
+    const sf = (id: string, href: string, label: string): ActivityEvent =>
+      feedEvent({
+        id,
+        type: "visit",
+        summary: "Visit from San Francisco, California, United States",
+        subject: { kind: "page", label, href },
+        meta: {
+          country: "US",
+          country_name: "United States",
+          region: "CA",
+          region_name: "California",
+          city: "San Francisco",
+          path: href,
+        },
+      });
+
+    const first = clusterVisitLocationRuns(
+      rollupActivityEvents([sf("sf-ama", "/ama", "AMA"), sf("sf-home", "/", "Home")]),
+    );
+    const next = clusterVisitLocationRuns(
+      rollupActivityEvents([
+        sf("sf-listening", "/listening", "Listening"),
+        sf("sf-ama", "/ama", "AMA"),
+        sf("sf-home", "/", "Home"),
+      ]),
+    );
+
+    expect(first).toHaveLength(1);
+    expect(next).toHaveLength(1);
+    expect(activityFeedItemReactKey(next[0]!)).toBe(activityFeedItemReactKey(first[0]!));
+    if (next[0]?.type !== "visit-cluster") return;
+    expect(next[0].actions.map((action) => action.latest.id)).toEqual([
+      "sf-home",
+      "sf-ama",
+      "sf-listening",
+    ]);
+    expect(next[0].actions[next[0].actions.length - 1]?.latest.id).toBe("sf-listening");
+  });
+
+  test("keeps the ×N chip on an identical action inside a location cluster", () => {
+    const sf = (id: string, href: string, label: string): ActivityEvent =>
+      feedEvent({
+        id,
+        type: "visit",
+        summary: "Visit from San Francisco, California, United States",
+        subject: { kind: "page", label, href },
+        meta: {
+          country: "US",
+          country_name: "United States",
+          region: "CA",
+          region_name: "California",
+          city: "San Francisco",
+          path: href,
+        },
+      });
+
+    const items = clusterVisitLocationRuns(
+      rollupActivityEvents([
+        sf("sf-listening", "/listening", "Listening"),
+        sf("ama-1", "/ama/one", "one"),
+        sf("ama-2", "/ama/two", "two"),
+      ]),
+    );
+
+    expect(items).toHaveLength(1);
+    if (items[0]?.type !== "visit-cluster") return;
+    expect(items[0].actions).toHaveLength(2);
+    expect(items[0].actions[0]?.count).toBe(2);
+    expect(items[0].actions[0]?.sectionLabel).toBe("an AMA question");
+    expect(items[0].actions[1]?.latest.id).toBe("sf-listening");
+    expect(items[0].count).toBe(3);
+  });
+
+  test("a different location in the middle starts a new labeled cluster", () => {
     const visit = (
       id: string,
       href: string,
@@ -3314,7 +3395,7 @@ describe("rollupActivityEvents", () => {
         meta: { ...geo, path: href },
       });
 
-    const stacks = markVisitLocationContinuations(
+    const items = clusterVisitLocationRuns(
       rollupActivityEvents([
         visit("sf-1", "/listening", "Listening", {
           city: "San Francisco",
@@ -3338,17 +3419,25 @@ describe("rollupActivityEvents", () => {
       ]),
     );
 
-    expect(stacks).toHaveLength(3);
-    const rows = stacks.map((stack) =>
-      getActivityRow(stack.latest, { omitVisitLocation: stack.omitVisitLocation }),
-    );
-    expect(rows[0]?.summary).toContain("Someone from San Francisco");
-    expect(rows[1]?.summary).toBe("Someone from London, United Kingdom viewed");
-    expect(rows[2]?.summary).toContain("Someone from San Francisco");
-    expect(rows.every((row) => row.summary.includes("Someone from"))).toBe(true);
+    expect(items).toHaveLength(3);
+    expect(items.map((item) => item.type)).toEqual([
+      "visit-cluster",
+      "visit-cluster",
+      "visit-cluster",
+    ]);
+    if (items[0]?.type !== "visit-cluster") return;
+    if (items[1]?.type !== "visit-cluster") return;
+    if (items[2]?.type !== "visit-cluster") return;
+    expect(items[0].locationHeader).toContain("Someone from San Francisco");
+    expect(items[1].locationHeader).toBe("Someone from London, United Kingdom");
+    expect(items[2].locationHeader).toContain("Someone from San Francisco");
+    expect(items[0].actions).toHaveLength(1);
+    expect(items[1].actions).toHaveLength(1);
+    expect(items[2].actions).toHaveLength(1);
+    expect(activityFeedItemReactKey(items[0])).not.toBe(activityFeedItemReactKey(items[2]));
   });
 
-  test("a non-visit row does not join a visit location run", () => {
+  test("a non-visit row does not join a visit location cluster", () => {
     const sf = (id: string, href: string, label: string): ActivityEvent =>
       feedEvent({
         id,
@@ -3371,7 +3460,7 @@ describe("rollupActivityEvents", () => {
       subject: { kind: "stack", label: "Cursor", href: "https://cursor.com" },
     });
 
-    const stacks = markVisitLocationContinuations(
+    const items = clusterVisitLocationRuns(
       rollupActivityEvents([
         sf("sf-1", "/listening", "Listening"),
         like,
@@ -3379,16 +3468,19 @@ describe("rollupActivityEvents", () => {
       ]),
     );
 
-    expect(stacks).toHaveLength(3);
-    const rows = stacks.map((stack) =>
-      getActivityRow(stack.latest, { omitVisitLocation: stack.omitVisitLocation }),
-    );
-    expect(rows[0]?.summary).toContain("Someone from San Francisco");
-    expect(rows[1]?.summary).toBe("Someone liked");
-    expect(rows[1]?.label).toBe("Cursor");
-    expect(rows[2]?.summary).toContain("Someone from San Francisco");
-    expect(stacks[1]?.omitVisitLocation).toBeFalsy();
-    expect(stacks[2]?.omitVisitLocation).toBeFalsy();
+    expect(items).toHaveLength(3);
+    expect(items[0]?.type).toBe("visit-cluster");
+    expect(items[1]?.type).toBe("row");
+    expect(items[2]?.type).toBe("visit-cluster");
+    if (items[0]?.type !== "visit-cluster") return;
+    if (items[1]?.type !== "row") return;
+    if (items[2]?.type !== "visit-cluster") return;
+    expect(items[0].locationHeader).toContain("Someone from San Francisco");
+    expect(getActivityRow(items[1].stack.latest).summary).toBe("Someone liked");
+    expect(getActivityRow(items[1].stack.latest).label).toBe("Cursor");
+    expect(items[2].locationHeader).toContain("Someone from San Francisco");
+    expect(items[0].actions).toHaveLength(1);
+    expect(items[2].actions).toHaveLength(1);
   });
 
   test("only pulses when the same run's count increments", () => {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -63,15 +63,23 @@ export {
   verifyGithubWebhookSignature,
 } from "./activity-github";
 export { isRegisteredActivityEvent } from "./activity-registry";
-export type { ActivityLikeTarget, ActivityRollup } from "./activity-rollup";
+export type {
+  ActivityFeedItem,
+  ActivityLikeTarget,
+  ActivityRollup,
+  ActivityVisitCluster,
+} from "./activity-rollup";
 export {
   ACTIVITY_ENTER_STAGGER_MAX,
   ACTIVITY_ENTER_STAGGER_STEP,
   activityEnterStaggerDelays,
   activityEventHref,
+  activityFeedItemCount,
+  activityFeedItemReactKey,
   activityRollupKey,
   activityStackReactKey,
-  markVisitLocationContinuations,
+  activityVisitClusterReactKey,
+  clusterVisitLocationRuns,
   nextActivityEnterState,
   rollupActivityEvents,
   shouldPulseActivityRollup,
@@ -113,6 +121,7 @@ export {
   formatDownloadSummary,
   formatLikeOthersLabel,
   formatTrackedEventsLabel,
+  formatVisitLocationHeader,
   formatVisitRowSummary,
   getActivityRow,
   getCaffeineIcon,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#2323 squash-merged the first pass (per-row location-prefix hiding). This is the intended rewrite: consecutive same-location visits become **one visual block**.

Re-applied from `c6d3610` onto current `main`. Does not revive `markVisitLocationContinuations`.

## What it looks like

```
[favicon] Someone from San Francisco, California
              viewed Hacker News          ← oldest
              viewed Writing
              viewed About
              └ visited the site          ← newest
```

- One visual block, one favicon on the location header. No hairline dividers between sibling actions.
- Hairline L-rail from under the icon down, then 90° into the last action.
- Header is location only (`Someone from Davao City, Philippines`). US: city+state, no “United States”.
- Action lines are verb + title, oldest → newest top to bottom.
- New same-location events append at the bottom of the current top cluster. Cluster React key stays stable (anchor = oldest event).
- Outer feed is still newest-first. A different location / like / Shiori / GitHub breaks the run and starts a new block above. A later return from SF is a new cluster, not a merge across a break.
- Single visits stay the compact one-line sentence.
- Identical consecutive events can still use ×N on that action line. Don’t collapse different pages into ×N.

## Tests

Behavior only: copy, hrefs, counts, cluster membership, oldest→newest order, stable key on append, like/other-source does not join, US country trim. No SVG/class/asset/size assertions.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6908512e-8760-4e2f-ad2a-9b2de71b20e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6908512e-8760-4e2f-ad2a-9b2de71b20e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

