### PR TITLE
Slow the /activity batch enter stagger

### DIFF
--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -68,8 +68,8 @@ export function activityFeedItemCount(item: ActivityFeedItem): number {
   return item.type === "visit-cluster" ? item.count : item.stack.count;
 }
 
-export const ACTIVITY_ENTER_STAGGER_STEP = 0.05;
-export const ACTIVITY_ENTER_STAGGER_MAX = 0.4;
+export const ACTIVITY_ENTER_STAGGER_STEP = 0.15;
+export const ACTIVITY_ENTER_STAGGER_MAX = 1.2;
 
 /**
  * Enter delays for keys that were not on screen last paint. First paint (`previous` null) is empty.

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -3107,19 +3107,19 @@ describe("rollupActivityEvents", () => {
       previous,
     );
     expect([...delays.entries()]).toEqual([
-      ["new-1", 0.2],
-      ["new-2", 0.15],
-      ["new-3", 0.1],
-      ["new-4", 0.05],
+      ["new-1", 0.6],
+      ["new-2", 0.45],
+      ["new-3", 0.3],
+      ["new-4", 0.15],
       ["new-5", 0],
     ]);
 
     const many = Array.from({ length: 16 }, (_, index) => `n-${index}`);
     const capped = activityEnterStaggerDelays(many, new Set());
     expect(capped.get("n-15")).toBe(0);
-    expect(capped.get("n-8")).toBe(0.35);
-    expect(capped.get("n-7")).toBe(0.4);
-    expect(capped.get("n-0")).toBe(0.4);
+    expect(capped.get("n-8")).toBe(1.05);
+    expect(capped.get("n-7")).toBe(1.2);
+    expect(capped.get("n-0")).toBe(1.2);
     expect(capped.has("old-1")).toBe(false);
   });
 
@@ -3144,8 +3144,8 @@ describe("rollupActivityEvents", () => {
     const previous = new Set(["old-1"]);
     const next = nextActivityEnterState(["newest", "middle", "oldest-new", "old-1"], previous);
     expect(next.delays.get("oldest-new")).toBe(0);
-    expect(next.delays.get("middle")).toBe(0.05);
-    expect(next.delays.get("newest")).toBe(0.1);
+    expect(next.delays.get("middle")).toBe(0.15);
+    expect(next.delays.get("newest")).toBe(0.3);
     expect(next.delays.has("old-1")).toBe(false);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a poll returns several new `/activity` rows, they now stream in more slowly so the cascade is easier to follow.

**Timing**
- Stagger step: `50ms` → `150ms` between incoming rows (oldest first)
- Stagger cap: `400ms` → `1.2s` so larger batches keep spacing instead of collapsing together
- First paint is still unstaggered; only newly fetched keys animate in

A 5-row batch now lands at `0 / 150 / 300 / 450 / 600ms` instead of `0 / 50 / 100 / 150 / 200ms`. The 1.2s cap stays under the 2s feed poll so overlapping refreshes do not stack.

**Verification**
- `bun run lint`
- `bun test src/lib/activity.test.ts` (188 pass), including the stagger delay cases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d10cb3de-2f4e-4ce1-8a94-852fa6e25db5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d10cb3de-2f4e-4ce1-8a94-852fa6e25db5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

