### PR TITLE
Show saved site titles on /activity and use a compass icon

### DIFF
--- a/src/app/api/webhooks/capture-site-preview/route.ts
+++ b/src/app/api/webhooks/capture-site-preview/route.ts
@@ -118,7 +118,7 @@ export async function POST(request: Request) {
       await purgeContentType("sites");
 
       afterActivity((store) =>
-        recordSiteAdded({ id: pageId, title: titleFromNotionPage(currentPage) }, store),
+        recordSiteAdded({ id: pageId, title: titleFromNotionPage(currentPage), url }, store),
       );
 
       return NextResponse.json(

--- a/src/app/api/webhooks/update-site-icon/route.ts
+++ b/src/app/api/webhooks/update-site-icon/route.ts
@@ -119,7 +119,7 @@ export async function POST(request: Request) {
 
     const page = await notion.pages.retrieve({ page_id: pageId });
     afterActivity((store) =>
-      recordSiteAdded({ id: pageId, title: titleFromNotionPage(page) }, store),
+      recordSiteAdded({ id: pageId, title: titleFromNotionPage(page), url }, store),
     );
 
     return NextResponse.json(

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -411,6 +411,49 @@ describe("ActivityRow", () => {
     }
   });
 
+  test("uses the Compass icon and saved title for site_added events", () => {
+    const pulsePath = "M4.75 11.75H8.25L10.25 4.75L13.75 19.25L15.75 11.75H19.25";
+    const compassNeedle =
+      "M10.409 10.409L15.2499 8.74997L13.591 13.591L8.75012 15.25L10.409 10.409Z";
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "site_added",
+          speed: "event",
+          summary: "A good website was added",
+          subject: { kind: "site", label: "Linear", href: "https://linear.app" },
+          meta: { title: "Linear", href: "https://linear.app" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain(compassNeedle);
+    expect(markup).not.toContain(pulsePath);
+    expect(markup).toContain("A good website was added");
+    expect(markup).toContain(">Linear<");
+    expect(markup).not.toContain(">Sites<");
+    expect(markup).toContain('href="https://linear.app"');
+  });
+
+  test("links a stored site title to /sites when the event has no site URL", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityRow
+        event={event({
+          type: "site_added",
+          speed: "event",
+          summary: "A good website was added",
+          subject: { kind: "site", label: "A good website", href: "/sites" },
+          meta: { title: "A good website", href: "/sites" },
+        })}
+      />,
+    );
+
+    expect(markup).toContain("A good website was added");
+    expect(markup).toContain(">A good website<");
+    expect(markup).not.toContain(">Sites<");
+    expect(markup).toContain('href="/sites"');
+  });
+
   test("links Tax UI in a download summary even without subject.href", () => {
     const markup = renderToStaticMarkup(
       <ActivityRow

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -14,6 +14,7 @@ import {
 
 import { ActivityGlobe, type ActivityGlobeAimRequest } from "@/components/ActivityGlobe";
 import { Activity } from "@/components/icons/Activity";
+import { Compass } from "@/components/icons/Compass";
 import { Github } from "@/components/icons/Github";
 import { Heart } from "@/components/icons/Heart";
 import { Shiori } from "@/components/icons/Shiori";
@@ -113,6 +114,10 @@ function ActivityRowIcon({ event, icon }: { event: ActivityEvent; icon?: string 
         {icon ?? "🥤"}
       </span>
     );
+  }
+
+  if (event.type === "site_added") {
+    return <Compass size={16} className="text-tertiary" aria-hidden />;
   }
 
   return <Activity size={16} className="text-tertiary" aria-hidden />;

--- a/src/lib/activity-from-notion.ts
+++ b/src/lib/activity-from-notion.ts
@@ -9,7 +9,7 @@ import {
   recordWritingPublished,
 } from "./activity";
 import { notion } from "./notion/client";
-import { richText, select, title } from "./notion/properties";
+import { richText, select, title, url } from "./notion/properties";
 import { type PurgeableContentType } from "./notion/purge";
 import { isFullPage, type PageResponse } from "./notion/types";
 import { buildSlug } from "./short-id";
@@ -57,7 +57,14 @@ export async function ingestActivityFromContentPurge(
       return;
     }
     case "sites": {
-      await recordSiteAdded({ id: pageId, title: title(properties, "Name") ?? "Untitled" }, store);
+      await recordSiteAdded(
+        {
+          id: pageId,
+          title: title(properties, "Name") ?? "Untitled",
+          url: url(properties, "URL"),
+        },
+        store,
+      );
       return;
     }
   }

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -171,6 +171,14 @@ export function activityRollupKey(event: ActivityEvent): string {
     return `${event.source}:${event.type}:${pullRequestIdentity(event)}`;
   }
 
+  if (event.type === "site_added" || event.type === "stack_added") {
+    const identity =
+      event.subject?.label?.trim() ||
+      (typeof event.meta?.title === "string" ? event.meta.title.trim() : "") ||
+      event.summary;
+    return `${event.source}:${event.type}:${identity}`;
+  }
+
   return `${event.source}:${event.type}:${event.summary}`;
 }
 

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -1244,6 +1244,18 @@ export function getActivityRow(
     return attachSourceMetadata(event, { summary: "Someone clicked a link on" });
   }
 
+  // List-page hrefs like `/sites` or `/stack` would otherwise replace a
+  // specific item name with the section title ("Sites", "Stack").
+  if (event.type === "site_added" || event.type === "stack_added") {
+    return attachSourceMetadata(event, {
+      summary: event.summary,
+      href: event.subject?.href,
+      label: displaySubjectLabel(event.subject?.label, event.subject?.href, {
+        preferStored: true,
+      }),
+    });
+  }
+
   return attachSourceMetadata(event, {
     summary: event.summary,
     href: event.subject?.href,

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -40,6 +40,7 @@ import {
   recordCaffeine,
   recordDigestSubscribed,
   recordLike,
+  recordSiteAdded,
   recordVisit,
   resolveActivitySourceHref,
   resolveIngestVisitTitle,
@@ -1946,6 +1947,50 @@ describe("getActivityRow page titles", () => {
     });
   });
 
+  test("keeps a saved site title instead of rewriting it to Sites", () => {
+    const row = getActivityRow({
+      v: 1,
+      id: "site-linear",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "brios",
+      type: "site_added",
+      speed: "event",
+      summary: "A good website was added",
+      visibility: "public",
+      idempotency_key: "brios:site_added:linear",
+      subject: { kind: "site", label: "Linear", href: "/sites" },
+      meta: { title: "Linear", href: "/sites" },
+    });
+    expect(row).toEqual({
+      summary: "A good website was added",
+      href: "/sites",
+      label: "Linear",
+    });
+  });
+
+  test("keeps a saved stack item title instead of rewriting it to Stack", () => {
+    const row = getActivityRow({
+      v: 1,
+      id: "stack-cursor",
+      ts: "2026-08-16T00:00:00.000Z",
+      received_at: "2026-08-16T00:00:00.000Z",
+      source: "brios",
+      type: "stack_added",
+      speed: "event",
+      summary: "A stack item was added",
+      visibility: "public",
+      idempotency_key: "brios:stack_added:cursor",
+      subject: { kind: "stack", label: "Cursor", href: "/stack" },
+      meta: { title: "Cursor", href: "/stack" },
+    });
+    expect(row).toEqual({
+      summary: "A stack item was added",
+      href: "/stack",
+      label: "Cursor",
+    });
+  });
+
   test("title-cases a stored like slug without rewriting Redis", () => {
     const row = getActivityRow({
       v: 1,
@@ -3393,6 +3438,33 @@ describe("rollupActivityEvents", () => {
     expect(stacks[0]?.sectionLabel).toBe("Fix player skip");
   });
 
+  test("does not roll up consecutive site_added events for different sites", () => {
+    const site = (id: string, title: string, href: string): ActivityEvent =>
+      feedEvent({
+        id,
+        type: "site_added",
+        summary: "A good website was added",
+        subject: { kind: "site", label: title, href },
+        meta: { title, href },
+      });
+
+    const linear = site("site-linear", "Linear", "https://linear.app");
+    const notion = site("site-notion", "Notion", "https://www.notion.so");
+    const stacks = rollupActivityEvents([linear, notion]);
+
+    expect(stacks).toHaveLength(2);
+    expect(activityRollupKey(linear)).not.toBe(activityRollupKey(notion));
+    expect(stacks[0]?.sectionLabel).toBe("Linear");
+    expect(stacks[1]?.sectionLabel).toBe("Notion");
+    expect(stacks[0]?.href).toBe("https://linear.app");
+    expect(stacks[1]?.href).toBe("https://www.notion.so");
+    expect(getActivityRow(linear)).toEqual({
+      summary: "A good website was added",
+      href: "https://linear.app",
+      label: "Linear",
+    });
+  });
+
   test("uses the latest absolute href when a stacked run has mixed GitHub URLs", () => {
     const stacked = (id: string, path: string, label: string): ActivityEvent =>
       feedEvent({
@@ -3711,6 +3783,61 @@ describe("rollupActivityEvents", () => {
         { key: "shiori:link_saved:old-anchor", count: 16 },
       ),
     ).toBe(true);
+  });
+});
+
+describe("recordSiteAdded", () => {
+  test("stores the site title and links to the saved URL", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordSiteAdded(
+      { id: "page-1", title: "Linear", url: "https://linear.app" },
+      store,
+    );
+
+    expect(result.ok && !result.duplicate).toBe(true);
+    const [event] = await store.getTail(1);
+    expect(event?.type).toBe("site_added");
+    expect(event?.summary).toBe("A good website was added");
+    expect(event?.subject).toEqual({
+      kind: "site",
+      label: "Linear",
+      href: "https://linear.app",
+    });
+    expect(event?.meta).toEqual({ title: "Linear", href: "https://linear.app" });
+    expect(event?.idempotency_key).toBe("brios:site_added:page-1");
+    expect(getActivityRow(event!)).toEqual({
+      summary: "A good website was added",
+      href: "https://linear.app",
+      label: "Linear",
+    });
+  });
+
+  test("falls back to /sites when the URL is missing or not http(s)", async () => {
+    const store = createMemoryActivityStore();
+    const result = await recordSiteAdded({ id: "page-2", title: "A good website" }, store);
+
+    expect(result.ok && !result.duplicate).toBe(true);
+    const [event] = await store.getTail(1);
+    expect(event?.subject).toEqual({
+      kind: "site",
+      label: "A good website",
+      href: "/sites",
+    });
+    expect(getActivityRow(event!)).toEqual({
+      summary: "A good website was added",
+      href: "/sites",
+      label: "A good website",
+    });
+  });
+
+  test("is idempotent for the same Notion page", async () => {
+    const store = createMemoryActivityStore();
+    const first = await recordSiteAdded({ id: "page-1", title: "Linear" }, store);
+    const second = await recordSiteAdded({ id: "page-1", title: "Linear" }, store);
+
+    expect(first.ok && !first.duplicate).toBe(true);
+    expect(second.ok && second.duplicate).toBe(true);
+    expect(await store.getStreamLength()).toBe(1);
   });
 });
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -31,6 +31,7 @@ import {
   formatDownloadSummary,
   hnStoryIdFromPath,
   inferContentTypeFromPath,
+  isAbsoluteHttpUrl,
   isActivityPath,
   isGenericHnStoryTitle,
   isHomeLikeTitle,
@@ -748,13 +749,18 @@ export async function recordStackAdded(
   );
 }
 
+function siteAddedHref(url?: string): string {
+  const trimmed = url?.trim();
+  return trimmed && isAbsoluteHttpUrl(trimmed) ? trimmed : "/sites";
+}
+
 export async function recordSiteAdded(
-  input: { id: string; title: string },
+  input: { id: string; title: string; url?: string },
   store: ActivityStore,
   now: Date = new Date(),
 ): Promise<IngestResult> {
   const title = input.title.trim() || "a site";
-  const href = "/sites";
+  const href = siteAddedHref(input.url);
   return recordBriosEvent(
     {
       type: "site_added",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`site_added` events on `/activity` now show the saved site **Title** (instead of the generic “Sites” section label) and use a compass icon.

## How this event is triggered

A new site in the Notion Good Websites database is recorded after those automations finish:

1. **`POST /api/webhooks/update-site-icon`** — Notion automation that fetches and uploads the favicon
2. **`POST /api/webhooks/capture-site-preview`** — Notion automation that captures the screenshot
3. **`POST /api/purge-cache?type=sites`** — cache purge for a specific Notion page (`ingestActivityFromContentPurge`)

All three call `recordSiteAdded({ id, title, url })`. The idempotency key is `brios:site_added:{notionPageId}`, so the same page only appears once even if both webhooks fire.

The title was already stored from the Notion `Name` property. The feed then rewrote list-page hrefs like `/sites` to the section label “Sites”, which hid it.

## Changes

- Keep the stored title for `site_added` / `stack_added` (same list-page href issue)
- Link the title to the site URL when the webhook/purge path has one; otherwise `/sites`
- Use the compass icon for `site_added`
- Do not roll consecutive different sites into one “×N Sites” row

## Testing

`bun test src/lib/activity.test.ts src/components/ActivityFeed.test.tsx src/lib/activity-from-notion.test.ts src/lib/activity-registry.test.ts` — 258 pass.

Live `/activity` feed after the change, with existing Redis events (`Resurf`, `Deep Lakhani`) now showing titles and the compass icon:

[Activity feed showing site_added rows with Resurf and Deep Lakhani titles and compass icons](https://cursor.com/agents/bc-b77c3304-4310-4903-95d0-578b5fddcccb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_site_added_resurf_and_deep_lakhani.webp)

[activity_site_added_title_and_compass.mp4](https://cursor.com/agents/bc-b77c3304-4310-4903-95d0-578b5fddcccb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_site_added_title_and_compass.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b77c3304-4310-4903-95d0-578b5fddcccb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b77c3304-4310-4903-95d0-578b5fddcccb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

