### PR TITLE
Show a black Y Combinator mark for Hacker News activity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,27 @@ This repository is a Next.js 15 project built with TypeScript and Tailwind CSS. 
 - All data fetching hooks should be client-side hooks placed in `src/hooks/` with `"use client"` directive at the top.
 - Favor React hooks and functional components over class components.
 
+## Testing
+
+This site is iterated on visually. Tests lock **user-visible behavior and logic**, not presentation.
+
+Write tests for:
+
+- Copy, labels, hrefs, and visibility (what a person reads or can click)
+- Branching logic (ingest, rollup, title sanitization, path helpers, geo)
+- User flows (what happens when X, then Y)
+
+Do **not** write tests for styling or presentation internals unless the user explicitly asks. That includes:
+
+- Tailwind or CSS class names (`toContain("text-primary")`, `rounded-[3px]`, `dark:invert`)
+- SVG path data or icon geometry (`d="M12.7..."`, path fragments used to prove an icon rendered)
+- Favicon or image `src` strings used only to prove which mark is on screen
+- Spacing, color tokens, `className` combinations, or decorative `aria-hidden` markup
+
+Do not copy that pattern from existing tests. Older activity-feed tests assert on SVG path snippets and favicon URLs; do not add more of those.
+
+If a design change has no logic or copy to assert, skip the unit test and verify it in the browser.
+
 ## Programmatic Checks
 
 Before submitting changes run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ Personal website built with Next.js and Notion as CMS.
 - [Architecture](.claude/architecture.md) — Data flow, UI patterns, tech stack
 - [Commands](.claude/commands.md) — All available scripts and their usage
 
+## Testing
+
+Tests cover user flows and logic (copy, hrefs, ingest/rollup). Do not add tests that assert on CSS classes, Tailwind tokens, SVG path `d` values, or icon markup unless explicitly asked. See `AGENTS.md`.
+
 ## Verification
 
 After making changes:

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -231,6 +231,9 @@ describe("ActivityRow", () => {
     expect(markup).toContain('href="/hn/42991019"');
     expect(markup).not.toContain("a Hacker News story");
     expect(markup).not.toContain(">42991019<");
+    expect(markup).toContain("M12.7 18.5h-1.4v-6.2");
+    expect(markup).toContain("dark:invert");
+    expect(markup).not.toContain("/activity/favicons/brios.png");
   });
 
   test("shows a Hacker News story instead of a raw story id", () => {
@@ -249,6 +252,24 @@ describe("ActivityRow", () => {
     expect(markup).toContain("a Hacker News story");
     expect(markup).toContain('href="/hn/46993596"');
     expect(markup).not.toContain(">46993596<");
+    expect(markup).toContain("M12.7 18.5h-1.4v-6.2");
+    expect(markup).not.toContain("/activity/favicons/brios.png");
+  });
+
+  test("uses the Y Combinator mark for Hacker News index visits", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          summary: "🇺🇸 Visit from United States",
+          subject: { kind: "page", label: "Hacker News", href: "/hn" },
+          meta: { country: "US", path: "/hn", title: "Hacker News" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("M12.7 18.5h-1.4v-6.2");
+    expect(markup).toContain("dark:invert");
+    expect(markup).not.toContain("/activity/favicons/brios.png");
   });
 
   test("uses the event source favicon for visits and downloads", () => {

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -231,9 +231,6 @@ describe("ActivityRow", () => {
     expect(markup).toContain('href="/hn/42991019"');
     expect(markup).not.toContain("a Hacker News story");
     expect(markup).not.toContain(">42991019<");
-    expect(markup).toContain("zm12.7 18.5h-1.4v-6.2");
-    expect(markup).toContain("text-primary rounded-[3px]");
-    expect(markup).not.toContain("/activity/favicons/brios.png");
   });
 
   test("shows a Hacker News story instead of a raw story id", () => {
@@ -252,24 +249,6 @@ describe("ActivityRow", () => {
     expect(markup).toContain("a Hacker News story");
     expect(markup).toContain('href="/hn/46993596"');
     expect(markup).not.toContain(">46993596<");
-    expect(markup).toContain("zm12.7 18.5h-1.4v-6.2");
-    expect(markup).not.toContain("/activity/favicons/brios.png");
-  });
-
-  test("uses the Y Combinator mark for Hacker News index visits", () => {
-    const markup = renderToStaticMarkup(
-      <ActivityRow
-        event={event({
-          summary: "🇺🇸 Visit from United States",
-          subject: { kind: "page", label: "Hacker News", href: "/hn" },
-          meta: { country: "US", path: "/hn", title: "Hacker News" },
-        })}
-      />,
-    );
-
-    expect(markup).toContain("zm12.7 18.5h-1.4v-6.2");
-    expect(markup).toContain("text-primary rounded-[3px]");
-    expect(markup).not.toContain("/activity/favicons/brios.png");
   });
 
   test("uses the event source favicon for visits and downloads", () => {

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -231,8 +231,8 @@ describe("ActivityRow", () => {
     expect(markup).toContain('href="/hn/42991019"');
     expect(markup).not.toContain("a Hacker News story");
     expect(markup).not.toContain(">42991019<");
-    expect(markup).toContain("M12.7 18.5h-1.4v-6.2");
-    expect(markup).toContain("dark:invert");
+    expect(markup).toContain("zm12.7 18.5h-1.4v-6.2");
+    expect(markup).toContain("text-primary rounded-[3px]");
     expect(markup).not.toContain("/activity/favicons/brios.png");
   });
 
@@ -252,7 +252,7 @@ describe("ActivityRow", () => {
     expect(markup).toContain("a Hacker News story");
     expect(markup).toContain('href="/hn/46993596"');
     expect(markup).not.toContain(">46993596<");
-    expect(markup).toContain("M12.7 18.5h-1.4v-6.2");
+    expect(markup).toContain("zm12.7 18.5h-1.4v-6.2");
     expect(markup).not.toContain("/activity/favicons/brios.png");
   });
 
@@ -267,8 +267,8 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("M12.7 18.5h-1.4v-6.2");
-    expect(markup).toContain("dark:invert");
+    expect(markup).toContain("zm12.7 18.5h-1.4v-6.2");
+    expect(markup).toContain("text-primary rounded-[3px]");
     expect(markup).not.toContain("/activity/favicons/brios.png");
   });
 

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -19,6 +19,7 @@ import { Heart } from "@/components/icons/Heart";
 import { Shiori } from "@/components/icons/Shiori";
 import { StaffDesign } from "@/components/icons/StaffDesign";
 import { World } from "@/components/icons/World";
+import { YCombinator } from "@/components/icons/YCombinator";
 import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { SlotDigits } from "@/components/SlotDigits";
 import { useTopBarActions } from "@/components/TopBarActions";
@@ -47,6 +48,7 @@ import {
   formatLikeOthersLabel,
   getActivityRow,
   getMergedPullRequestDiff,
+  isHnActivityEvent,
   isHomeLikeTitle,
   resolveActivitySourceHref,
 } from "@/lib/activity-shared";
@@ -100,6 +102,9 @@ function ActivityRowIcon({ event, icon }: { event: ActivityEvent; icon?: string 
   }
 
   if (event.type === "visit" || event.type === "visit_country_first" || event.type === "download") {
+    if (isHnActivityEvent(event)) {
+      return <YCombinator size={16} />;
+    }
     const faviconSrc = activitySourceFaviconSrc(event.source);
     if (faviconSrc) {
       return <ActivitySourceFavicon src={faviconSrc} />;

--- a/src/components/icons/YCombinator.tsx
+++ b/src/components/icons/YCombinator.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils";
+
+import { IconProps } from "./types";
+
+/** Y Combinator square mark. Black in light mode; inverted in dark mode. */
+export function YCombinator({ size = 16, className, ...rest }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={cn("rounded-[3px] dark:invert", className)}
+      aria-hidden
+      {...rest}
+    >
+      <path fill="#000" d="M0 0h24v24H0z" />
+      <path
+        fill="#fff"
+        d="M12.7 18.5h-1.4v-6.2L7.1 5.5h1.7l3.2 6.3c.1.2.2.5.3.8h.1c.1-.3.2-.6.3-.8l3.2-6.3h1.7l-4.2 6.8v6.2z"
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/YCombinator.tsx
+++ b/src/components/icons/YCombinator.tsx
@@ -2,21 +2,21 @@ import { cn } from "@/lib/utils";
 
 import { IconProps } from "./types";
 
-/** Y Combinator square mark. Black in light mode; inverted in dark mode. */
+/** Y Combinator square mark. Follows text color so it inverts in dark mode. */
 export function YCombinator({ size = 16, className, ...rest }: IconProps) {
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      className={cn("rounded-[3px] dark:invert", className)}
+      className={cn("text-primary rounded-[3px]", className)}
       aria-hidden
       {...rest}
     >
-      <path fill="#000" d="M0 0h24v24H0z" />
       <path
-        fill="#fff"
-        d="M12.7 18.5h-1.4v-6.2L7.1 5.5h1.7l3.2 6.3c.1.2.2.5.3.8h.1c.1-.3.2-.6.3-.8l3.2-6.3h1.7l-4.2 6.8v6.2z"
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M0 0h24v24H0V0zm12.7 18.5h-1.4v-6.2L7.1 5.5h1.7l3.2 6.3c.1.2.2.5.3.8h.1c.1-.3.2-.6.3-.8l3.2-6.3h1.7l-4.2 6.8v6.2z"
       />
     </svg>
   );

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -377,6 +377,19 @@ export function hnStoryIdFromPath(pathname: string): string | undefined {
   return match?.[1];
 }
 
+/** `/hn` index or `/hn/*` story routes (and absolute briOS URLs). */
+export function isHnActivityPath(value: string | undefined): boolean {
+  if (!value?.trim()) return false;
+  const path = normalizeActivityPath(pathnameFromHref(value));
+  return path === "/hn" || path.startsWith("/hn/");
+}
+
+export function isHnActivityEvent(event: Pick<ActivityEvent, "subject" | "meta">): boolean {
+  if (isHnActivityPath(event.subject?.href)) return true;
+  const path = event.meta?.path;
+  return typeof path === "string" && isHnActivityPath(path);
+}
+
 /** Writing/TIL child slug from `/writing/{slug}` or `/til/{slug}` (and absolute URLs). */
 export function cmsPostRefFromPath(
   pathname: string,

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -30,6 +30,8 @@ import {
   inferTitleFromPath,
   ingestActivityEvent,
   isHiddenLikeEvent,
+  isHnActivityEvent,
+  isHnActivityPath,
   isSlugLikeActivityTitle,
   likeActivityPayload,
   likeMetaFromRequest,
@@ -1475,6 +1477,32 @@ describe("inferTitleFromPath", () => {
   test("never returns a page for an unknown or empty path", () => {
     expect(inferTitleFromPath("/mystery")).toBe("mystery");
     expect(inferTitleFromPath("")).toBe("Home");
+  });
+
+  test("recognizes Hacker News activity paths and events", () => {
+    expect(isHnActivityPath("/hn")).toBe(true);
+    expect(isHnActivityPath("/hn/")).toBe(true);
+    expect(isHnActivityPath("/hn/42991019")).toBe(true);
+    expect(isHnActivityPath("https://brianlovin.com/hn/42991019")).toBe(true);
+    expect(isHnActivityPath("/writing/a-post")).toBe(false);
+    expect(isHnActivityPath("/")).toBe(false);
+    expect(isHnActivityPath(undefined)).toBe(false);
+
+    expect(
+      isHnActivityEvent({
+        subject: { kind: "page", label: "Some HN Story", href: "/hn/42991019" },
+      }),
+    ).toBe(true);
+    expect(
+      isHnActivityEvent({
+        meta: { path: "/hn/42991019" },
+      }),
+    ).toBe(true);
+    expect(
+      isHnActivityEvent({
+        subject: { kind: "writing", label: "A post", href: "/writing/a-post" },
+      }),
+    ).toBe(false);
   });
 
   test("uses a contextual phrase for identifier routes instead of the raw id", () => {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -137,6 +137,8 @@ export {
   isCoffeeFamilyDrink,
   isGenericHnStoryTitle,
   isHiddenLikeEvent,
+  isHnActivityEvent,
+  isHnActivityPath,
   isHomeLikeTitle,
   isKnownActivitySection,
   isKnownActivityTitle,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HN visits on `/activity` currently use the site favicon, which makes those rows look like original writing.

This switches `/hn` and `/hn/*` visit (and download) events to a monochrome Y Combinator square SVG. The mark uses `currentColor` / `text-primary` so it is black in light mode and inverts with the rest of the UI in dark mode.

Likes still use the heart. Other site visits still use the briOS favicon.

Also encodes a testing rule in `AGENTS.md` / `CLAUDE.md`: tests cover user flows and logic (copy, hrefs, ingest/rollup), not CSS classes, SVG path data, or icon markup, unless explicitly requested.

## Testing
- Unit tests for HN path detection and activity row copy/hrefs
- Lint and production build
- Manual check of `/activity` against live HN visit rows

[Activity feed HN rows using the black Y Combinator mark](https://cursor.com/agents/bc-4ca29e63-cd76-49e4-99c6-f79262920e0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_hn_yc_logo_light.webp)
[activity_hn_yc_logo_walkthrough.mp4](https://cursor.com/agents/bc-4ca29e63-cd76-49e4-99c6-f79262920e0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_hn_yc_logo_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ca29e63-cd76-49e4-99c6-f79262920e0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca29e63-cd76-49e4-99c6-f79262920e0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

