### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,10 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "./scripts/conductor-setup.sh"
+
+[scripts.run.run]
+available_in = "local"
+command = "bun run generate-schemas && bun run dev -p ${CONDUCTOR_PORT:-3000}"
+default = true
+icon = "play"

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,0 @@
-{
-  "scripts": {
-    "setup": "./scripts/conductor-setup.sh",
-    "run": "bun run generate-schemas && bun run dev -p ${CONDUCTOR_PORT:-3000}"
-  }
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.