### PR TITLE
Put the GitHub PR number in activity row copy

### DIFF
--- a/src/app/api/webhooks/github/route.test.ts
+++ b/src/app/api/webhooks/github/route.test.ts
@@ -103,7 +103,7 @@ describe("POST /api/webhooks/github", () => {
     expect(serialized).not.toContain("octocat@example.com");
     expect(event?.type).toBe("pr_opened");
     expect(event?.source).toBe("github");
-    expect(event?.summary).toBe("Opened a pull request on briOS");
+    expect(event?.summary).toBe("Opened #7 on briOS");
   });
 
   test("records private repos without the name, and skips bot PRs, unmerged closes, and deleted stars", async () => {

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -486,7 +486,7 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Opened a pull request on briOS");
+    expect(markup).toContain("Opened #42 on briOS");
     expect(markup).toContain(">Add activity feed<");
     expect(markup).toContain('href="https://github.com/brianlovin/briOS/pull/42"');
     expect(markup).toContain('target="_blank"');
@@ -574,13 +574,13 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Merged some-fix");
+    expect(markup).toContain("Merged #12 on briOS");
     expect(markup).toContain("brianlovin/briOS#12");
     expect(markup).toContain("+18");
     expect(markup).toContain("-3");
     expect(markup).not.toContain("+18 -3");
     expect(markup).toMatch(
-      /Merged some-fix[\s\S]*href="https:\/\/github.com\/brianlovin\/briOS\/pull\/12"[^>]*>brianlovin\/briOS#12[\s\S]*\+18[\s\S]*-3/,
+      /Merged #12 on briOS[\s\S]*href="https:\/\/github.com\/brianlovin\/briOS\/pull\/12"[^>]*>brianlovin\/briOS#12[\s\S]*\+18[\s\S]*-3/,
     );
   });
 

--- a/src/lib/activity-github.test.ts
+++ b/src/lib/activity-github.test.ts
@@ -104,7 +104,7 @@ describe("githubActivityFromWebhook", () => {
         type: "pr_opened",
         speed: "event",
         visibility: "public",
-        summary: "Opened a pull request on briOS",
+        summary: "Opened #42 on briOS",
         idempotency_key: "github:pr_opened:briOS:42",
         subject: {
           kind: "pull_request",
@@ -141,7 +141,7 @@ describe("githubActivityFromWebhook", () => {
     expect(merged.status).toBe("ingest");
     if (merged.status === "ingest") {
       expect(merged.input.type).toBe("pr_merged");
-      expect(merged.input.summary).toBe("Merged a pull request on briOS");
+      expect(merged.input.summary).toBe("Merged #42 on briOS");
       expect(merged.input.idempotency_key).toBe("github:pr_merged:briOS:42");
       expect(merged.input.subject).toEqual({
         kind: "pull_request",
@@ -306,7 +306,7 @@ describe("githubActivityFromWebhook", () => {
     expect(agent.status).toBe("ingest");
     if (agent.status === "ingest") {
       expect(agent.input.type).toBe("pr_opened");
-      expect(agent.input.summary).toBe("Opened a pull request on briOS");
+      expect(agent.input.summary).toBe("Opened #10 on briOS");
       expect(agent.input.subject).toEqual({
         kind: "pull_request",
         label: "Agent PR",
@@ -360,7 +360,7 @@ describe("recordGithubActivity", () => {
     expect(result).toEqual(expect.objectContaining({ ok: true, duplicate: false }));
     const [event] = await store.getTail(1);
     expect(event?.type).toBe("pr_merged");
-    expect(event?.summary).toBe("Merged a pull request on briOS");
+    expect(event?.summary).toBe("Merged #42 on briOS");
     expect(event?.subject).toEqual({
       kind: "pull_request",
       label: "Add activity feed",

--- a/src/lib/activity-github.ts
+++ b/src/lib/activity-github.ts
@@ -4,6 +4,7 @@ import {
   ACTIVITY_SOURCE_GITHUB,
   type ActivityIngestInput,
   privatePullRequestSummary,
+  publicPullRequestSummary,
 } from "./activity-shared";
 import { safeCompare } from "./api-utils";
 
@@ -129,14 +130,10 @@ function pullRequestInput(
     };
   }
 
-  const summary =
-    type === "pr_opened"
-      ? `Opened a pull request on ${repoShortName(repository)}`
-      : `Merged a pull request on ${repoShortName(repository)}`;
-
+  const repo = repoShortName(repository);
+  const summary = publicPullRequestSummary(type, repo, number);
   const title = asString(pullRequest?.title) || "a pull request";
   const href = asString(pullRequest?.html_url);
-  const repo = repoShortName(repository);
   const diff = type === "pr_merged" ? pullRequestDiffMeta(pullRequest) : {};
 
   return {

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -877,11 +877,51 @@ export function caffeineDrinkFromEvent(event: ActivityEvent): string {
 }
 
 const PRIVATE_PULL_REQUEST_DUMMY_LABEL = "a pull request";
+const GITHUB_PULL_URL_RE = /github\.com\/[^/]+\/([^/]+)\/pull\/(\d+)/i;
+const PULL_PATH_NUMBER_RE = /\/pull\/(\d+)(?:\/|$|\?|#)/i;
+const SUBJECT_PR_NUMBER_RE = /#(\d+)\s*$/;
+const SUMMARY_ON_REPO_RE = /\son\s+(\S+)\s*$/i;
 
 export function privatePullRequestSummary(type: "pr_opened" | "pr_merged"): string {
   return type === "pr_opened"
     ? "Opened a pull request in a private repo"
     : "Merged a pull request in a private repo";
+}
+
+function asPositiveInt(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const n = Number(value);
+    if (Number.isInteger(n) && n > 0) return n;
+  }
+  return undefined;
+}
+
+function pullRequestNumberFromHref(href: string | undefined): number | undefined {
+  if (!href) return undefined;
+  const github = GITHUB_PULL_URL_RE.exec(href);
+  if (github?.[2]) return asPositiveInt(github[2]);
+  const path = PULL_PATH_NUMBER_RE.exec(href);
+  return path?.[1] ? asPositiveInt(path[1]) : undefined;
+}
+
+function formatPullRequestTarget(number: number | undefined): string {
+  const n = asPositiveInt(number);
+  return n !== undefined ? `#${n}` : "a pull request";
+}
+
+/** `Opened #2324 on briOS`, or `Opened a pull request on briOS` when the number is missing. */
+export function publicPullRequestSummary(
+  type: "pr_opened" | "pr_merged",
+  repo: string | undefined,
+  number: number | undefined,
+): string {
+  const verb = type === "pr_opened" ? "Opened" : "Merged";
+  const target = formatPullRequestTarget(number);
+  const name = repo?.trim();
+  return name ? `${verb} ${target} on ${name}` : `${verb} ${target}`;
 }
 
 function isPrivatePullRequestEvent(
@@ -896,6 +936,30 @@ function publicPullRequestHref(event: ActivityEvent): string | undefined {
   if (event.subject?.href) return event.subject.href;
   const metaHref = event.meta?.href;
   return typeof metaHref === "string" && metaHref ? metaHref : undefined;
+}
+
+function publicPullRequestNumber(event: ActivityEvent): number | undefined {
+  const fromMeta = asPositiveInt(event.meta?.number);
+  if (fromMeta !== undefined) return fromMeta;
+
+  const fromHref = pullRequestNumberFromHref(publicPullRequestHref(event));
+  if (fromHref !== undefined) return fromHref;
+
+  const label = event.subject?.label?.trim();
+  if (!label) return undefined;
+  const fromLabel = SUBJECT_PR_NUMBER_RE.exec(label);
+  return fromLabel?.[1] ? asPositiveInt(fromLabel[1]) : undefined;
+}
+
+function publicPullRequestRepo(event: ActivityEvent): string | undefined {
+  const fromMeta = typeof event.meta?.repo === "string" ? event.meta.repo.trim() : "";
+  if (fromMeta) return fromMeta;
+
+  const href = publicPullRequestHref(event);
+  const github = href ? GITHUB_PULL_URL_RE.exec(href) : null;
+  if (github?.[1]) return github[1];
+
+  return SUMMARY_ON_REPO_RE.exec(event.summary.trim())?.[1];
 }
 
 /** Linked fallback when a visit has no real page title. Never “Home”. */
@@ -1108,7 +1172,11 @@ export function getActivityRow(
   if (event.type === "pr_opened" || event.type === "pr_merged") {
     const href = publicPullRequestHref(event);
     return {
-      summary: event.summary,
+      summary: publicPullRequestSummary(
+        event.type,
+        publicPullRequestRepo(event),
+        publicPullRequestNumber(event),
+      ),
       ...(href ? { href } : {}),
       label: publicPullRequestLabel(event),
     };

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -2412,7 +2412,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Opened a pull request on briOS",
+      summary: "Opened #42 on briOS",
       href: "https://github.com/brianlovin/briOS/pull/42",
       label: "Add activity feed",
     });
@@ -2534,7 +2534,7 @@ describe("getActivityRow private pull requests", () => {
       }),
     );
     expect(row).toEqual({
-      summary: "Opened a pull request on briOS",
+      summary: "Opened #42 on briOS",
       href: "https://github.com/brianlovin/briOS/pull/42",
       label: "Add activity feed",
     });
@@ -2576,7 +2576,7 @@ describe("getActivityRow private pull requests", () => {
       }),
     );
     expect(row).toEqual({
-      summary: "Opened a pull request on briOS",
+      summary: "Opened #42 on briOS",
       href: "https://github.com/brianlovin/briOS/pull/42",
       label: "briOS#42",
     });
@@ -2595,6 +2595,71 @@ describe("getActivityRow private pull requests", () => {
     );
     expect(row.label).toBe("a pull request");
     expect(row.href).toBe("https://github.com/brianlovin/briOS/pull/42");
+  });
+
+  test("opened PR with number 2324 uses Opened #2324 and the repo, not a pull request", () => {
+    const row = getActivityRow(
+      prEvent({
+        summary: "Opened a pull request on briOS",
+        subject: {
+          kind: "pull_request",
+          label: "Add activity feed",
+          href: "https://github.com/brianlovin/briOS/pull/2324",
+        },
+        meta: {
+          repo: "briOS",
+          title: "Add activity feed",
+          number: 2324,
+          href: "https://github.com/brianlovin/briOS/pull/2324",
+        },
+      }),
+    );
+    expect(row.summary).toContain("Opened #2324");
+    expect(row.summary).toContain("briOS");
+    expect(row.summary).not.toContain("a pull request");
+    expect(row.label).toBe("Add activity feed");
+  });
+
+  test("merged PR with number 2 uses Merged #2", () => {
+    const row = getActivityRow(
+      prEvent({
+        type: "pr_merged",
+        summary: "Merged a pull request on staff-design",
+        subject: {
+          kind: "pull_request",
+          label: "First ship",
+          href: "https://github.com/brianlovin/staff-design/pull/2",
+        },
+        meta: {
+          repo: "staff-design",
+          title: "First ship",
+          number: 2,
+          href: "https://github.com/brianlovin/staff-design/pull/2",
+        },
+      }),
+    );
+    expect(row.summary).toContain("Merged #2");
+    expect(row.summary).toContain("staff-design");
+    expect(row.summary).not.toContain("a pull request");
+    expect(row.label).toBe("First ship");
+  });
+
+  test("missing number still says a pull request and has no bare #", () => {
+    const row = getActivityRow(
+      prEvent({
+        summary: "Opened a pull request on briOS",
+        subject: {
+          kind: "pull_request",
+          label: "Add activity feed",
+        },
+        meta: { repo: "briOS", title: "Add activity feed" },
+      }),
+    );
+    expect(row.summary).toBe("Opened a pull request on briOS");
+    expect(row.summary).toContain("a pull request");
+    expect(row.summary).not.toMatch(/#(?!\d)/);
+    expect(row.summary).not.toContain("# ");
+    expect(row.label).toBe("Add activity feed");
   });
 });
 
@@ -3190,12 +3255,12 @@ describe("rollupActivityEvents", () => {
 
     const rows = stacks.map((stack) => getActivityRow(stack.latest));
     expect(rows[0]).toEqual({
-      summary: "Merged a pull request on designdetails",
+      summary: "Merged #719 on designdetails",
       href: "https://github.com/designdetails/designdetails/pull/719",
       label: "Fix player skip",
     });
     expect(rows[1]).toEqual({
-      summary: "Merged a pull request on designdetails",
+      summary: "Merged #720 on designdetails",
       href: "https://github.com/designdetails/designdetails/pull/720",
       label: "Tweak chapter marks",
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public GitHub open/merge rows currently say `Opened a pull request on briOS` plus a grey title. That hides whether the repo is new (`#2`) or busy (`#2324`).

This changes the sentence to include the number when we have one:

- `Opened #2324 on briOS`
- `Merged #2 on staff-design`

The grey title link is unchanged. Stars and non-PR GitHub events are unchanged. Private-repo rows still say `Opened a pull request in a private repo`.

The number comes from `meta.number`, the PR URL, or a `repo#123` subject. If it is missing on an old event, the copy stays `a pull request` so we never render `Merged # on briOS`.

## Tests
- Opened PR `2324` → summary contains `Opened #2324` and the repo, not `a pull request`
- Merged PR `2` → `Merged #2`
- Missing number → still `a pull request`, no bare `#`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b69218a-4d6f-401d-ad86-796907c8521d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b69218a-4d6f-401d-ad86-796907c8521d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

