### PR TITLE
Wait longer before capturing /sites preview screenshots

### DIFF
--- a/src/lib/screenshot/index.ts
+++ b/src/lib/screenshot/index.ts
@@ -8,7 +8,9 @@ const VIEWPORT = {
 };
 
 const TIMEOUT = 30000; // 30 seconds
-const SETTLE_DELAY = 1500; // Wait for animations/transitions to settle
+// Intro/loading animations often run 1–2s after first paint; wait a bit longer so
+// the screenshot is of the settled page rather than a splash or fade-in.
+const SETTLE_DELAY = 2500;
 
 // Check if running in serverless environment
 const IS_SERVERLESS = !!process.env.AWS_LAMBDA_FUNCTION_NAME || !!process.env.VERCEL;
@@ -73,11 +75,8 @@ export async function captureScreenshot(url: string): Promise<Buffer> {
       timeout: TIMEOUT,
     });
 
-    // Wait for any animations/transitions to settle
-    await page.evaluate(
-      (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
-      SETTLE_DELAY,
-    );
+    // Wait in Node (not page JS) so a site that overrides timers still settles
+    await new Promise((resolve) => setTimeout(resolve, SETTLE_DELAY));
 
     // Take screenshot of the viewport (not full page)
     const screenshot = await page.screenshot({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Site preview screenshots for `/sites` were taken 1.5s after `networkidle2`. Some sites run intro or loading animations for 1–2 seconds after hydration, so the capture could still land on a splash or fade-in.

This waits **2.5s** after the page is network-idle before taking the screenshot, covering those animations with a little extra buffer. The wait now runs in Node rather than `page.evaluate`, so a site that overrides `setTimeout` cannot skip it.

## Test plan

- [x] `bun run lint`
- [x] `bun run build` — `/api/webhooks/capture-site-preview` compiled
- [x] Local fixture: page stays on a red LOADING splash for 1s (hydration) + 2s (intro), then turns green SETTLED
  - 1.5s after network idle still captured LOADING
  - 2.5s after network idle captured SETTLED
  - `captureScreenshot()` captured SETTLED in 3844ms

[1.5s delay still shows LOADING](https://cursor.com/agents/bc-6d9937c7-0cfc-4448-b781-f90947022e4d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_after_1500ms_still_loading.png)
[2.5s delay shows SETTLED](https://cursor.com/agents/bc-6d9937c7-0cfc-4448-b781-f90947022e4d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_after_2500ms_settled.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d9937c7-0cfc-4448-b781-f90947022e4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d9937c7-0cfc-4448-b781-f90947022e4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

