### PR TITLE
Push the activity globe off the viewport corner

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -260,12 +260,10 @@
     width: 0.875rem;
     height: 0.875rem;
     border-radius: 9999px;
-    background: radial-gradient(circle at 30% 26%, #ffe0d4 0%, #fc532a 48%, #6a1408 100%);
+    background-color: #fc532a;
     box-shadow:
-      0 0 12px rgba(252, 83, 42, 0.55),
-      0 1px 2px rgba(0, 0, 0, 0.3),
-      inset 0 -2px 3px rgba(60, 8, 0, 0.5),
-      inset 0 1px 2px rgba(255, 255, 255, 0.35);
+      0 1px 1px rgba(0, 0, 0, 0.22),
+      inset 0 1px 1px rgba(255, 255, 255, 0.2);
     opacity: calc(0.12 + var(--orb-facing, 0) * 0.88);
     transform: translate(-50%, -50%) scale(calc(0.32 + var(--orb-facing, 0) * 0.78));
     filter: blur(calc((1 - var(--orb-facing, 0)) * 1.4px));

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -251,6 +251,7 @@
       animation: none;
     }
   }
+  /* Flat disc: solid fill, not a lit marble. */
   .activity-globe-orb {
     position: absolute;
     left: 0;

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -2,13 +2,22 @@
 
 import createGlobe from "cobe";
 import { useReducedMotion } from "motion/react";
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import type { ActivityEvent } from "@/lib/activity";
 import { activityGlobeMarkers, type ActivityLatLng } from "@/lib/activity-geo";
 import {
   GLOBE_HANG,
   GLOBE_MARKER_ELEVATION,
+  GLOBE_MESH_MIN,
   globeDiameterFromHeight,
   latLngToGlobePose,
   projectGlobeMarker,
@@ -113,7 +122,7 @@ export function ActivityGlobe({
   const orbElsRef = useRef(new Map<string, HTMLDivElement>());
   const isDark = useIsDark();
   const prefersReducedMotion = useReducedMotion() === true;
-  const [layout, setLayout] = useState(() => readPaneSize(null));
+  const [layout, setLayout] = useState({ hasRoom: true, size: GLOBE_MESH_MIN });
   const [grabbing, setGrabbing] = useState(false);
 
   const markers = useMemo(() => activityGlobeMarkers(events), [events]);
@@ -126,21 +135,21 @@ export function ActivityGlobe({
   }, [markers]);
 
   useEffect(() => {
-    themeRef.current = { isDark, prefersReducedMotion };
-  }, [isDark, prefersReducedMotion]);
-
-  useEffect(() => {
     sizeRef.current = layout.size;
   }, [layout.size]);
 
   useEffect(() => {
-    const host = overlayRef.current?.parentElement;
+    themeRef.current = { isDark, prefersReducedMotion };
+  }, [isDark, prefersReducedMotion]);
+
+  useLayoutEffect(() => {
     const update = () => {
-      setLayout(readPaneSize(host ?? overlayRef.current?.parentElement ?? null));
+      setLayout(readPaneSize(overlayRef.current?.parentElement ?? null));
     };
     update();
 
     const observer = new ResizeObserver(update);
+    const host = overlayRef.current?.parentElement;
     if (host) observer.observe(host);
     window.addEventListener("resize", update);
     return () => {

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -60,11 +60,12 @@ export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: 
 export const GLOBE_MESH_RADIUS = 0.8;
 export const GLOBE_MARKER_ELEVATION = 0.03;
 
-/** On-screen disc target. 240 was too timid; 1080p should read ~360px visible. */
-export const GLOBE_VISIBLE_MIN = 320;
-export const GLOBE_VISIBLE_MAX = 580;
-/** Fraction of the mesh that hangs off the corner — just enough to kiss the edge. */
-export const GLOBE_HANG = 0.12;
+/** Fraction of the mesh that hangs past the right and bottom edges. */
+export const GLOBE_HANG = 0.4;
+/** Floor so a short pane cannot collapse the sphere back to a marble. */
+export const GLOBE_MESH_MIN = 640;
+/** Mesh is ~90% of pane/window height. No max cap. */
+export const GLOBE_MESH_HEIGHT_RATIO = 0.9;
 
 /** Project a lat/lng onto the COBE canvas, matching v2 marker anchors. */
 export function projectGlobeMarker(
@@ -88,19 +89,8 @@ export function projectGlobeMarker(
   };
 }
 
-/** Visible on-screen disc ≈ 1/3 of the activity pane / window height. */
-export function globeVisibleDiameterFromHeight(height: number): number {
-  if (!Number.isFinite(height) || height <= 0) return GLOBE_VISIBLE_MIN;
-  return Math.round(Math.min(GLOBE_VISIBLE_MAX, Math.max(GLOBE_VISIBLE_MIN, height / 3)));
-}
-
-/** Mesh size so that after `hang` is clipped, the remaining disc is `visible`. */
-export function globeMeshDiameter(visible: number, hang = GLOBE_HANG): number {
-  const fraction = Math.min(0.2, Math.max(0, hang));
-  return Math.round(visible / (1 - fraction));
-}
-
-/** Canvas diameter from pane height: visible 1/3, plus a small corner hang. */
+/** Canvas diameter ≈ 0.9 × pane/window height, clipped off the bottom-right. */
 export function globeDiameterFromHeight(height: number): number {
-  return globeMeshDiameter(globeVisibleDiameterFromHeight(height));
+  if (!Number.isFinite(height) || height <= 0) return GLOBE_MESH_MIN;
+  return Math.round(Math.max(GLOBE_MESH_MIN, height * GLOBE_MESH_HEIGHT_RATIO));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#2322 sized the `/activity` globe as a timid on-screen disc (~1/3 of pane height, 320–580 cap) with a 12% hang — a marble sitting *inside* the corner with a gap. The DOM orbs were also 3D beads (highlight, shadow, glow) that stacked like physical balls over Europe.

This throws both of those looks away.

## Size
- Mesh diameter is **0.9 ×** `max(host.clientHeight, window.innerHeight)`
- **No 580 cap.** 1080p → ~970px; a 1440p pane is larger
- Floor at **640** so it cannot shrink back to a marble
- Size is measured after mount (stable SSR default) so hydration cannot leave the 960 fallback stuck on the DOM

## Hang
- **40%** of the mesh hangs past both the right and bottom edges
- `right: -hang; bottom: -hang` (unchanged positioning)
- Bottom-right of the sphere is off-canvas; there is **no inset gap**
- After hang, a large arc still fills the bottom-right of the feed

## Orbs
- Solid `#fc532a` discs — no radial-gradient marble, no glow
- Whisper of inset light + a 1px-ish contact shadow so overlaps still separate
- Facing-depth scale / opacity / blur unchanged

## Unchanged
- Click-to-aim, drag/flick, scrim
- Hidden below `lg` / when the column is too tight
- COBE `update()` width/height on resize
- Not centered

Pose/math tests are unchanged. No chrome/size tests — this is a restyle.

[activity_globe_overflow_and_flat_orbs.mp4](https://cursor.com/agents/bc-1907f22c-e806-4f00-a220-c8a22bf84095/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_globe_overflow_and_flat_orbs.mp4)
[1080p globe overflowing the corner with flat orbs](https://cursor.com/agents/bc-1907f22c-e806-4f00-a220-c8a22bf84095/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_globe_overflow_flat_orbs.png)
[Orb close-up after flattening](https://cursor.com/agents/bc-1907f22c-e806-4f00-a220-c8a22bf84095/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_globe_orbs_closeup.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1907f22c-e806-4f00-a220-c8a22bf84095?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1907f22c-e806-4f00-a220-c8a22bf84095&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

