### PR TITLE
Draw the visit cluster L-rail as one SVG path

### DIFF
--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -300,22 +300,22 @@ export function ActivityRow({
 
 function VisitClusterRail() {
   return (
-    <svg
-      aria-hidden
-      viewBox="0 0 32 64"
-      preserveAspectRatio="none"
-      className="text-tertiary pointer-events-none absolute inset-x-0 top-8 bottom-1 block w-full overflow-visible"
-    >
-      <path
-        d="M16 0 L16 52 Q16 62 30 62"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        vectorEffect="nonScalingStroke"
-      />
-    </svg>
+    <span aria-hidden className="pointer-events-none absolute inset-x-0 top-8 bottom-1">
+      <svg
+        viewBox="0 0 32 200"
+        preserveAspectRatio="xMidYMax slice"
+        className="text-tertiary block h-full w-full overflow-hidden"
+      >
+        <path
+          d="M16 0 L16 188 Q16 198 30 198"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </span>
   );
 }
 

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -300,21 +300,22 @@ export function ActivityRow({
 
 function VisitClusterRail() {
   return (
-    <span
+    <svg
       aria-hidden
-      className="text-tertiary pointer-events-none absolute inset-x-0 top-8 bottom-1 flex flex-col"
+      viewBox="0 0 32 64"
+      preserveAspectRatio="none"
+      className="text-tertiary pointer-events-none absolute inset-x-0 top-8 bottom-1 block w-full overflow-visible"
     >
-      <span className="mx-auto w-px flex-1 bg-current opacity-50" />
-      <svg width="32" height="10" viewBox="0 0 32 10" className="overflow-visible">
-        <path
-          d="M16 0 V3 Q16 9 30 9"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1"
-          strokeLinecap="round"
-        />
-      </svg>
-    </span>
+      <path
+        d="M16 0 L16 52 Q16 62 30 62"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="nonScalingStroke"
+      />
+    </svg>
   );
 }
 
@@ -333,7 +334,7 @@ function ActivityClusterAction({
   const showCountChip = stack.count > 1;
 
   return (
-    <li className="relative flex items-baseline gap-1.5">
+    <li className="relative flex items-baseline gap-1.5 py-0.5">
       {pulse ? (
         <span
           key={stack.latest.id}
@@ -419,7 +420,7 @@ function ActivityVisitClusterBlock({
         </div>
         <div className="min-w-0 flex-1">
           <p className="text-primary">{cluster.locationHeader}</p>
-          <ul className="mt-0.5 flex flex-col gap-0.5">
+          <ul className="mt-1 flex flex-col gap-1">
             {cluster.actions.map((action) => {
               const actionKey = activityStackReactKey(action);
               return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #2324 after previewing the live cluster.

## Visual fixes

1. **One-path L-rail.** `VisitClusterRail` was a CSS `w-px` stem plus a tiny SVG elbow — different grey, visible seam. It is now a single SVG path (`currentColor` / `text-tertiary`, hairline, round caps/joins) that fills the cluster column from under the icon and turns 90° into the last action. No CSS bar + SVG join, no extra ticks.

2. **Action-line spacing.** Clustered sub-items (`visited the site` / `viewed Stack` / …) were `gap-0.5`. Bumped to `gap-1` with a little `py` on each action so they are not cramped.

[Concord cluster L-rail](https://cursor.com/agents/bc-7966e05b-943f-4bec-b63a-1aae27c315ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconcord_cluster_rail.png)

[visit_cluster_rail_and_spacing.mp4](https://cursor.com/agents/bc-7966e05b-943f-4bec-b63a-1aae27c315ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvisit_cluster_rail_and_spacing.mp4)

## Tests

Restyle only. No new tests, and none that assert SVG `d`, classes, Tailwind, or sizes. Existing activity feed / cluster behavior tests still pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7966e05b-943f-4bec-b63a-1aae27c315ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7966e05b-943f-4bec-b63a-1aae27c315ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

