### PR TITLE
Polish the activity globe fade and add a local sandbox

### DIFF
--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -33,7 +33,7 @@ function ActivityFallback() {
                 <div className="flex size-8 flex-none items-center justify-center">
                   <LoadingSkeleton className="size-6" />
                 </div>
-                <LoadingSkeleton className="h-5 w-2/3" />
+                <LoadingSkeleton className="h-3 w-2/3" />
               </div>
             ))}
           </div>

--- a/src/app/activity/sandbox/page.tsx
+++ b/src/app/activity/sandbox/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { ActivitySandbox } from "@/components/ActivitySandbox";
+import { createMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = createMetadata({
+  title: "Activity Sandbox",
+  description: "Simulate activity-feed events without writing to Redis.",
+  path: "/activity/sandbox",
+  noIndex: true,
+});
+
+export default function ActivitySandboxPage() {
+  if (process.env.NODE_ENV === "production") notFound();
+  return <ActivitySandbox />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -251,24 +251,35 @@
       animation: none;
     }
   }
-  /* Flat disc: solid fill, not a lit marble. */
-  .activity-globe-orb {
+
+  /* Official COBE bindable-marker fade: --cobe-visible-{id} is `N` or unset. */
+  .activity-globe-dot {
     position: absolute;
-    left: 0;
-    top: 0;
     z-index: 1;
-    pointer-events: none;
-    width: 0.875rem;
-    height: 0.875rem;
     border-radius: 9999px;
-    background-color: #fc532a;
-    box-shadow:
-      0 1px 1px rgba(0, 0, 0, 0.22),
-      inset 0 1px 1px rgba(255, 255, 255, 0.2);
-    opacity: calc(0.12 + var(--orb-facing, 0) * 0.88);
-    transform: translate(-50%, -50%) scale(calc(0.32 + var(--orb-facing, 0) * 0.78));
-    filter: blur(calc((1 - var(--orb-facing, 0)) * 1.4px));
-    will-change: left, top, opacity, transform, filter;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+  }
+  .activity-globe-dot.is-focused {
+    background-color: rgb(255 148 72);
+    box-shadow: 0 0 14px rgb(252 83 42 / 0.65);
+    animation: activity-globe-focus var(--activity-globe-focus-ms, 1.2s) ease-out;
+  }
+  @keyframes activity-globe-focus {
+    0% {
+      transform: translate(-50%, -50%) scale(1);
+    }
+    35% {
+      transform: translate(-50%, -50%) scale(var(--activity-globe-focus-scale, 1.45));
+    }
+    100% {
+      transform: translate(-50%, -50%) scale(1);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .activity-globe-dot.is-focused {
+      animation: none;
+    }
   }
   @keyframes zoom-in {
     from {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,28 +256,32 @@
   .activity-globe-dot {
     position: absolute;
     z-index: 1;
-    border-radius: 9999px;
     pointer-events: none;
     transform: translate(-50%, -50%);
   }
-  .activity-globe-dot.is-focused {
+  .activity-globe-dot-core {
+    display: block;
+    border-radius: 9999px;
+    transition: opacity 300ms ease;
+  }
+  .activity-globe-dot.is-focused .activity-globe-dot-core {
     background-color: rgb(255 148 72);
     box-shadow: 0 0 14px rgb(252 83 42 / 0.65);
     animation: activity-globe-focus var(--activity-globe-focus-ms, 1.2s) ease-out;
   }
   @keyframes activity-globe-focus {
     0% {
-      transform: translate(-50%, -50%) scale(1);
+      transform: scale(1);
     }
     35% {
-      transform: translate(-50%, -50%) scale(var(--activity-globe-focus-scale, 1.45));
+      transform: scale(var(--activity-globe-focus-scale, 1.45));
     }
     100% {
-      transform: translate(-50%, -50%) scale(1);
+      transform: scale(1);
     }
   }
   @media (prefers-reduced-motion: reduce) {
-    .activity-globe-dot.is-focused {
+    .activity-globe-dot.is-focused .activity-globe-dot-core {
       animation: none;
     }
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -262,26 +262,33 @@
   .activity-globe-dot-core {
     display: block;
     border-radius: 9999px;
-    transition: opacity 300ms ease;
+    transition:
+      width 300ms ease,
+      height 300ms ease,
+      box-shadow 300ms ease;
+    box-shadow: 0 0 calc(var(--activity-globe-dot-px, 12px) * 1.15) rgb(252 83 42 / 0.95);
   }
-  .activity-globe-dot.is-focused .activity-globe-dot-core {
-    background-color: rgb(255 148 72);
-    box-shadow: 0 0 14px rgb(252 83 42 / 0.65);
-    animation: activity-globe-focus var(--activity-globe-focus-ms, 1.2s) ease-out;
+  .activity-globe-dot-core.is-focused {
+    background-color: rgb(255 196 92);
+    box-shadow: 0 0 calc(var(--activity-globe-dot-px, 12px) * 2.2) rgb(255 150 60 / 1);
+    animation: activity-globe-focus var(--activity-globe-focus-ms, 1.4s) ease-out;
   }
   @keyframes activity-globe-focus {
     0% {
       transform: scale(1);
+      filter: brightness(1);
     }
-    35% {
-      transform: scale(var(--activity-globe-focus-scale, 1.45));
+    28% {
+      transform: scale(var(--activity-globe-focus-scale, 1.75));
+      filter: brightness(1.55);
     }
     100% {
       transform: scale(1);
+      filter: brightness(1);
     }
   }
   @media (prefers-reduced-motion: reduce) {
-    .activity-globe-dot.is-focused .activity-globe-dot-core {
+    .activity-globe-dot-core.is-focused {
       animation: none;
     }
   }

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -40,7 +40,7 @@ describe("ActivityRow", () => {
     expect(markup).not.toContain("🇮🇳");
     expect(markup).toContain("/activity/favicons/brios.png");
     expect(markup).toContain('href="/"');
-    expect(markup).toContain("the site");
+    expect(markup).toContain("brianlovin.com");
     expect(markup).not.toContain("Home");
     expect(markup).not.toContain("a page");
   });
@@ -294,7 +294,7 @@ describe("ActivityRow", () => {
     expect(download).toContain('target="_blank"');
     expect(download).toContain("noopener noreferrer");
     expect(unknown).not.toContain("/activity/favicons/");
-    expect(unknown).toContain("Someone from United States visited the site");
+    expect(unknown).toContain("Someone from United States visited brianlovin.com");
     expect(unknown).not.toContain("Visit from");
     expect(unknown).not.toContain("🇺🇸");
   });
@@ -304,7 +304,7 @@ describe("ActivityRow", () => {
       <ActivityRow event={event({ summary: "Visit from TW", meta: { country: "TW" } })} />,
     );
     expect(markup).not.toContain("🇹🇼");
-    expect(markup).toContain("Someone from Taiwan visited the site");
+    expect(markup).toContain("Someone from Taiwan visited brianlovin.com");
     expect(markup).not.toContain("Visit from");
   });
 
@@ -319,7 +319,7 @@ describe("ActivityRow", () => {
     );
 
     expect(markup).toContain("Someone from a mysterious place on earth visited");
-    expect(markup).toContain("the site");
+    expect(markup).toContain("brianlovin.com");
     expect(markup).not.toContain("Someone visited from a mysterious place on earth");
     expect(markup).not.toContain("Home");
     expect(markup).not.toContain(">Visit<");
@@ -920,7 +920,7 @@ describe("ActivityRow", () => {
     expect(staff).not.toContain("Visit from");
     expect(staff).not.toContain("🇺🇸");
     expect(staff).toContain(">Staff.design<");
-    expect(staff).not.toContain("the site");
+    expect(staff).not.toContain("brianlovin.com");
     expect(staff).toContain('href="https://staff.design"');
     expect(staff).toContain('target="_blank"');
     expect(details).toContain("Someone from San Francisco");
@@ -1009,7 +1009,7 @@ describe("ActivityRow", () => {
     expect(like).toContain('href="/writing/grok-bot-first-impressions"');
     expect(like).not.toContain(">briOS<");
     expect(like).not.toContain('target="_blank"');
-    expect(visit).toContain(">the site<");
+    expect(visit).toContain(">brianlovin.com<");
     expect(visit).toContain('href="/"');
     expect(visit).not.toContain(">Home<");
     expect(visit).not.toContain(">briOS<");
@@ -1104,7 +1104,7 @@ describe("ActivityFeed", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from India visited the site");
+    expect(markup).toContain("Someone from India visited brianlovin.com");
     expect(markup).not.toContain("Visit from");
     expect(markup).not.toContain("🇮🇳");
     expect(markup).not.toContain(">Event<");
@@ -1240,9 +1240,11 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("Listening");
     expect(markup).toContain("AMA");
     expect(markup).toContain("visited");
-    expect(markup).toContain("the site");
-    expect(markup.indexOf("the site")).toBeLessThan(markup.indexOf("AMA"));
+    expect(markup).toContain("brianlovin.com");
+    expect(markup.indexOf("brianlovin.com")).toBeLessThan(markup.indexOf("AMA"));
     expect(markup.indexOf("AMA")).toBeLessThan(markup.indexOf("Listening"));
+    expect(markup).toContain('data-visit-rail="hook"');
+    expect(markup).not.toContain('data-visit-rail="line"');
   });
 
   test("staff.design home cluster actions say visited Staff.design", () => {
@@ -1288,7 +1290,70 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("visited");
     expect(markup).toContain(">Staff.design<");
     expect(markup).toContain("Karla Mickens Cole");
-    expect(markup).not.toContain("the site");
+    expect(markup).not.toContain("brianlovin.com");
+  });
+
+  test("keeps one location cluster and marks a property change on the rail", () => {
+    const sf = {
+      country: "US",
+      country_name: "United States",
+      region: "CA",
+      region_name: "California",
+      city: "San Francisco",
+    };
+    const markup = renderToStaticMarkup(
+      <ActivityFeed
+        initialEvents={[
+          event({
+            id: "sf-staff-home",
+            source: "staff-design",
+            summary: "Visit from San Francisco, California, United States",
+            subject: { kind: "home", label: "Home", href: "/" },
+            meta: { ...sf, path: "/", title: "Home" },
+          }),
+          event({
+            id: "sf-vivian",
+            source: "staff-design",
+            summary: "Visit from San Francisco, California, United States",
+            subject: {
+              kind: "page",
+              label: "Vivian Wang",
+              href: "/interviews/vivian-wang",
+            },
+            meta: { ...sf, path: "/interviews/vivian-wang", title: "Vivian Wang" },
+          }),
+          event({
+            id: "sf-stack",
+            summary: "Visit from San Francisco, California, United States",
+            subject: { kind: "page", label: "Stack", href: "/stack" },
+            meta: { ...sf, path: "/stack" },
+          }),
+          event({
+            id: "sf-home",
+            summary: "Visit from San Francisco, California, United States",
+            subject: { kind: "home", label: "Home", href: "/" },
+            meta: { ...sf, path: "/", title: "Home" },
+          }),
+        ]}
+        initialCount={4}
+      />,
+    );
+
+    expect(markup.match(/Someone from San Francisco/g)?.length).toBe(1);
+    expect(markup).toContain("/activity/favicons/brios.png");
+    expect(markup).toContain('data-visit-source-mark="staff-design"');
+    expect(markup).not.toContain('data-visit-source-mark="brios"');
+    expect(markup).toContain('data-visit-rail="line"');
+    expect(markup).toContain('data-visit-rail="hook"');
+    expect(markup.match(/data-visit-rail="/g)?.length).toBe(2);
+    expect(markup).toContain('data-visit-rail-inset="end"');
+    expect(markup).toContain('data-visit-rail-inset="start"');
+    expect(markup).toContain("brianlovin.com");
+    expect(markup).toContain("Stack");
+    expect(markup).toContain("Vivian Wang");
+    expect(markup).toContain(">Staff.design<");
+    expect(markup.indexOf("brianlovin.com")).toBeLessThan(markup.indexOf("Stack"));
+    expect(markup.indexOf("Stack")).toBeLessThan(markup.indexOf("Vivian Wang"));
   });
 
   test("a different location in the middle labels two visit clusters", () => {

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -1393,6 +1393,27 @@ describe("ActivityFeed", () => {
     expect(markup).toContain("AMA");
   });
 
+  test("renders controlled events without the empty state", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityFeed
+        initialEvents={[]}
+        initialCount={0}
+        events={[
+          event({
+            id: "sandbox-1",
+            summary: "Visit from San Francisco, California, United States",
+            subject: { kind: "page", label: "AMA", href: "/ama" },
+            meta: { country: "US", city: "San Francisco", path: "/ama" },
+          }),
+        ]}
+        count={1}
+      />,
+    );
+
+    expect(markup).toContain("Someone from San Francisco");
+    expect(markup).not.toContain("Nothing yet. Likes and visits will show up here.");
+  });
+
   test("shows the end-cap after a non-empty feed and not on the empty state", () => {
     const empty = renderToStaticMarkup(<ActivityFeed initialEvents={[]} initialCount={0} />);
     const filled = renderToStaticMarkup(
@@ -1419,6 +1440,14 @@ describe("ActivityLiveBadge", () => {
     expect(activity).toContain("Live");
     expect(writing).toContain("Writing");
     expect(writing).not.toContain("Live");
+  });
+
+  test("shows Sandbox instead of Live on the sandbox route", () => {
+    const sandbox = renderToStaticMarkup(<TopBarTrail pathname="/activity/sandbox" />);
+    expect(sandbox).toContain("Activity");
+    expect(sandbox).toContain("Sandbox");
+    expect(sandbox).not.toContain("Live");
+    expect(renderToStaticMarkup(<ActivityLiveBadge sandbox />)).toContain("Sandbox");
   });
 });
 

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -4,7 +4,6 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import {
   type ReactNode,
-  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -12,7 +11,7 @@ import {
   useSyncExternalStore,
 } from "react";
 
-import { ActivityGlobe, type ActivityGlobeAimRequest } from "@/components/ActivityGlobe";
+import { ActivityGlobe } from "@/components/ActivityGlobe";
 import { Activity } from "@/components/icons/Activity";
 import { Github } from "@/components/icons/Github";
 import { Heart } from "@/components/icons/Heart";
@@ -24,7 +23,6 @@ import { SlotDigits } from "@/components/SlotDigits";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import {
   type ActivityEvent,
-  activityEventLocation,
   type ActivityFeedItem,
   type ActivityLikeTarget,
   type ActivityRollup,
@@ -208,7 +206,6 @@ export function ActivityRow({
   href: hrefOverride,
   pulse = false,
   likeTargets: likeTargetsProp,
-  onAimGlobe,
 }: {
   event: ActivityEvent;
   count?: number;
@@ -216,7 +213,6 @@ export function ActivityRow({
   href?: string;
   pulse?: boolean;
   likeTargets?: ActivityLikeTarget[];
-  onAimGlobe?: (event: ActivityEvent) => void;
 }) {
   const row = getActivityRow(event);
   const homeUrl = activitySourceUrl(event.source);
@@ -234,7 +230,6 @@ export function ActivityRow({
   const context = isLike ? likeTitle : (label ?? (href || undefined));
   const diff = event.type === "pr_merged" ? getMergedPullRequestDiff(event.meta) : null;
   const showCountChip = count > 1 && !(isLike && othersCount > 0);
-  const canAimGlobe = Boolean(onAimGlobe && activityEventLocation(event));
 
   if (isLike && likeTargets.length === 0) {
     return null;
@@ -243,18 +238,7 @@ export function ActivityRow({
   return (
     <div
       data-rollup-pulse={pulse ? "" : undefined}
-      className={cn(
-        "group hover:bg-secondary relative isolate flex items-center gap-3 px-4 py-3 md:py-2 md:dark:hover:bg-white/5",
-        canAimGlobe && "cursor-pointer",
-      )}
-      onClick={
-        canAimGlobe
-          ? (click) => {
-              if (click.target instanceof Element && click.target.closest("a")) return;
-              onAimGlobe?.(event);
-            }
-          : undefined
-      }
+      className="group hover:bg-secondary relative isolate flex items-center gap-3 px-4 py-3 md:py-2 md:dark:hover:bg-white/5"
     >
       {pulse ? (
         <span
@@ -350,16 +334,13 @@ function ActivityVisitClusterBlock({
   cluster,
   pulse = false,
   pulseActionKey = null,
-  onAimGlobe,
 }: {
   cluster: ActivityVisitCluster;
   pulse?: boolean;
   pulseActionKey?: string | null;
-  onAimGlobe?: (event: ActivityEvent) => void;
 }) {
   const iconEvent = cluster.actions[0]?.latest ?? cluster.latest;
   const showRail = cluster.actions.length > 1;
-  const canAimGlobe = Boolean(onAimGlobe && activityEventLocation(cluster.latest));
 
   if (cluster.actions.length === 1) {
     const stack = cluster.actions[0]!;
@@ -371,7 +352,6 @@ function ActivityVisitClusterBlock({
         href={stack.href}
         likeTargets={stack.likeTargets}
         pulse={pulse}
-        onAimGlobe={onAimGlobe}
       />
     );
   }
@@ -379,18 +359,7 @@ function ActivityVisitClusterBlock({
   return (
     <div
       data-rollup-pulse={pulse ? "" : undefined}
-      className={cn(
-        "group hover:bg-secondary relative isolate px-4 py-3 md:py-2 md:dark:hover:bg-white/5",
-        canAimGlobe && "cursor-pointer",
-      )}
-      onClick={
-        canAimGlobe
-          ? (click) => {
-              if (click.target instanceof Element && click.target.closest("a")) return;
-              onAimGlobe?.(cluster.latest);
-            }
-          : undefined
-      }
+      className="group hover:bg-secondary relative isolate px-4 py-3 md:py-2 md:dark:hover:bg-white/5"
     >
       {pulse ? (
         <span
@@ -539,12 +508,10 @@ function ActivityStackList({
   items,
   pulseKey,
   pulseActionKey,
-  onAimGlobe,
 }: {
   items: ActivityFeedItem[];
   pulseKey: string | null;
   pulseActionKey: string | null;
-  onAimGlobe?: (event: ActivityEvent) => void;
 }) {
   const hydrated = useHydrated();
   const prefersReducedMotion = useReducedMotion();
@@ -596,7 +563,6 @@ function ActivityStackList({
                     cluster={item}
                     pulse={pulse}
                     pulseActionKey={pulseKey === reactKey ? pulseActionKey : null}
-                    onAimGlobe={onAimGlobe}
                   />
                 ) : (
                   <ActivityRow
@@ -606,7 +572,6 @@ function ActivityStackList({
                     href={item.stack.href}
                     likeTargets={item.stack.likeTargets}
                     pulse={pulse}
-                    onAimGlobe={onAimGlobe}
                   />
                 )}
               </div>
@@ -686,12 +651,6 @@ export function ActivityFeed({
   const events = controlledEvents ?? live.events;
   const items = useMemo(() => clusterVisitLocationRuns(rollupActivityEvents(events)), [events]);
   const { pulseKey, pulseActionKey } = useRollupPulse(items);
-  const [globeAim, setGlobeAim] = useState<ActivityGlobeAimRequest | null>(null);
-  const handleAimGlobe = useCallback((event: ActivityEvent) => {
-    const location = activityEventLocation(event);
-    if (!location) return;
-    setGlobeAim((current) => ({ location, nonce: (current?.nonce ?? 0) + 1 }));
-  }, []);
 
   return (
     <ListDetailWrapper>
@@ -707,7 +666,6 @@ export function ActivityFeed({
                 items={items}
                 pulseKey={pulseKey}
                 pulseActionKey={pulseActionKey}
-                onAimGlobe={handleAimGlobe}
               />
               <p className="text-tertiary p-32 text-center text-sm">
                 Older activity is dust in the wind...
@@ -715,7 +673,7 @@ export function ActivityFeed({
             </>
           )}
         </div>
-        <ActivityGlobe events={events} aim={globeAim} config={globeConfig} />
+        <ActivityGlobe events={events} config={globeConfig} />
       </div>
     </ListDetailWrapper>
   );

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -396,7 +396,7 @@ function ActivityVisitClusterBlock({
         <div className="flex size-8 items-center justify-center">
           <ActivityRowIcon event={iconEvent} />
         </div>
-        <p className="mt-[5px] text-primary">{cluster.locationHeader}</p>
+        <p className="text-primary mt-[5px]">{cluster.locationHeader}</p>
         {sourceRuns.map((run, runIndex) => {
           const showMark = runIndex > 0;
           const isLastRun = runIndex === sourceRuns.length - 1;

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -21,7 +21,6 @@ import { StaffDesign } from "@/components/icons/StaffDesign";
 import { World } from "@/components/icons/World";
 import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { SlotDigits } from "@/components/SlotDigits";
-import { useTopBarActions } from "@/components/TopBarActions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import {
   type ActivityEvent,
@@ -407,7 +406,7 @@ function ActivityVisitClusterBlock({
           </div>
           {showRail ? <VisitClusterRail /> : null}
         </div>
-        <div className="min-w-0 flex-1">
+        <div className="mt-[5px] min-w-0 flex-1">
           <p className="text-primary">{cluster.locationHeader}</p>
           <ul className="mt-1 flex flex-col gap-1">
             {cluster.actions.map((action) => {
@@ -672,7 +671,6 @@ export function ActivityFeed({
   initialEvents,
   initialCount,
   events: controlledEvents,
-  count: controlledCount,
   globeConfig,
 }: {
   initialEvents: ActivityEvent[];
@@ -686,7 +684,6 @@ export function ActivityFeed({
     enabled: controlledEvents === undefined,
   });
   const events = controlledEvents ?? live.events;
-  const count = controlledCount ?? live.count;
   const items = useMemo(() => clusterVisitLocationRuns(rollupActivityEvents(events)), [events]);
   const { pulseKey, pulseActionKey } = useRollupPulse(items);
   const [globeAim, setGlobeAim] = useState<ActivityGlobeAimRequest | null>(null);
@@ -695,9 +692,6 @@ export function ActivityFeed({
     if (!location) return;
     setGlobeAim((current) => ({ location, nonce: (current?.nonce ?? 0) + 1 }));
   }, []);
-
-  const topBarContent = useMemo(() => <ActivityTrackedCount count={count} />, [count]);
-  useTopBarActions(topBarContent);
 
   return (
     <ListDetailWrapper>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -31,6 +31,7 @@ import {
   type ActivityRollup,
   type ActivityVisitCluster,
 } from "@/lib/activity";
+import type { ActivityGlobeConfig } from "@/lib/activity-globe-config";
 import {
   activityFeedItemCount,
   activityFeedItemReactKey,
@@ -194,7 +195,7 @@ function ActivityCountChip({ count }: { count: number }) {
   return (
     <span
       data-count={count}
-      className="text-tertiary border-secondary shrink-0 -translate-y-[2px] rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
+      className="text-tertiary border-secondary shrink-0 -translate-y-0.5 rounded-sm border px-1.5 py-px font-mono text-xs leading-4 tabular-nums"
     >
       ×<SlotDigits value={count} />
     </span>
@@ -300,22 +301,10 @@ export function ActivityRow({
 
 function VisitClusterRail() {
   return (
-    <span aria-hidden className="pointer-events-none absolute inset-x-0 top-8 bottom-1">
-      <svg
-        viewBox="0 0 32 200"
-        preserveAspectRatio="xMidYMax slice"
-        className="text-tertiary block h-full w-full overflow-hidden"
-      >
-        <path
-          d="M16 0 L16 188 Q16 198 30 198"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </span>
+    <span
+      aria-hidden
+      className="text-tertiary pointer-events-none absolute top-8 right-0 bottom-[calc((1lh+0.25rem)/2-3px)] left-[calc(50%-1px)] rounded-bl-lg border-b-2 border-l-2 border-black/10 dark:border-white/15"
+    />
   );
 }
 
@@ -466,7 +455,7 @@ export function ActivityTrackedCount({ count }: { count: number }) {
 }
 
 const ROLLUP_PULSE_MS = 1500;
-const LIST_MOTION = { duration: 0.14, ease: [0.2, 0, 0, 1] } as const;
+const LIST_MOTION = { duration: 0.36, ease: [0.22, 1, 0.36, 1] } as const;
 
 function useEnterPulseKeys(incoming: string[], enabled: boolean): Set<string> {
   const [keys, setKeys] = useState<Set<string>>(() => new Set());
@@ -600,26 +589,28 @@ function ActivityStackList({
                   return remaining;
                 });
               }}
-              className={isEntering ? "overflow-hidden" : "[clip-path:inset(0)]"}
+              className="overflow-hidden"
             >
-              {item.type === "visit-cluster" ? (
-                <ActivityVisitClusterBlock
-                  cluster={item}
-                  pulse={pulse}
-                  pulseActionKey={pulseKey === reactKey ? pulseActionKey : null}
-                  onAimGlobe={onAimGlobe}
-                />
-              ) : (
-                <ActivityRow
-                  event={item.stack.latest}
-                  count={item.stack.count}
-                  sectionLabel={item.stack.sectionLabel}
-                  href={item.stack.href}
-                  likeTargets={item.stack.likeTargets}
-                  pulse={pulse}
-                  onAimGlobe={onAimGlobe}
-                />
-              )}
+              <div>
+                {item.type === "visit-cluster" ? (
+                  <ActivityVisitClusterBlock
+                    cluster={item}
+                    pulse={pulse}
+                    pulseActionKey={pulseKey === reactKey ? pulseActionKey : null}
+                    onAimGlobe={onAimGlobe}
+                  />
+                ) : (
+                  <ActivityRow
+                    event={item.stack.latest}
+                    count={item.stack.count}
+                    sectionLabel={item.stack.sectionLabel}
+                    href={item.stack.href}
+                    likeTargets={item.stack.likeTargets}
+                    pulse={pulse}
+                    onAimGlobe={onAimGlobe}
+                  />
+                )}
+              </div>
             </motion.div>
           );
         })}
@@ -680,11 +671,22 @@ function useRollupPulse(items: ActivityFeedItem[]): {
 export function ActivityFeed({
   initialEvents,
   initialCount,
+  events: controlledEvents,
+  count: controlledCount,
+  globeConfig,
 }: {
   initialEvents: ActivityEvent[];
   initialCount: number;
+  /** When set, skip live polling and render this list. Used by the sandbox. */
+  events?: ActivityEvent[];
+  count?: number;
+  globeConfig?: ActivityGlobeConfig;
 }) {
-  const { events, count } = useActivity(initialEvents, initialCount);
+  const live = useActivity(initialEvents, initialCount, {
+    enabled: controlledEvents === undefined,
+  });
+  const events = controlledEvents ?? live.events;
+  const count = controlledCount ?? live.count;
   const items = useMemo(() => clusterVisitLocationRuns(rollupActivityEvents(events)), [events]);
   const { pulseKey, pulseActionKey } = useRollupPulse(items);
   const [globeAim, setGlobeAim] = useState<ActivityGlobeAimRequest | null>(null);
@@ -719,7 +721,7 @@ export function ActivityFeed({
             </>
           )}
         </div>
-        <ActivityGlobe events={events} aim={globeAim} />
+        <ActivityGlobe events={events} aim={globeAim} config={globeConfig} />
       </div>
     </ListDetailWrapper>
   );

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import {
+  Fragment,
   type ReactNode,
   useEffect,
   useMemo,
@@ -37,6 +38,7 @@ import {
   nextActivityEnterState,
   rollupActivityEvents,
   shouldPulseActivityRollup,
+  visitClusterSourceRuns,
 } from "@/lib/activity-rollup";
 import {
   ACTIVITY_TRACKED_SINCE_TOOLTIP,
@@ -282,11 +284,33 @@ export function ActivityRow({
   );
 }
 
-function VisitClusterRail() {
+function VisitClusterRailSegment({
+  insetStart = false,
+  insetEnd = false,
+  hook = false,
+}: {
+  insetStart?: boolean;
+  insetEnd?: boolean;
+  hook?: boolean;
+}) {
   return (
     <span
       aria-hidden
-      className="text-tertiary pointer-events-none absolute top-8 right-0 bottom-[calc((1lh+0.25rem)/2-3px)] left-[calc(50%-1px)] rounded-bl-lg border-b-2 border-l-2 border-black/10 dark:border-white/15"
+      data-visit-rail={hook ? "hook" : "line"}
+      data-visit-rail-inset={
+        insetStart && insetEnd ? "both" : insetStart ? "start" : insetEnd ? "end" : undefined
+      }
+      className={cn(
+        "pointer-events-none absolute left-[calc(50%-1px)] border-black/10 dark:border-white/15",
+        hook
+          ? "right-0 bottom-[calc((1lh+0.25rem)/2-3px)] rounded-bl-lg border-b-2 border-l-2"
+          : insetEnd
+            ? // Stop 4px above the next run's 20px mark (mt-1 + first-action center).
+              "bottom-[calc(0.625rem-(1lh+0.25rem)/2)] border-l-2"
+            : "bottom-1 border-l-2",
+        // Start 4px below a 20px mark centered on the first action (py-0.5 + 1lh).
+        insetStart ? "top-[calc((1lh+0.25rem)/2+0.875rem)]" : "top-0",
+      )}
     />
   );
 }
@@ -340,7 +364,7 @@ function ActivityVisitClusterBlock({
   pulseActionKey?: string | null;
 }) {
   const iconEvent = cluster.actions[0]?.latest ?? cluster.latest;
-  const showRail = cluster.actions.length > 1;
+  const sourceRuns = visitClusterSourceRuns(cluster.actions);
 
   if (cluster.actions.length === 1) {
     const stack = cluster.actions[0]!;
@@ -368,28 +392,52 @@ function ActivityVisitClusterBlock({
           className="activity-rollup-pulse pointer-events-none absolute inset-0 z-0"
         />
       ) : null}
-      <div className="relative z-10 flex items-start gap-3">
-        <div className="relative w-8 flex-none self-stretch">
-          <div className="flex size-8 items-center justify-center">
-            <ActivityRowIcon event={iconEvent} />
-          </div>
-          {showRail ? <VisitClusterRail /> : null}
+      <div className="relative z-10 grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-x-3">
+        <div className="flex size-8 items-center justify-center">
+          <ActivityRowIcon event={iconEvent} />
         </div>
-        <div className="mt-[5px] min-w-0 flex-1">
-          <p className="text-primary">{cluster.locationHeader}</p>
-          <ul className="mt-1 flex flex-col gap-1">
-            {cluster.actions.map((action) => {
-              const actionKey = activityStackReactKey(action);
-              return (
-                <ActivityClusterAction
-                  key={actionKey}
-                  stack={action}
-                  pulse={pulseActionKey === actionKey}
-                />
-              );
-            })}
-          </ul>
-        </div>
+        <p className="mt-[5px] text-primary">{cluster.locationHeader}</p>
+        {sourceRuns.map((run, runIndex) => {
+          const showMark = runIndex > 0;
+          const isLastRun = runIndex === sourceRuns.length - 1;
+          const showRunRail = showMark ? run.actions.length > 1 : true;
+          const markEvent = run.actions[0]?.latest;
+
+          return (
+            <Fragment key={`${run.source}:${run.actions[0]?.anchorId ?? runIndex}`}>
+              <div className={cn("relative self-stretch", showMark && "mt-1")}>
+                {showMark && markEvent ? (
+                  <span
+                    data-visit-source-mark={run.source}
+                    aria-hidden
+                    className="absolute top-[calc((1lh+0.25rem)/2)] left-1/2 z-10 flex size-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
+                  >
+                    <ActivityRowIcon event={markEvent} />
+                  </span>
+                ) : null}
+                {showRunRail ? (
+                  <VisitClusterRailSegment
+                    insetStart={showMark}
+                    insetEnd={!isLastRun}
+                    hook={isLastRun}
+                  />
+                ) : null}
+              </div>
+              <ul className="mt-1 flex flex-col gap-1">
+                {run.actions.map((action) => {
+                  const actionKey = activityStackReactKey(action);
+                  return (
+                    <ActivityClusterAction
+                      key={actionKey}
+                      stack={action}
+                      pulse={pulseActionKey === actionKey}
+                    />
+                  );
+                })}
+              </ul>
+            </Fragment>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -14,10 +14,7 @@ import {
 } from "react";
 
 import type { ActivityEvent } from "@/lib/activity";
-import {
-  activityRecentGlobeMarkers,
-  type ActivityLatLng,
-} from "@/lib/activity-geo";
+import { type ActivityLatLng, activityRecentGlobeMarkers } from "@/lib/activity-geo";
 import {
   bindableGlobeMarkers,
   GLOBE_HANG,
@@ -135,6 +132,12 @@ export function ActivityGlobe({
     () => activityRecentGlobeMarkers(events, config.markerRecentCount),
     [events, config.markerRecentCount],
   );
+  const newestId = markers[0]?.eventId ?? null;
+  const [seenNewestId, setSeenNewestId] = useState(newestId);
+  if (newestId !== seenNewestId) {
+    setSeenNewestId(newestId);
+    setFocusId(newestId);
+  }
   const markersRef = useRef(markers);
   const themeRef = useRef({ isDark, prefersReducedMotion });
   const sizeRef = useRef(layout.size);
@@ -226,7 +229,6 @@ export function ActivityGlobe({
     }
     if (userSteeringRef.current) return;
     aimAt(location);
-    setFocusId(newest.eventId);
   }, [markers, aimAt]);
 
   useEffect(() => {
@@ -427,11 +429,7 @@ export function ActivityGlobe({
         />
       </div>
       {markers.map((marker) => {
-        const px = markerDotPxForAge(
-          marker.age,
-          config,
-          globeMapDotPx(layout.size, config.scale),
-        );
+        const px = markerDotPxForAge(marker.age, config, globeMapDotPx(layout.size, config.scale));
         return (
           <span
             key={marker.id}

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -15,8 +15,7 @@ import {
 
 import type { ActivityEvent } from "@/lib/activity";
 import {
-  activityGlobeMarkerIdForLocation,
-  activityGlobeMarkers,
+  activityRecentGlobeMarkers,
   type ActivityLatLng,
 } from "@/lib/activity-geo";
 import {
@@ -32,7 +31,8 @@ import {
   cobeMarkerStyle,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
-  markerDotPxForSize,
+  markerAgeOpacity,
+  rgbCss,
 } from "@/lib/activity-globe-config";
 import { cn } from "@/lib/utils";
 
@@ -44,11 +44,6 @@ const THETA_LIMIT = Math.PI / 2 - 0.08;
 const MIN_FEED_WIDTH = 720;
 const AIM_MS_MIN = 600;
 const AIM_MS_MAX = 850;
-
-export type ActivityGlobeAimRequest = {
-  location: ActivityLatLng;
-  nonce: number;
-};
 
 type AimState = {
   fromPhi: number;
@@ -105,11 +100,9 @@ function scrollFeedFromOverlay(overlay: HTMLElement, deltaY: number): void {
 
 export function ActivityGlobe({
   events,
-  aim,
   config: configProp,
 }: {
   events: ActivityEvent[];
-  aim?: ActivityGlobeAimRequest | null;
   config?: ActivityGlobeConfig;
 }) {
   const config = configProp ?? DEFAULT_ACTIVITY_GLOBE_CONFIG;
@@ -125,6 +118,9 @@ export function ActivityGlobe({
   const draggingRef = useRef(false);
   const pendingRef = useRef(false);
   const aimingRef = useRef<AimState | null>(null);
+  const userSteeringRef = useRef(false);
+  const primedNewestRef = useRef<string | null>(null);
+  const skipAutoPanRef = useRef(true);
   const lastXRef = useRef(0);
   const lastYRef = useRef(0);
   const lastTRef = useRef(0);
@@ -134,7 +130,10 @@ export function ActivityGlobe({
   const [grabbing, setGrabbing] = useState(false);
   const [focusId, setFocusId] = useState<string | null>(null);
 
-  const markers = useMemo(() => activityGlobeMarkers(events, config), [events, config]);
+  const markers = useMemo(
+    () => activityRecentGlobeMarkers(events, config.markerRecentCount),
+    [events, config.markerRecentCount],
+  );
   const markersRef = useRef(markers);
   const themeRef = useRef({ isDark, prefersReducedMotion });
   const sizeRef = useRef(layout.size);
@@ -206,17 +205,24 @@ export function ActivityGlobe({
   }, []);
 
   useEffect(() => {
-    if (!aim) return;
-    aimAt(aim.location);
-    const id = activityGlobeMarkerIdForLocation(aim.location, markersRef.current);
-    setFocusId(id ?? null);
-  }, [aim, aimAt]);
+    const newest = markers[0];
+    if (skipAutoPanRef.current) {
+      skipAutoPanRef.current = false;
+      primedNewestRef.current = newest?.eventId ?? null;
+      return;
+    }
+    if (!newest || primedNewestRef.current === newest.eventId) return;
+    primedNewestRef.current = newest.eventId;
+    if (userSteeringRef.current || themeRef.current.prefersReducedMotion) return;
+    aimAt({ lat: newest.location[0], lng: newest.location[1] });
+    setFocusId(newest.id);
+  }, [markers, aimAt]);
 
   useEffect(() => {
     if (!focusId) return;
     const timeout = window.setTimeout(() => setFocusId(null), config.focusMs);
     return () => window.clearTimeout(timeout);
-  }, [focusId, config.focusMs, aim?.nonce]);
+  }, [focusId, config.focusMs]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -240,6 +246,14 @@ export function ActivityGlobe({
     const onRender = () => {
       const { isDark: nextDark, prefersReducedMotion: reduced } = themeRef.current;
       const aimState = aimingRef.current;
+
+      if (draggingRef.current) {
+        userSteeringRef.current = true;
+      } else if (userSteeringRef.current && !aimState) {
+        const idlePhi = Math.abs(velocityRef.current - (reduced ? 0 : IDLE_SPIN)) < 0.0015;
+        const idleTheta = Math.abs(thetaVelocityRef.current) < 0.001;
+        if (idlePhi && idleTheta) userSteeringRef.current = false;
+      }
 
       if (aimState) {
         const t = Math.min(1, (performance.now() - aimState.start) / aimState.duration);
@@ -291,6 +305,7 @@ export function ActivityGlobe({
 
   function beginDrag(clientX: number, clientY: number): void {
     aimingRef.current = null;
+    userSteeringRef.current = true;
     draggingRef.current = true;
     pendingRef.current = false;
     lastXRef.current = clientX;
@@ -400,26 +415,32 @@ export function ActivityGlobe({
           onPointerCancel={endDrag}
         />
       </div>
-      {markers.map((marker) => {
-        const dotPx = markerDotPxForSize(marker.size, config);
-        return (
+      {markers.map((marker) => (
+        <span
+          key={marker.id}
+          className={cn("activity-globe-dot", focusId === marker.id && "is-focused")}
+          style={
+            {
+              ...cobeMarkerStyle(marker.id, {
+                markerBlurPx: config.markerBlurPx,
+                markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
+              }),
+              "--activity-globe-focus-scale": 1 + config.focusPulseScale,
+              "--activity-globe-focus-ms": `${config.focusMs}ms`,
+            } as CSSProperties
+          }
+        >
           <span
-            key={marker.id}
-            className={cn("activity-globe-dot", focusId === marker.id && "is-focused")}
-            style={
-              {
-                ...cobeMarkerStyle(marker.id, {
-                  ...config,
-                  markerDotPx: dotPx,
-                  markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
-                }),
-                "--activity-globe-focus-scale": 1 + config.focusPulseScale,
-                "--activity-globe-focus-ms": `${config.focusMs}ms`,
-              } as CSSProperties
-            }
+            className="activity-globe-dot-core"
+            style={{
+              width: config.markerDotPx,
+              height: config.markerDotPx,
+              backgroundColor: rgbCss(config.markerColor),
+              opacity: markerAgeOpacity(marker.age, config.markerAgeFade),
+            }}
           />
-        );
-      })}
+        </span>
+      ))}
     </div>
   );
 }

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -23,6 +23,7 @@ import {
   GLOBE_HANG,
   GLOBE_MESH_MIN,
   globeDiameterFromHeight,
+  globeMapDotPx,
   latLngToVisibleGlobePose,
   shortestAngleDelta,
 } from "@/lib/activity-globe";
@@ -31,12 +32,12 @@ import {
   cobeMarkerStyle,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
-  markerAgeOpacity,
+  markerDotPxForAge,
   rgbCss,
 } from "@/lib/activity-globe-config";
 import { cn } from "@/lib/utils";
 
-const IDLE_SPIN = 0.003;
+const IDLE_SPIN = 0.0015;
 const VELOCITY_EASE = 0.035;
 const DRAG_ANGLE_SCALE = 0.005;
 const DRAG_THRESHOLD_PX = 6;
@@ -173,6 +174,7 @@ export function ActivityGlobe({
   useEffect(() => {
     if (prefersReducedMotion) {
       velocityRef.current = 0;
+      thetaVelocityRef.current = 0;
       aimingRef.current = null;
     } else if (!draggingRef.current && !aimingRef.current) {
       velocityRef.current = IDLE_SPIN;
@@ -206,16 +208,25 @@ export function ActivityGlobe({
 
   useEffect(() => {
     const newest = markers[0];
-    if (skipAutoPanRef.current) {
+    if (!newest) {
       skipAutoPanRef.current = false;
-      primedNewestRef.current = newest?.eventId ?? null;
+      primedNewestRef.current = null;
       return;
     }
-    if (!newest || primedNewestRef.current === newest.eventId) return;
+    if (primedNewestRef.current === newest.eventId) return;
     primedNewestRef.current = newest.eventId;
-    if (userSteeringRef.current || themeRef.current.prefersReducedMotion) return;
-    aimAt({ lat: newest.location[0], lng: newest.location[1] });
-    setFocusId(newest.id);
+
+    const location = { lat: newest.location[0], lng: newest.location[1] };
+    if (skipAutoPanRef.current) {
+      skipAutoPanRef.current = false;
+      const pose = latLngToVisibleGlobePose(location.lat, location.lng);
+      phiRef.current = pose.phi;
+      thetaRef.current = clampTheta(pose.theta);
+      return;
+    }
+    if (userSteeringRef.current) return;
+    aimAt(location);
+    setFocusId(newest.eventId);
   }, [markers, aimAt]);
 
   useEffect(() => {
@@ -250,7 +261,7 @@ export function ActivityGlobe({
       if (draggingRef.current) {
         userSteeringRef.current = true;
       } else if (userSteeringRef.current && !aimState) {
-        const idlePhi = Math.abs(velocityRef.current - (reduced ? 0 : IDLE_SPIN)) < 0.0015;
+        const idlePhi = Math.abs(velocityRef.current - (reduced ? 0 : IDLE_SPIN)) < 0.001;
         const idleTheta = Math.abs(thetaVelocityRef.current) < 0.001;
         if (idlePhi && idleTheta) userSteeringRef.current = false;
       }
@@ -415,32 +426,42 @@ export function ActivityGlobe({
           onPointerCancel={endDrag}
         />
       </div>
-      {markers.map((marker) => (
-        <span
-          key={marker.id}
-          className={cn("activity-globe-dot", focusId === marker.id && "is-focused")}
-          style={
-            {
-              ...cobeMarkerStyle(marker.id, {
-                markerBlurPx: config.markerBlurPx,
-                markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
-              }),
-              "--activity-globe-focus-scale": 1 + config.focusPulseScale,
-              "--activity-globe-focus-ms": `${config.focusMs}ms`,
-            } as CSSProperties
-          }
-        >
+      {markers.map((marker) => {
+        const px = markerDotPxForAge(
+          marker.age,
+          config,
+          globeMapDotPx(layout.size, config.scale),
+        );
+        return (
           <span
-            className="activity-globe-dot-core"
-            style={{
-              width: config.markerDotPx,
-              height: config.markerDotPx,
-              backgroundColor: rgbCss(config.markerColor),
-              opacity: markerAgeOpacity(marker.age, config.markerAgeFade),
-            }}
-          />
-        </span>
-      ))}
+            key={marker.id}
+            className="activity-globe-dot"
+            style={
+              {
+                ...cobeMarkerStyle(marker.id, {
+                  markerBlurPx: config.markerBlurPx,
+                  markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
+                }),
+                "--activity-globe-focus-scale": 1 + config.focusPulseScale,
+                "--activity-globe-focus-ms": `${config.focusMs}ms`,
+              } as CSSProperties
+            }
+          >
+            <span
+              key={focusId === marker.eventId ? focusId : "idle"}
+              className={cn("activity-globe-dot-core", focusId === marker.eventId && "is-focused")}
+              style={
+                {
+                  width: px,
+                  height: px,
+                  backgroundColor: rgbCss(config.markerColor),
+                  "--activity-globe-dot-px": `${px}px`,
+                } as CSSProperties
+              }
+            />
+          </span>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -3,6 +3,7 @@
 import createGlobe from "cobe";
 import { useReducedMotion } from "motion/react";
 import {
+  type CSSProperties,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -13,16 +14,26 @@ import {
 } from "react";
 
 import type { ActivityEvent } from "@/lib/activity";
-import { activityGlobeMarkers, type ActivityLatLng } from "@/lib/activity-geo";
 import {
+  activityGlobeMarkerIdForLocation,
+  activityGlobeMarkers,
+  type ActivityLatLng,
+} from "@/lib/activity-geo";
+import {
+  bindableGlobeMarkers,
   GLOBE_HANG,
-  GLOBE_MARKER_ELEVATION,
   GLOBE_MESH_MIN,
   globeDiameterFromHeight,
-  latLngToGlobePose,
-  projectGlobeMarker,
+  latLngToVisibleGlobePose,
   shortestAngleDelta,
 } from "@/lib/activity-globe";
+import {
+  type ActivityGlobeConfig,
+  cobeMarkerStyle,
+  DEFAULT_ACTIVITY_GLOBE_CONFIG,
+  globeCobeOptions,
+  markerDotPxForSize,
+} from "@/lib/activity-globe-config";
 import { cn } from "@/lib/utils";
 
 const IDLE_SPIN = 0.003;
@@ -33,12 +44,6 @@ const THETA_LIMIT = Math.PI / 2 - 0.08;
 const MIN_FEED_WIDTH = 720;
 const AIM_MS_MIN = 600;
 const AIM_MS_MAX = 850;
-
-const MARKER_COLOR: [number, number, number] = [252 / 255, 83 / 255, 42 / 255];
-const LIGHT_BASE: [number, number, number] = [1, 1, 1];
-const LIGHT_GLOW: [number, number, number] = [0.95, 0.95, 0.95];
-const DARK_BASE: [number, number, number] = [0.3, 0.3, 0.3];
-const DARK_GLOW: [number, number, number] = [0.12, 0.12, 0.12];
 
 export type ActivityGlobeAimRequest = {
   location: ActivityLatLng;
@@ -101,10 +106,14 @@ function scrollFeedFromOverlay(overlay: HTMLElement, deltaY: number): void {
 export function ActivityGlobe({
   events,
   aim,
+  config: configProp,
 }: {
   events: ActivityEvent[];
   aim?: ActivityGlobeAimRequest | null;
+  config?: ActivityGlobeConfig;
 }) {
+  const config = configProp ?? DEFAULT_ACTIVITY_GLOBE_CONFIG;
+  const configRef = useRef(config);
   const overlayRef = useRef<HTMLDivElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -119,16 +128,20 @@ export function ActivityGlobe({
   const lastXRef = useRef(0);
   const lastYRef = useRef(0);
   const lastTRef = useRef(0);
-  const orbElsRef = useRef(new Map<string, HTMLDivElement>());
   const isDark = useIsDark();
   const prefersReducedMotion = useReducedMotion() === true;
   const [layout, setLayout] = useState({ hasRoom: true, size: GLOBE_MESH_MIN });
   const [grabbing, setGrabbing] = useState(false);
+  const [focusId, setFocusId] = useState<string | null>(null);
 
-  const markers = useMemo(() => activityGlobeMarkers(events), [events]);
+  const markers = useMemo(() => activityGlobeMarkers(events, config), [events, config]);
   const markersRef = useRef(markers);
   const themeRef = useRef({ isDark, prefersReducedMotion });
   const sizeRef = useRef(layout.size);
+
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
 
   useEffect(() => {
     markersRef.current = markers;
@@ -167,58 +180,43 @@ export function ActivityGlobe({
     }
   }, [prefersReducedMotion]);
 
-  const applyOrbFacing = useCallback(() => {
-    const phi = phiRef.current;
-    const theta = thetaRef.current;
-    for (const marker of markersRef.current) {
-      const el = orbElsRef.current.get(marker.id);
-      if (!el) continue;
-      const projected = projectGlobeMarker(
-        marker.location[0],
-        marker.location[1],
-        phi,
-        theta,
-        GLOBE_MARKER_ELEVATION,
-      );
-      el.style.left = `${(projected.x * 100).toFixed(3)}%`;
-      el.style.top = `${(projected.y * 100).toFixed(3)}%`;
-      el.style.setProperty("--orb-facing", projected.facing.toFixed(3));
+  const aimAt = useCallback((location: ActivityLatLng) => {
+    const pose = latLngToVisibleGlobePose(location.lat, location.lng);
+    const dPhi = shortestAngleDelta(phiRef.current, pose.phi);
+    const dTheta = clampTheta(pose.theta) - thetaRef.current;
+    velocityRef.current = 0;
+    thetaVelocityRef.current = 0;
+
+    if (themeRef.current.prefersReducedMotion) {
+      aimingRef.current = null;
+      phiRef.current += dPhi;
+      thetaRef.current = clampTheta(pose.theta);
+      return;
     }
+
+    const distance = Math.hypot(dPhi, dTheta);
+    aimingRef.current = {
+      fromPhi: phiRef.current,
+      fromTheta: thetaRef.current,
+      dPhi,
+      dTheta,
+      start: performance.now(),
+      duration: Math.round(AIM_MS_MIN + Math.min(AIM_MS_MAX - AIM_MS_MIN, distance * 180)),
+    };
   }, []);
-
-  const aimAt = useCallback(
-    (location: ActivityLatLng) => {
-      const pose = latLngToGlobePose(location.lat, location.lng);
-      const dPhi = shortestAngleDelta(phiRef.current, pose.phi);
-      const dTheta = clampTheta(pose.theta) - thetaRef.current;
-      velocityRef.current = 0;
-      thetaVelocityRef.current = 0;
-
-      if (themeRef.current.prefersReducedMotion) {
-        aimingRef.current = null;
-        phiRef.current += dPhi;
-        thetaRef.current = clampTheta(pose.theta);
-        applyOrbFacing();
-        return;
-      }
-
-      const distance = Math.hypot(dPhi, dTheta);
-      aimingRef.current = {
-        fromPhi: phiRef.current,
-        fromTheta: thetaRef.current,
-        dPhi,
-        dTheta,
-        start: performance.now(),
-        duration: Math.round(AIM_MS_MIN + Math.min(AIM_MS_MAX - AIM_MS_MIN, distance * 180)),
-      };
-    },
-    [applyOrbFacing],
-  );
 
   useEffect(() => {
     if (!aim) return;
     aimAt(aim.location);
+    const id = activityGlobeMarkerIdForLocation(aim.location, markersRef.current);
+    setFocusId(id ?? null);
   }, [aim, aimAt]);
+
+  useEffect(() => {
+    if (!focusId) return;
+    const timeout = window.setTimeout(() => setFocusId(null), config.focusMs);
+    return () => window.clearTimeout(timeout);
+  }, [focusId, config.focusMs, aim?.nonce]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -226,7 +224,6 @@ export function ActivityGlobe({
     if (!canvas) return;
 
     const dpr = Math.min(2, window.devicePixelRatio || 1);
-    const dark = themeRef.current.isDark;
     const size = sizeRef.current;
     const globe = createGlobe(canvas, {
       devicePixelRatio: dpr,
@@ -234,30 +231,21 @@ export function ActivityGlobe({
       height: size,
       phi: phiRef.current,
       theta: thetaRef.current,
-      dark: dark ? 1 : 0,
-      diffuse: 1.2,
-      mapSamples: 16000,
-      mapBrightness: dark ? 5 : 6,
-      baseColor: dark ? DARK_BASE : LIGHT_BASE,
-      markerColor: MARKER_COLOR,
-      glowColor: dark ? DARK_GLOW : LIGHT_GLOW,
-      markers: markersRef.current,
-      markerElevation: GLOBE_MARKER_ELEVATION,
-      scale: 1,
-      offset: [0, 0],
+      markers: bindableGlobeMarkers(markersRef.current),
+      ...globeCobeOptions(themeRef.current.isDark, configRef.current),
     });
     globeRef.current = globe;
 
     let frame = 0;
     const onRender = () => {
       const { isDark: nextDark, prefersReducedMotion: reduced } = themeRef.current;
-      const aim = aimingRef.current;
+      const aimState = aimingRef.current;
 
-      if (aim) {
-        const t = Math.min(1, (performance.now() - aim.start) / aim.duration);
+      if (aimState) {
+        const t = Math.min(1, (performance.now() - aimState.start) / aimState.duration);
         const eased = easeOutCubic(t);
-        phiRef.current = aim.fromPhi + aim.dPhi * eased;
-        thetaRef.current = clampTheta(aim.fromTheta + aim.dTheta * eased);
+        phiRef.current = aimState.fromPhi + aimState.dPhi * eased;
+        thetaRef.current = clampTheta(aimState.fromTheta + aimState.dTheta * eased);
         if (t >= 1) {
           aimingRef.current = null;
           velocityRef.current = reduced ? 0 : IDLE_SPIN;
@@ -278,13 +266,9 @@ export function ActivityGlobe({
       globe.update({
         phi: phiRef.current,
         theta: thetaRef.current,
-        markers: markersRef.current,
-        dark: nextDark ? 1 : 0,
-        mapBrightness: nextDark ? 5 : 6,
-        baseColor: nextDark ? DARK_BASE : LIGHT_BASE,
-        glowColor: nextDark ? DARK_GLOW : LIGHT_GLOW,
+        markers: bindableGlobeMarkers(markersRef.current),
+        ...globeCobeOptions(nextDark, configRef.current),
       });
-      applyOrbFacing();
       frame = window.requestAnimationFrame(onRender);
     };
     frame = window.requestAnimationFrame(onRender);
@@ -299,7 +283,7 @@ export function ActivityGlobe({
         extra.remove();
       }
     };
-  }, [applyOrbFacing]);
+  }, []);
 
   useEffect(() => {
     globeRef.current?.update({ width: layout.size, height: layout.size });
@@ -415,21 +399,27 @@ export function ActivityGlobe({
           onPointerUp={endDrag}
           onPointerCancel={endDrag}
         />
-        {markers.map((marker) => (
-          <div
-            key={marker.id}
-            ref={(node) => {
-              if (node) {
-                orbElsRef.current.set(marker.id, node);
-                node.style.setProperty("position-anchor", `--cobe-${marker.id}`);
-              } else {
-                orbElsRef.current.delete(marker.id);
-              }
-            }}
-            className="activity-globe-orb"
-          />
-        ))}
       </div>
+      {markers.map((marker) => {
+        const dotPx = markerDotPxForSize(marker.size, config);
+        return (
+          <span
+            key={marker.id}
+            className={cn("activity-globe-dot", focusId === marker.id && "is-focused")}
+            style={
+              {
+                ...cobeMarkerStyle(marker.id, {
+                  ...config,
+                  markerDotPx: dotPx,
+                  markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
+                }),
+                "--activity-globe-focus-scale": 1 + config.focusPulseScale,
+                "--activity-globe-focus-ms": `${config.focusMs}ms`,
+              } as CSSProperties
+            }
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/ActivityGlobeSandboxPanel.test.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ActivityGlobeSandboxPanel } from "@/components/ActivityGlobeSandboxPanel";
+import { DEFAULT_ACTIVITY_GLOBE_CONFIG } from "@/lib/activity-globe-config";
+
+describe("ActivityGlobeSandboxPanel", () => {
+  test("renders DialKit-style sliders instead of native range inputs", () => {
+    const markup = renderToStaticMarkup(
+      <ActivityGlobeSandboxPanel config={DEFAULT_ACTIVITY_GLOBE_CONFIG} onChange={() => {}} />,
+    );
+
+    expect(markup).toContain("Diffuse");
+    expect(markup).toContain('role="slider"');
+    expect(markup).toContain("0.60");
+    expect(markup).not.toContain('type="range"');
+  });
+});

--- a/src/components/ActivityGlobeSandboxPanel.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.tsx
@@ -3,7 +3,20 @@
 import { useCallback, useState } from "react";
 
 import { Button } from "@/components/ui/Button";
-import { type ActivityGlobeConfig, DEFAULT_ACTIVITY_GLOBE_CONFIG } from "@/lib/activity-globe-config";
+import { DialSlider } from "@/components/ui/DialSlider";
+import {
+  type ActivityGlobeConfig,
+  DEFAULT_ACTIVITY_GLOBE_CONFIG,
+} from "@/lib/activity-globe-config";
+
+export function SandboxHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-quaternary mb-1.5 ml-1 flex items-center gap-2 text-xs font-medium">
+      <span className="shrink-0">{children}</span>
+      <span className="bg-secondary h-px min-w-0 flex-1" aria-hidden />
+    </p>
+  );
+}
 
 type SliderDef = {
   key: keyof ActivityGlobeConfig;
@@ -30,8 +43,8 @@ const MARKER_SLIDERS: SliderDef[] = [
   { key: "markerDotPx", label: "Dot size (px)", min: 3, max: 16, step: 1 },
   { key: "markerBlurPx", label: "Horizon blur (px)", min: 0, max: 20, step: 1 },
   { key: "markerFadeMs", label: "Horizon fade (ms)", min: 0, max: 800, step: 25 },
-  { key: "markerRecentCount", label: "Recent markers", min: 1, max: 12, step: 1 },
-  { key: "markerAgeFade", label: "Age fade step", min: 0.05, max: 0.5, step: 0.05 },
+  { key: "markerRecentCount", label: "Recent markers", min: 1, max: 16, step: 1 },
+  { key: "markerAgeShrink", label: "Age size shrink", min: 0.04, max: 0.25, step: 0.01 },
   { key: "focusPulseScale", label: "Focus size pulse", min: 0, max: 1.5, step: 0.05 },
   { key: "focusMs", label: "Focus duration (ms)", min: 400, max: 2400, step: 50 },
 ];
@@ -46,36 +59,6 @@ const RGB_FIELDS: Array<{
   { key: "darkBaseColor", label: "Dark base" },
   { key: "darkGlowColor", label: "Dark glow" },
 ];
-
-function GlobeSlider({
-  def,
-  value,
-  onChange,
-}: {
-  def: SliderDef;
-  value: number;
-  onChange: (value: number) => void;
-}) {
-  return (
-    <label className="flex flex-col gap-1">
-      <span className="text-tertiary flex items-center justify-between text-[11px]">
-        <span>{def.label}</span>
-        <span className="text-quaternary font-mono tabular-nums">
-          {Number.isInteger(def.step) ? value : value.toFixed(3)}
-        </span>
-      </span>
-      <input
-        type="range"
-        min={def.min}
-        max={def.max}
-        step={def.step}
-        value={value}
-        onChange={(event) => onChange(Number(event.target.value))}
-        className="w-full accent-current"
-      />
-    </label>
-  );
-}
 
 function RgbControl({
   label,
@@ -125,17 +108,16 @@ function GlobeSliderSection({
 }) {
   return (
     <div>
-      {title ? (
-        <p className="text-quaternary mb-2 text-[11px] font-medium tracking-wide uppercase">
-          {title}
-        </p>
-      ) : null}
-      <div className="flex flex-col gap-2.5">
+      {title ? <SandboxHeading>{title}</SandboxHeading> : null}
+      <div className="flex flex-col gap-1.5">
         {sliders.map((def) => (
-          <GlobeSlider
+          <DialSlider
             key={def.key}
-            def={def}
+            label={def.label}
             value={config[def.key] as number}
+            min={def.min}
+            max={def.max}
+            step={def.step}
             onChange={(value) => onPatch({ [def.key]: value })}
           />
         ))}
@@ -172,31 +154,12 @@ export function ActivityGlobeSandboxPanel({
   }, [config]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-3 flex items-center justify-end gap-2">
-        <div className="flex gap-1">
-          <Button
-            type="button"
-            size="xs"
-            variant="ghost"
-            className="text-tertiary"
-            onClick={() => onChange(DEFAULT_ACTIVITY_GLOBE_CONFIG)}
-          >
-            Reset
-          </Button>
-          <Button type="button" size="xs" variant="secondary" onClick={copyConfig}>
-            {copied ? "Copied" : "Copy JSON"}
-          </Button>
-        </div>
-      </div>
-
-      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-col gap-5">
         <GlobeSliderSection title="COBE" sliders={COBE_SLIDERS} config={config} onPatch={patch} />
 
         <div>
-          <p className="text-quaternary mb-2 text-[11px] font-medium tracking-wide uppercase">
-            Colors (0–1 RGB)
-          </p>
+          <SandboxHeading>Colors (0–1 RGB)</SandboxHeading>
           <div className="flex flex-col gap-2">
             {RGB_FIELDS.map(({ key, label }) => (
               <RgbControl
@@ -215,6 +178,20 @@ export function ActivityGlobeSandboxPanel({
           config={config}
           onPatch={patch}
         />
+
+        <div className="flex flex-wrap gap-1.5">
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => onChange(DEFAULT_ACTIVITY_GLOBE_CONFIG)}
+          >
+            Reset
+          </Button>
+          <Button type="button" size="xs" variant="outline" onClick={copyConfig}>
+            {copied ? "Copied" : "Copy JSON"}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ActivityGlobeSandboxPanel.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { type ActivityGlobeConfig, DEFAULT_ACTIVITY_GLOBE_CONFIG } from "@/lib/activity-globe-config";
+
+type SliderDef = {
+  key: keyof ActivityGlobeConfig;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+};
+
+const COBE_SLIDERS: SliderDef[] = [
+  { key: "diffuse", label: "Diffuse", min: 0.2, max: 3, step: 0.05 },
+  { key: "mapSamples", label: "Map samples", min: 2000, max: 32000, step: 500 },
+  { key: "mapBrightness", label: "Map brightness (light)", min: 1, max: 12, step: 0.1 },
+  { key: "mapBrightnessDark", label: "Map brightness (dark)", min: 1, max: 12, step: 0.1 },
+  { key: "mapBaseBrightness", label: "Ocean base", min: 0, max: 1, step: 0.01 },
+  { key: "scale", label: "Scale", min: 0.6, max: 1.2, step: 0.01 },
+  { key: "offsetX", label: "Offset X", min: -120, max: 120, step: 1 },
+  { key: "offsetY", label: "Offset Y", min: -120, max: 120, step: 1 },
+  { key: "opacity", label: "Globe opacity", min: 0.2, max: 1, step: 0.01 },
+  { key: "markerElevation", label: "Marker elevation", min: 0, max: 0.12, step: 0.005 },
+];
+
+const MARKER_SLIDERS: SliderDef[] = [
+  { key: "markerDotPx", label: "Dot size (px)", min: 4, max: 24, step: 1 },
+  { key: "markerBlurPx", label: "Horizon blur (px)", min: 0, max: 20, step: 1 },
+  { key: "markerFadeMs", label: "Fade (ms)", min: 0, max: 800, step: 25 },
+  { key: "markerBaseSize", label: "Count scale base", min: 0.005, max: 0.04, step: 0.001 },
+  { key: "markerSizePerLog", label: "Size per log₂(count)", min: 0, max: 0.01, step: 0.0005 },
+  { key: "markerMaxSize", label: "Max count scale", min: 0.01, max: 0.08, step: 0.001 },
+  { key: "focusPulseScale", label: "Focus size pulse", min: 0, max: 1.5, step: 0.05 },
+  { key: "focusMs", label: "Focus duration (ms)", min: 400, max: 2400, step: 50 },
+];
+
+const RGB_FIELDS: Array<{
+  key: keyof ActivityGlobeConfig;
+  label: string;
+}> = [
+  { key: "markerColor", label: "Marker color" },
+  { key: "lightBaseColor", label: "Light base" },
+  { key: "lightGlowColor", label: "Light glow" },
+  { key: "darkBaseColor", label: "Dark base" },
+  { key: "darkGlowColor", label: "Dark glow" },
+];
+
+function GlobeSlider({
+  def,
+  value,
+  onChange,
+}: {
+  def: SliderDef;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-tertiary flex items-center justify-between text-[11px]">
+        <span>{def.label}</span>
+        <span className="text-quaternary font-mono tabular-nums">
+          {Number.isInteger(def.step) ? value : value.toFixed(3)}
+        </span>
+      </span>
+      <input
+        type="range"
+        min={def.min}
+        max={def.max}
+        step={def.step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="w-full accent-current"
+      />
+    </label>
+  );
+}
+
+function RgbControl({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: [number, number, number];
+  onChange: (value: [number, number, number]) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-tertiary text-[11px]">{label}</span>
+      <div className="grid grid-cols-3 gap-1">
+        {(["R", "G", "B"] as const).map((channel, index) => (
+          <input
+            key={channel}
+            type="number"
+            min={0}
+            max={1}
+            step={0.01}
+            value={value[index]?.toFixed(2) ?? "0"}
+            onChange={(event) => {
+              const next = [...value] as [number, number, number];
+              next[index] = Number(event.target.value);
+              onChange(next);
+            }}
+            className="border-secondary bg-primary text-primary rounded border px-1.5 py-1 font-mono text-[11px] tabular-nums"
+            aria-label={`${label} ${channel}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function GlobeSliderSection({
+  title,
+  sliders,
+  config,
+  onPatch,
+}: {
+  title?: string;
+  sliders: SliderDef[];
+  config: ActivityGlobeConfig;
+  onPatch: (patch: Partial<ActivityGlobeConfig>) => void;
+}) {
+  return (
+    <div>
+      {title ? (
+        <p className="text-quaternary mb-2 text-[11px] font-medium tracking-wide uppercase">
+          {title}
+        </p>
+      ) : null}
+      <div className="flex flex-col gap-2.5">
+        {sliders.map((def) => (
+          <GlobeSlider
+            key={def.key}
+            def={def}
+            value={config[def.key] as number}
+            onChange={(value) => onPatch({ [def.key]: value })}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ActivityGlobeSandboxPanel({
+  config,
+  onChange,
+}: {
+  config: ActivityGlobeConfig;
+  onChange: (config: ActivityGlobeConfig) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const patch = useCallback(
+    (partial: Partial<ActivityGlobeConfig>) => {
+      onChange({ ...config, ...partial });
+    },
+    [config, onChange],
+  );
+
+  const copyConfig = useCallback(async () => {
+    const payload = JSON.stringify(config, null, 2);
+    try {
+      await navigator.clipboard.writeText(payload);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      window.prompt("Copy globe config:", payload);
+    }
+  }, [config]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-3 flex items-center justify-end gap-2">
+        <div className="flex gap-1">
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost"
+            className="text-tertiary"
+            onClick={() => onChange(DEFAULT_ACTIVITY_GLOBE_CONFIG)}
+          >
+            Reset
+          </Button>
+          <Button type="button" size="xs" variant="secondary" onClick={copyConfig}>
+            {copied ? "Copied" : "Copy JSON"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
+        <GlobeSliderSection title="COBE" sliders={COBE_SLIDERS} config={config} onPatch={patch} />
+
+        <div>
+          <p className="text-quaternary mb-2 text-[11px] font-medium tracking-wide uppercase">
+            Colors (0–1 RGB)
+          </p>
+          <div className="flex flex-col gap-2">
+            {RGB_FIELDS.map(({ key, label }) => (
+              <RgbControl
+                key={key}
+                label={label}
+                value={config[key] as [number, number, number]}
+                onChange={(value) => patch({ [key]: value })}
+              />
+            ))}
+          </div>
+        </div>
+
+        <GlobeSliderSection
+          title="Markers (CSS fade)"
+          sliders={MARKER_SLIDERS}
+          config={config}
+          onPatch={patch}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ActivityGlobeSandboxPanel.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.tsx
@@ -27,12 +27,11 @@ const COBE_SLIDERS: SliderDef[] = [
 ];
 
 const MARKER_SLIDERS: SliderDef[] = [
-  { key: "markerDotPx", label: "Dot size (px)", min: 4, max: 24, step: 1 },
+  { key: "markerDotPx", label: "Dot size (px)", min: 3, max: 16, step: 1 },
   { key: "markerBlurPx", label: "Horizon blur (px)", min: 0, max: 20, step: 1 },
-  { key: "markerFadeMs", label: "Fade (ms)", min: 0, max: 800, step: 25 },
-  { key: "markerBaseSize", label: "Count scale base", min: 0.005, max: 0.04, step: 0.001 },
-  { key: "markerSizePerLog", label: "Size per log₂(count)", min: 0, max: 0.01, step: 0.0005 },
-  { key: "markerMaxSize", label: "Max count scale", min: 0.01, max: 0.08, step: 0.001 },
+  { key: "markerFadeMs", label: "Horizon fade (ms)", min: 0, max: 800, step: 25 },
+  { key: "markerRecentCount", label: "Recent markers", min: 1, max: 12, step: 1 },
+  { key: "markerAgeFade", label: "Age fade step", min: 0.05, max: 0.5, step: 0.05 },
   { key: "focusPulseScale", label: "Focus size pulse", min: 0, max: 1.5, step: 0.05 },
   { key: "focusMs", label: "Focus duration (ms)", min: 400, max: 2400, step: 50 },
 ];

--- a/src/components/ActivitySandbox.tsx
+++ b/src/components/ActivitySandbox.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { ActivityFeed } from "@/components/ActivityFeed";
-import { ActivityGlobeSandboxPanel } from "@/components/ActivityGlobeSandboxPanel";
+import { ActivityGlobeSandboxPanel, SandboxHeading } from "@/components/ActivityGlobeSandboxPanel";
+import { Close } from "@/components/icons/Close";
 import { Button } from "@/components/ui/Button";
 import type { ActivityEvent } from "@/lib/activity";
 import {
@@ -12,8 +13,6 @@ import {
 } from "@/lib/activity-globe-config";
 import { SANDBOX_SCENARIOS, SANDBOX_SINGLES } from "@/lib/activity-sandbox";
 import { cn } from "@/lib/utils";
-
-const INJECT_DELAY_MS = 600;
 
 type SandboxTab = "events" | "globe";
 
@@ -25,34 +24,14 @@ export function ActivitySandbox() {
   );
   const [open, setOpen] = useState(true);
   const [tab, setTab] = useState<SandboxTab>("events");
-  const [watch, setWatch] = useState(true);
-  const [pending, setPending] = useState(false);
-  const timerRef = useRef<number | null>(null);
 
-  const inject = useCallback(
-    (incoming: ActivityEvent[]) => {
-      if (incoming.length === 0) return;
-      const apply = () => {
-        setEvents((current) => [...incoming, ...current]);
-        setCount((current) => current + incoming.length);
-        setPending(false);
-      };
-
-      if (timerRef.current) window.clearTimeout(timerRef.current);
-      if (!watch) {
-        apply();
-        return;
-      }
-
-      setPending(true);
-      timerRef.current = window.setTimeout(apply, INJECT_DELAY_MS);
-    },
-    [watch],
-  );
+  const inject = useCallback((incoming: ActivityEvent[]) => {
+    if (incoming.length === 0) return;
+    setEvents((current) => [...incoming, ...current]);
+    setCount((current) => current + incoming.length);
+  }, []);
 
   const clear = useCallback(() => {
-    if (timerRef.current) window.clearTimeout(timerRef.current);
-    setPending(false);
     setEvents([]);
     setCount(0);
   }, []);
@@ -67,18 +46,20 @@ export function ActivitySandbox() {
         globeConfig={globeConfig}
       />
       <div className="pointer-events-none fixed bottom-4 left-4 z-30 flex max-w-[min(24rem,calc(100vw-2rem))] flex-col items-start gap-2">
-        <Button
-          type="button"
-          size="xs"
-          variant="secondary"
-          className="pointer-events-auto shadow-sm"
-          onClick={() => setOpen((current) => !current)}
-        >
-          {open ? "Hide sandbox" : "Sandbox"}
-        </Button>
         {open ? (
-          <div className="bg-primary border-secondary pointer-events-auto flex max-h-[min(70vh,42rem)] w-full flex-col rounded-xl border p-3 shadow-lg">
-            <div className="mb-3 flex items-center gap-1">
+          <div className="bg-primary border-secondary pointer-events-auto relative flex max-h-[min(70vh,42rem)] w-full flex-col overflow-hidden rounded-xl border p-3 shadow-lg">
+            <button
+              type="button"
+              className="text-tertiary hover:bg-tertiary hover:text-primary absolute top-0 right-0 flex size-9 items-center justify-center rounded-tr-xl"
+              aria-label="Hide sandbox"
+              onClick={() => setOpen(false)}
+            >
+              <Close size={14} strokeWidth={2.25} />
+            </button>
+            <div className="mb-3 flex items-center pr-8">
+              <p className="text-primary text-sm font-medium">Sandbox</p>
+            </div>
+            <div className="mb-3 flex items-center gap-1.5">
               {(
                 [
                   ["events", "Events"],
@@ -89,7 +70,7 @@ export function ActivitySandbox() {
                   key={id}
                   type="button"
                   size="xs"
-                  variant={tab === id ? "secondary" : "ghost"}
+                  variant="outline"
                   className={cn(tab !== id && "text-tertiary")}
                   onClick={() => setTab(id)}
                 >
@@ -99,73 +80,55 @@ export function ActivitySandbox() {
             </div>
 
             {tab === "events" ? (
-              <>
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <p className="text-secondary text-xs">
-                    {pending ? "Watch the feed…" : `${count.toLocaleString("en-US")} fake events`}
-                  </p>
-                  <label className="text-tertiary flex cursor-pointer items-center gap-1.5 text-xs">
-                    <input
-                      type="checkbox"
-                      checked={watch}
-                      onChange={(event) => setWatch(event.target.checked)}
-                      className="accent-current"
-                    />
-                    Pause before inject
-                  </label>
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+                <SandboxHeading>Scenarios</SandboxHeading>
+                <div className="mb-3 flex flex-wrap gap-1.5">
+                  {Object.entries(SANDBOX_SCENARIOS).map(([id, scenario]) => (
+                    <Button
+                      key={id}
+                      type="button"
+                      size="xs"
+                      variant="outline"
+                      title={scenario.hint}
+                      onClick={() => inject(scenario.build())}
+                    >
+                      {scenario.label}
+                    </Button>
+                  ))}
                 </div>
-                <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-                  <p className="text-quaternary mb-1.5 text-[11px] font-medium tracking-wide uppercase">
-                    Scenarios
-                  </p>
-                  <div className="mb-3 flex flex-wrap gap-1.5">
-                    {Object.entries(SANDBOX_SCENARIOS).map(([id, scenario]) => (
-                      <Button
-                        key={id}
-                        type="button"
-                        size="xs"
-                        variant="outline"
-                        title={scenario.hint}
-                        disabled={pending}
-                        onClick={() => inject(scenario.build())}
-                      >
-                        {scenario.label}
-                      </Button>
-                    ))}
-                  </div>
-                  <p className="text-quaternary mb-1.5 text-[11px] font-medium tracking-wide uppercase">
-                    Singles
-                  </p>
-                  <div className="mb-3 flex flex-wrap gap-1.5">
-                    {SANDBOX_SINGLES.map((single) => (
-                      <Button
-                        key={single.id}
-                        type="button"
-                        size="xs"
-                        variant="ghost"
-                        disabled={pending}
-                        onClick={() => inject([single.build()])}
-                      >
-                        {single.label}
-                      </Button>
-                    ))}
-                  </div>
-                  <Button
-                    type="button"
-                    size="xs"
-                    variant="ghost"
-                    className={cn("text-tertiary")}
-                    onClick={clear}
-                  >
-                    Clear
-                  </Button>
+                <SandboxHeading>Singles</SandboxHeading>
+                <div className="mb-3 flex flex-wrap gap-1.5">
+                  {SANDBOX_SINGLES.map((single) => (
+                    <Button
+                      key={single.id}
+                      type="button"
+                      size="xs"
+                      variant="outline"
+                      onClick={() => inject([single.build()])}
+                    >
+                      {single.label}
+                    </Button>
+                  ))}
                 </div>
-              </>
+                <Button type="button" size="xs" variant="outline" onClick={clear}>
+                  Clear
+                </Button>
+              </div>
             ) : (
               <ActivityGlobeSandboxPanel config={globeConfig} onChange={setGlobeConfig} />
             )}
           </div>
-        ) : null}
+        ) : (
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            className="pointer-events-auto shadow-sm"
+            onClick={() => setOpen(true)}
+          >
+            Sandbox
+          </Button>
+        )}
       </div>
     </>
   );

--- a/src/components/ActivitySandbox.tsx
+++ b/src/components/ActivitySandbox.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { ActivityFeed } from "@/components/ActivityFeed";
+import { ActivityGlobeSandboxPanel } from "@/components/ActivityGlobeSandboxPanel";
+import { Button } from "@/components/ui/Button";
+import type { ActivityEvent } from "@/lib/activity";
+import {
+  type ActivityGlobeConfig,
+  DEFAULT_ACTIVITY_GLOBE_CONFIG,
+} from "@/lib/activity-globe-config";
+import { SANDBOX_SCENARIOS, SANDBOX_SINGLES } from "@/lib/activity-sandbox";
+import { cn } from "@/lib/utils";
+
+const INJECT_DELAY_MS = 600;
+
+type SandboxTab = "events" | "globe";
+
+export function ActivitySandbox() {
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [count, setCount] = useState(0);
+  const [globeConfig, setGlobeConfig] = useState<ActivityGlobeConfig>(
+    DEFAULT_ACTIVITY_GLOBE_CONFIG,
+  );
+  const [open, setOpen] = useState(true);
+  const [tab, setTab] = useState<SandboxTab>("events");
+  const [watch, setWatch] = useState(true);
+  const [pending, setPending] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  const inject = useCallback(
+    (incoming: ActivityEvent[]) => {
+      if (incoming.length === 0) return;
+      const apply = () => {
+        setEvents((current) => [...incoming, ...current]);
+        setCount((current) => current + incoming.length);
+        setPending(false);
+      };
+
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+      if (!watch) {
+        apply();
+        return;
+      }
+
+      setPending(true);
+      timerRef.current = window.setTimeout(apply, INJECT_DELAY_MS);
+    },
+    [watch],
+  );
+
+  const clear = useCallback(() => {
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    setPending(false);
+    setEvents([]);
+    setCount(0);
+  }, []);
+
+  return (
+    <>
+      <ActivityFeed
+        initialEvents={[]}
+        initialCount={0}
+        events={events}
+        count={count}
+        globeConfig={globeConfig}
+      />
+      <div className="pointer-events-none fixed bottom-4 left-4 z-30 flex max-w-[min(24rem,calc(100vw-2rem))] flex-col items-start gap-2">
+        <Button
+          type="button"
+          size="xs"
+          variant="secondary"
+          className="pointer-events-auto shadow-sm"
+          onClick={() => setOpen((current) => !current)}
+        >
+          {open ? "Hide sandbox" : "Sandbox"}
+        </Button>
+        {open ? (
+          <div className="bg-primary border-secondary pointer-events-auto flex max-h-[min(70vh,42rem)] w-full flex-col rounded-xl border p-3 shadow-lg">
+            <div className="mb-3 flex items-center gap-1">
+              {(
+                [
+                  ["events", "Events"],
+                  ["globe", "Globe"],
+                ] as const
+              ).map(([id, label]) => (
+                <Button
+                  key={id}
+                  type="button"
+                  size="xs"
+                  variant={tab === id ? "secondary" : "ghost"}
+                  className={cn(tab !== id && "text-tertiary")}
+                  onClick={() => setTab(id)}
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+
+            {tab === "events" ? (
+              <>
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <p className="text-secondary text-xs">
+                    {pending ? "Watch the feed…" : `${count.toLocaleString("en-US")} fake events`}
+                  </p>
+                  <label className="text-tertiary flex cursor-pointer items-center gap-1.5 text-xs">
+                    <input
+                      type="checkbox"
+                      checked={watch}
+                      onChange={(event) => setWatch(event.target.checked)}
+                      className="accent-current"
+                    />
+                    Pause before inject
+                  </label>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                  <p className="text-quaternary mb-1.5 text-[11px] font-medium tracking-wide uppercase">
+                    Scenarios
+                  </p>
+                  <div className="mb-3 flex flex-wrap gap-1.5">
+                    {Object.entries(SANDBOX_SCENARIOS).map(([id, scenario]) => (
+                      <Button
+                        key={id}
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        title={scenario.hint}
+                        disabled={pending}
+                        onClick={() => inject(scenario.build())}
+                      >
+                        {scenario.label}
+                      </Button>
+                    ))}
+                  </div>
+                  <p className="text-quaternary mb-1.5 text-[11px] font-medium tracking-wide uppercase">
+                    Singles
+                  </p>
+                  <div className="mb-3 flex flex-wrap gap-1.5">
+                    {SANDBOX_SINGLES.map((single) => (
+                      <Button
+                        key={single.id}
+                        type="button"
+                        size="xs"
+                        variant="ghost"
+                        disabled={pending}
+                        onClick={() => inject([single.build()])}
+                      >
+                        {single.label}
+                      </Button>
+                    ))}
+                  </div>
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="ghost"
+                    className={cn("text-tertiary")}
+                    onClick={clear}
+                  >
+                    Clear
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <ActivityGlobeSandboxPanel config={globeConfig} onChange={setGlobeConfig} />
+            )}
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/src/components/GlobalTopBar.tsx
+++ b/src/components/GlobalTopBar.tsx
@@ -8,7 +8,7 @@ import { Suspense, useCallback } from "react";
 import { scrollTargetAtom } from "@/atoms/scrollTarget";
 import { sidebarAtom } from "@/atoms/sidebar";
 import { navigationItems } from "@/config/navigation";
-import { isActivityPath } from "@/lib/activity-shared";
+import { isActivityPath, isActivitySandboxPath } from "@/lib/activity-shared";
 import { cn } from "@/lib/utils";
 
 import { MenuToggle } from "./icons/MenuToggle";
@@ -38,7 +38,15 @@ export function BreadcrumbDivider() {
   return <div className="text-quaternary font-medium opacity-50 dark:opacity-70">/</div>;
 }
 
-export function ActivityLiveBadge() {
+export function ActivityLiveBadge({ sandbox = false }: { sandbox?: boolean }) {
+  if (sandbox) {
+    return (
+      <span className="ml-0.5 inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-800 dark:text-amber-300">
+        Sandbox
+      </span>
+    );
+  }
+
   return (
     <span className="ml-0.5 inline-flex items-center gap-1 rounded-full bg-green-500/10 px-1.5 py-0.5 text-[11px] font-medium text-green-700 dark:text-green-400">
       <span className="size-1.5 animate-pulse rounded-full bg-green-500" aria-hidden />
@@ -127,7 +135,9 @@ export function TopBarTrail({ pathname, onClose }: { pathname: string; onClose?:
           <BreadcrumbLabel href={currentNavItem.href} onClick={onClose}>
             {currentNavItem.label}
           </BreadcrumbLabel>
-          {isActivityPath(pathname) ? <ActivityLiveBadge /> : null}
+          {isActivityPath(pathname) ? (
+            <ActivityLiveBadge sandbox={isActivitySandboxPath(pathname)} />
+          ) : null}
         </>
       )}
     </>

--- a/src/components/ui/DialSlider.tsx
+++ b/src/components/ui/DialSlider.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { animate, motion, useMotionValue, useReducedMotion, useTransform } from "motion/react";
+import type { PointerEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import {
+  clamp,
+  formatDialValue,
+  hashMarkPercents,
+  percentFromValue,
+  roundValue,
+  snapClickValue,
+} from "@/lib/dial-slider";
+import { cn } from "@/lib/utils";
+
+const CLICK_THRESHOLD = 3;
+const DEAD_ZONE = 32;
+const MAX_CURSOR_RANGE = 200;
+const MAX_STRETCH = 8;
+const HANDLE_BUFFER = 8;
+const LABEL_CSS_LEFT = 10;
+const VALUE_CSS_RIGHT = 10;
+
+export function DialSlider({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step: number;
+}) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const valueSpanRef = useRef<HTMLSpanElement>(null);
+  const hoverTimeoutRef = useRef<number | null>(null);
+  const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
+  const isClickRef = useRef(true);
+  const animRef = useRef<{ stop: () => void } | null>(null);
+  const wrapperRectRef = useRef<DOMRect | null>(null);
+  const scaleRef = useRef(1);
+  const reduceMotion = useReducedMotion();
+
+  const [isInteracting, setIsInteracting] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [isValueEditable, setIsValueEditable] = useState(false);
+  const [showInput, setShowInput] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [leftThreshold, setLeftThreshold] = useState(30);
+  const [rightThreshold, setRightThreshold] = useState(78);
+
+  const percentage = percentFromValue(value, min, max);
+  const isActive = isInteracting || isHovered;
+  const displayValue = formatDialValue(value, step);
+  const marks = hashMarkPercents(min, max, step);
+
+  const fillPercent = useMotionValue(percentage);
+  const fillWidth = useTransform(fillPercent, (pct) => `${pct}%`);
+  const handleLeft = useTransform(fillPercent, (pct) => `max(5px, calc(${pct}% - 9px))`);
+  const rubberStretchPx = useMotionValue(0);
+  const rubberBandWidth = useTransform(
+    rubberStretchPx,
+    (stretch) => `calc(100% + ${Math.abs(stretch)}px)`,
+  );
+  const rubberBandX = useTransform(rubberStretchPx, (stretch) => (stretch < 0 ? stretch : 0));
+
+  useEffect(() => {
+    if (!isInteracting && !animRef.current) {
+      fillPercent.jump(percentage);
+    }
+  }, [fillPercent, isInteracting, percentage]);
+
+  useLayoutEffect(() => {
+    const trackWidth = wrapperRef.current?.offsetWidth;
+    if (!trackWidth) return;
+    if (labelRef.current) {
+      setLeftThreshold(
+        ((LABEL_CSS_LEFT + labelRef.current.offsetWidth + HANDLE_BUFFER) / trackWidth) * 100,
+      );
+    }
+    if (valueSpanRef.current) {
+      setRightThreshold(
+        ((trackWidth - VALUE_CSS_RIGHT - valueSpanRef.current.offsetWidth - HANDLE_BUFFER) /
+          trackWidth) *
+          100,
+      );
+    }
+  }, [displayValue, label, showInput]);
+
+  const positionToValue = useCallback(
+    (clientX: number) => {
+      const rect = wrapperRectRef.current;
+      if (!rect) return value;
+      const nativeWidth = wrapperRef.current ? wrapperRef.current.offsetWidth : rect.width;
+      const percent = clamp((clientX - rect.left) / scaleRef.current / nativeWidth, 0, 1);
+      return min + percent * (max - min);
+    },
+    [max, min, value],
+  );
+
+  const computeRubberStretch = useCallback((clientX: number, sign: -1 | 1) => {
+    const rect = wrapperRectRef.current;
+    if (!rect) return 0;
+    const distancePast = sign < 0 ? rect.left - clientX : clientX - rect.right;
+    const overflow = Math.max(0, distancePast - DEAD_ZONE);
+    return sign * MAX_STRETCH * Math.sqrt(Math.min(overflow / MAX_CURSOR_RANGE, 1));
+  }, []);
+
+  const commitValue = useCallback(
+    (next: number) => {
+      onChange(roundValue(clamp(next, min, max), step));
+    },
+    [max, min, onChange, step],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (showInput) return;
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      pointerDownPos.current = { x: event.clientX, y: event.clientY };
+      isClickRef.current = true;
+      setIsInteracting(true);
+      if (wrapperRef.current) {
+        wrapperRectRef.current = wrapperRef.current.getBoundingClientRect();
+        scaleRef.current = wrapperRectRef.current.width / wrapperRef.current.offsetWidth;
+      }
+    },
+    [showInput],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!isInteracting || !pointerDownPos.current) return;
+      const dx = event.clientX - pointerDownPos.current.x;
+      const dy = event.clientY - pointerDownPos.current.y;
+      if (isClickRef.current && Math.hypot(dx, dy) > CLICK_THRESHOLD) {
+        isClickRef.current = false;
+        setIsDragging(true);
+      }
+      if (isClickRef.current) return;
+
+      const rect = wrapperRectRef.current;
+      if (rect) {
+        if (event.clientX < rect.left)
+          rubberStretchPx.jump(computeRubberStretch(event.clientX, -1));
+        else if (event.clientX > rect.right)
+          rubberStretchPx.jump(computeRubberStretch(event.clientX, 1));
+        else rubberStretchPx.jump(0);
+      }
+
+      const next = positionToValue(event.clientX);
+      animRef.current?.stop();
+      animRef.current = null;
+      fillPercent.jump(percentFromValue(next, min, max));
+      commitValue(next);
+    },
+    [
+      commitValue,
+      computeRubberStretch,
+      fillPercent,
+      isInteracting,
+      max,
+      min,
+      positionToValue,
+      rubberStretchPx,
+    ],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!isInteracting) return;
+      if (isClickRef.current) {
+        const snapped = snapClickValue(positionToValue(event.clientX), min, max, step);
+        const nextPct = percentFromValue(snapped, min, max);
+        animRef.current?.stop();
+        if (reduceMotion) {
+          fillPercent.jump(nextPct);
+          animRef.current = null;
+        } else {
+          animRef.current = animate(fillPercent, nextPct, {
+            type: "spring",
+            stiffness: 300,
+            damping: 25,
+            mass: 0.8,
+            onComplete: () => {
+              animRef.current = null;
+            },
+          });
+        }
+        commitValue(snapped);
+      }
+      if (rubberStretchPx.get() !== 0) {
+        if (reduceMotion) rubberStretchPx.jump(0);
+        else {
+          animate(rubberStretchPx, 0, {
+            type: "spring",
+            visualDuration: 0.35,
+            bounce: 0.15,
+          });
+        }
+      }
+      setIsInteracting(false);
+      setIsDragging(false);
+      pointerDownPos.current = null;
+    },
+    [
+      commitValue,
+      fillPercent,
+      isInteracting,
+      max,
+      min,
+      positionToValue,
+      reduceMotion,
+      rubberStretchPx,
+      step,
+    ],
+  );
+
+  const clearHoverTimeout = useCallback(() => {
+    if (hoverTimeoutRef.current) {
+      window.clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (showInput) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [showInput]);
+
+  useEffect(() => () => clearHoverTimeout(), [clearHoverTimeout]);
+
+  const submitInput = () => {
+    const parsed = Number.parseFloat(inputValue);
+    if (Number.isFinite(parsed)) commitValue(parsed);
+    setShowInput(false);
+    setIsValueEditable(false);
+  };
+
+  const valueDodge = percentage < leftThreshold || percentage > rightThreshold;
+  const handleOpacity = !isActive ? 0 : valueDodge ? 0.1 : isDragging ? 0.9 : 0.5;
+
+  return (
+    <div ref={wrapperRef} className="relative h-9">
+      <motion.div
+        role="slider"
+        tabIndex={0}
+        aria-label={label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={displayValue}
+        data-active={isActive || undefined}
+        className="group absolute top-0 left-0 h-full w-full cursor-pointer touch-none overflow-hidden rounded-lg bg-black/[0.04] select-none dark:bg-white/5"
+        style={{ width: rubberBandWidth, x: rubberBandX }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onKeyDown={(event) => {
+          const coarse = step * 10;
+          if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+            event.preventDefault();
+            commitValue(value + (event.shiftKey ? coarse : step));
+          } else if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+            event.preventDefault();
+            commitValue(value - (event.shiftKey ? coarse : step));
+          } else if (event.key === "Home") {
+            event.preventDefault();
+            commitValue(min);
+          } else if (event.key === "End") {
+            event.preventDefault();
+            commitValue(max);
+          }
+        }}
+      >
+        <div className="pointer-events-none absolute inset-0">
+          {marks.map((pct) => (
+            <div
+              key={pct}
+              className="absolute top-1/2 h-2 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-transparent transition-colors duration-200 group-data-[active]:bg-black/15 dark:group-data-[active]:bg-white/15"
+              style={{ left: `${pct}%` }}
+            />
+          ))}
+        </div>
+        <motion.div
+          className="pointer-events-none absolute inset-y-0 left-0 bg-black/10 transition-colors duration-150 group-data-[active]:bg-black/15 dark:bg-white/[0.11] dark:group-data-[active]:bg-white/15"
+          style={{ width: fillWidth }}
+        />
+        <motion.div
+          className="pointer-events-none absolute top-1/2 h-5 w-[3px] rounded-full bg-neutral-900 dark:bg-white/95"
+          style={{ left: handleLeft, y: "-50%" }}
+          animate={{
+            opacity: handleOpacity,
+            scaleX: isActive ? 1 : 0.25,
+            scaleY: isActive && valueDodge ? 0.75 : 1,
+          }}
+          transition={{
+            scaleX: { type: "spring", visualDuration: 0.25, bounce: 0.15 },
+            scaleY: { type: "spring", visualDuration: 0.2, bounce: 0.1 },
+            opacity: { duration: 0.15 },
+          }}
+        />
+        <span
+          ref={labelRef}
+          className="text-tertiary pointer-events-none absolute top-1/2 left-2.5 inline-flex -translate-y-1/2 text-[13px] font-medium"
+        >
+          {label}
+        </span>
+        {showInput ? (
+          <input
+            ref={inputRef}
+            type="text"
+            inputMode="decimal"
+            className="text-tertiary focus:text-primary absolute top-1/2 right-2.5 w-12 -translate-y-1/2 border-0 border-b border-current bg-transparent p-0 pb-px text-right font-mono text-[13px] font-medium outline-none"
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") submitInput();
+              if (event.key === "Escape") {
+                setShowInput(false);
+                setIsValueEditable(false);
+              }
+            }}
+            onBlur={submitInput}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => event.stopPropagation()}
+          />
+        ) : (
+          <span
+            ref={valueSpanRef}
+            className={cn(
+              "text-tertiary absolute top-1/2 right-2.5 -translate-y-1/2 border-b border-transparent pb-px font-mono text-[13px] font-medium tabular-nums",
+              isActive && "text-primary",
+              isValueEditable && "border-current",
+            )}
+            style={{ cursor: isValueEditable ? "text" : "default" }}
+            onMouseEnter={() => {
+              clearHoverTimeout();
+              hoverTimeoutRef.current = window.setTimeout(() => setIsValueEditable(true), 800);
+            }}
+            onMouseLeave={() => {
+              clearHoverTimeout();
+              if (!showInput) setIsValueEditable(false);
+            }}
+            onClick={(event) => {
+              if (!isValueEditable) return;
+              event.stopPropagation();
+              event.preventDefault();
+              setShowInput(true);
+              setInputValue(displayValue);
+            }}
+            onPointerDown={(event) => {
+              if (isValueEditable) event.stopPropagation();
+            }}
+          >
+            {displayValue}
+          </span>
+        )}
+      </motion.div>
+    </div>
+  );
+}

--- a/src/lib/activity-geo.ts
+++ b/src/lib/activity-geo.ts
@@ -52,6 +52,11 @@ export type ActivityGlobeMarker = {
   size: number;
 };
 
+export type ActivityRecentGlobeMarker = ActivityGlobeMarker & {
+  eventId: string;
+  age: number;
+};
+
 /** 0.1° bucket used to merge nearby visits into one globe marker. */
 export function activityGlobeLocationKey(lat: number, lng: number): string {
   return `${lat.toFixed(1)},${lng.toFixed(1)}`;
@@ -683,4 +688,30 @@ export function activityGlobeMarkers(
     location: [bucket.lat, bucket.lng] as [number, number],
     size: markerSizeFromCount(bucket.count, sizing),
   }));
+}
+
+/** Newest-first unique locations, capped so the globe stays a trail instead of a pile. */
+export function activityRecentGlobeMarkers(
+  events: Array<{ id?: string; meta?: Record<string, unknown> }>,
+  limit: number,
+): ActivityRecentGlobeMarker[] {
+  const cap = Math.max(0, Math.floor(limit));
+  const seen = new Set<string>();
+  const markers: ActivityRecentGlobeMarker[] = [];
+  for (const event of events) {
+    if (markers.length >= cap) break;
+    const loc = activityEventLocation(event);
+    if (!loc) continue;
+    const key = activityGlobeLocationKey(loc.lat, loc.lng);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    markers.push({
+      id: activityGlobeMarkerId(loc.lat, loc.lng),
+      eventId: typeof event.id === "string" && event.id ? event.id : key,
+      location: [loc.lat, loc.lng],
+      size: 0,
+      age: markers.length,
+    });
+  }
+  return markers;
 }

--- a/src/lib/activity-geo.ts
+++ b/src/lib/activity-geo.ts
@@ -658,10 +658,33 @@ export function geoFromVisitMeta(meta: Record<string, unknown> | undefined): Act
   };
 }
 
-/** Prefer stored coords; otherwise the country centroid. Skip mysterious / missing country. */
+/** Brian's home pin — GitHub work and Notion publishes land here. */
+export const ACTIVITY_HOME_LOCATION: ActivityLatLng = { lat: 37.77, lng: -122.42 };
+
+const HOME_ORIGIN_TYPES = new Set([
+  "pr_opened",
+  "pr_merged",
+  "writing_published",
+  "til_published",
+  "stack_added",
+  "site_added",
+  "design_details_added",
+  "app_dissection_published",
+  "ama_answered",
+]);
+
+export function isHomeOriginActivity(event: { type?: string; source?: string }): boolean {
+  if (event.source === "github") return true;
+  return typeof event.type === "string" && HOME_ORIGIN_TYPES.has(event.type);
+}
+
+/** GitHub + Notion publishes always pin to SF. Visits use stored coords, then country centroid. */
 export function activityEventLocation(event: {
+  type?: string;
+  source?: string;
   meta?: Record<string, unknown>;
 }): ActivityLatLng | undefined {
+  if (isHomeOriginActivity(event)) return ACTIVITY_HOME_LOCATION;
   const geo = geoFromVisitMeta(event.meta);
   if (geo.latitude !== undefined && geo.longitude !== undefined) {
     return { lat: geo.latitude, lng: geo.longitude };
@@ -670,7 +693,7 @@ export function activityEventLocation(event: {
 }
 
 export function activityGlobeMarkers(
-  events: Array<{ meta?: Record<string, unknown> }>,
+  events: Array<{ type?: string; source?: string; meta?: Record<string, unknown> }>,
   sizeConfig?: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerSizePerLog" | "markerMaxSize">,
 ): ActivityGlobeMarker[] {
   const sizing = sizeConfig ?? DEFAULT_ACTIVITY_GLOBE_CONFIG;
@@ -692,7 +715,7 @@ export function activityGlobeMarkers(
 
 /** Newest-first unique locations, capped so the globe stays a trail instead of a pile. */
 export function activityRecentGlobeMarkers(
-  events: Array<{ id?: string; meta?: Record<string, unknown> }>,
+  events: Array<{ id?: string; type?: string; source?: string; meta?: Record<string, unknown> }>,
   limit: number,
 ): ActivityRecentGlobeMarker[] {
   const cap = Math.max(0, Math.floor(limit));

--- a/src/lib/activity-geo.ts
+++ b/src/lib/activity-geo.ts
@@ -1,4 +1,9 @@
 import { COUNTRY_CENTROIDS } from "./activity-geo-centroids";
+import {
+  type ActivityGlobeConfig,
+  DEFAULT_ACTIVITY_GLOBE_CONFIG,
+  markerSizeFromCount,
+} from "./activity-globe-config";
 
 /**
  * Country / region display names for activity visit summaries.
@@ -47,11 +52,26 @@ export type ActivityGlobeMarker = {
   size: number;
 };
 
+/** 0.1° bucket used to merge nearby visits into one globe marker. */
+export function activityGlobeLocationKey(lat: number, lng: number): string {
+  return `${lat.toFixed(1)},${lng.toFixed(1)}`;
+}
+
 /** Stable CSS-safe id for COBE bindable markers (`--cobe-{id}`). */
 export function activityGlobeMarkerId(lat: number, lng: number): string {
   const encode = (value: number): string =>
     value.toFixed(1).replaceAll("-", "n").replaceAll(".", "d");
   return `g${encode(lat)}x${encode(lng)}`;
+}
+
+export function activityGlobeMarkerIdForLocation(
+  location: ActivityLatLng,
+  markers: readonly ActivityGlobeMarker[],
+): string | undefined {
+  const key = activityGlobeLocationKey(location.lat, location.lng);
+  return markers.find(
+    (marker) => activityGlobeLocationKey(marker.location[0], marker.location[1]) === key,
+  )?.id;
 }
 
 /** Persist the same snake_case keys first-party visits store on event.meta. */
@@ -646,12 +666,14 @@ export function activityEventLocation(event: {
 
 export function activityGlobeMarkers(
   events: Array<{ meta?: Record<string, unknown> }>,
+  sizeConfig?: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerSizePerLog" | "markerMaxSize">,
 ): ActivityGlobeMarker[] {
+  const sizing = sizeConfig ?? DEFAULT_ACTIVITY_GLOBE_CONFIG;
   const buckets = new Map<string, { lat: number; lng: number; count: number }>();
   for (const event of events) {
     const loc = activityEventLocation(event);
     if (!loc) continue;
-    const key = `${loc.lat.toFixed(1)},${loc.lng.toFixed(1)}`;
+    const key = activityGlobeLocationKey(loc.lat, loc.lng);
     const existing = buckets.get(key);
     if (existing) existing.count += 1;
     else buckets.set(key, { lat: loc.lat, lng: loc.lng, count: 1 });
@@ -659,7 +681,6 @@ export function activityGlobeMarkers(
   return [...buckets.values()].map((bucket) => ({
     id: activityGlobeMarkerId(bucket.lat, bucket.lng),
     location: [bucket.lat, bucket.lng] as [number, number],
-    // Small WebGL discs: through-the-planet hint. DOM orbs carry facing depth.
-    size: Math.min(0.028, 0.01 + Math.log2(bucket.count) * 0.004),
+    size: markerSizeFromCount(bucket.count, sizing),
   }));
 }

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -5,7 +5,8 @@ import {
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
   globeThemeColors,
-  markerAgeOpacity,
+  markerAgeScale,
+  markerDotPxForAge,
   markerDotPxForSize,
   markerSizeFromCount,
 } from "./activity-globe-config";
@@ -46,10 +47,18 @@ describe("activity-globe-config", () => {
     expect(String(style.transition)).toContain("opacity 300ms");
   });
 
-  test("markerAgeOpacity drops 20% per older marker", () => {
-    expect(markerAgeOpacity(0, 0.2)).toBe(1);
-    expect(markerAgeOpacity(1, 0.2)).toBeCloseTo(0.8);
-    expect(markerAgeOpacity(4, 0.2)).toBeCloseTo(0.2);
-    expect(markerAgeOpacity(5, 0.2)).toBe(0);
+  test("markerAgeScale shrinks ~10% per older marker", () => {
+    expect(markerAgeScale(0, 0.1)).toBe(1);
+    expect(markerAgeScale(1, 0.1)).toBeCloseTo(0.9);
+    expect(markerAgeScale(2, 0.1)).toBeCloseTo(0.81);
+    expect(markerAgeScale(9, 0.1)).toBeCloseTo(0.9 ** 9);
+    expect(markerAgeScale(1, DEFAULT_ACTIVITY_GLOBE_CONFIG.markerAgeShrink)).toBeCloseTo(0.9);
+  });
+
+  test("markerDotPxForAge never shrinks below the land-dot floor", () => {
+    const cfg = DEFAULT_ACTIVITY_GLOBE_CONFIG;
+    expect(markerDotPxForAge(0, cfg, 5)).toBeCloseTo(cfg.markerDotPx);
+    expect(markerDotPxForAge(9, cfg, 5)).toBe(5);
+    expect(markerDotPxForAge(9, cfg, 0)).toBeCloseTo(cfg.markerDotPx * 0.9 ** 9);
   });
 });

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -5,9 +5,9 @@ import {
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
   globeThemeColors,
+  markerAgeOpacity,
   markerDotPxForSize,
   markerSizeFromCount,
-  rgbCss,
 } from "./activity-globe-config";
 
 describe("activity-globe-config", () => {
@@ -43,7 +43,13 @@ describe("activity-globe-config", () => {
     expect(style.top).toBe("anchor(center)");
     expect(style.opacity).toBe("var(--cobe-visible-sf, 0)");
     expect(style.filter).toBe("blur(calc((1 - var(--cobe-visible-sf, 0)) * 8px))");
-    expect(style.backgroundColor).toBe(rgbCss(DEFAULT_ACTIVITY_GLOBE_CONFIG.markerColor));
     expect(String(style.transition)).toContain("opacity 300ms");
+  });
+
+  test("markerAgeOpacity drops 20% per older marker", () => {
+    expect(markerAgeOpacity(0, 0.2)).toBe(1);
+    expect(markerAgeOpacity(1, 0.2)).toBeCloseTo(0.8);
+    expect(markerAgeOpacity(4, 0.2)).toBeCloseTo(0.2);
+    expect(markerAgeOpacity(5, 0.2)).toBe(0);
   });
 });

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  cobeMarkerStyle,
+  DEFAULT_ACTIVITY_GLOBE_CONFIG,
+  globeCobeOptions,
+  globeThemeColors,
+  markerDotPxForSize,
+  markerSizeFromCount,
+  rgbCss,
+} from "./activity-globe-config";
+
+describe("activity-globe-config", () => {
+  test("markerSizeFromCount grows with visit count and caps", () => {
+    const cfg = DEFAULT_ACTIVITY_GLOBE_CONFIG;
+    expect(markerSizeFromCount(1, cfg)).toBeCloseTo(cfg.markerBaseSize);
+    expect(markerSizeFromCount(4, cfg)).toBeGreaterThan(markerSizeFromCount(1, cfg));
+    expect(markerSizeFromCount(10_000, cfg)).toBeCloseTo(cfg.markerMaxSize);
+  });
+
+  test("markerDotPxForSize scales the CSS dot with visit count", () => {
+    const cfg = DEFAULT_ACTIVITY_GLOBE_CONFIG;
+    expect(markerDotPxForSize(cfg.markerBaseSize, cfg)).toBeCloseTo(cfg.markerDotPx);
+    expect(markerDotPxForSize(cfg.markerBaseSize * 2, cfg)).toBeCloseTo(cfg.markerDotPx * 2);
+  });
+
+  test("globeThemeColors and globeCobeOptions switch light and dark palettes", () => {
+    const light = globeThemeColors(false, DEFAULT_ACTIVITY_GLOBE_CONFIG);
+    const dark = globeThemeColors(true, DEFAULT_ACTIVITY_GLOBE_CONFIG);
+    expect(light.dark).toBe(0);
+    expect(dark.dark).toBe(1);
+    expect(light.baseColor).toEqual(DEFAULT_ACTIVITY_GLOBE_CONFIG.lightBaseColor);
+    expect(dark.baseColor).toEqual(DEFAULT_ACTIVITY_GLOBE_CONFIG.darkBaseColor);
+    expect(globeCobeOptions(true, DEFAULT_ACTIVITY_GLOBE_CONFIG).glowColor).toEqual(
+      DEFAULT_ACTIVITY_GLOBE_CONFIG.darkGlowColor,
+    );
+  });
+
+  test("cobeMarkerStyle matches the official visibility recipe", () => {
+    const style = cobeMarkerStyle("sf", DEFAULT_ACTIVITY_GLOBE_CONFIG);
+    expect(style.positionAnchor).toBe("--cobe-sf");
+    expect(style.left).toBe("anchor(center)");
+    expect(style.top).toBe("anchor(center)");
+    expect(style.opacity).toBe("var(--cobe-visible-sf, 0)");
+    expect(style.filter).toBe("blur(calc((1 - var(--cobe-visible-sf, 0)) * 8px))");
+    expect(style.backgroundColor).toBe(rgbCss(DEFAULT_ACTIVITY_GLOBE_CONFIG.markerColor));
+    expect(String(style.transition)).toContain("opacity 300ms");
+  });
+});

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -31,15 +31,28 @@ export type ActivityGlobeConfig = {
   markerFadeMs: number;
   /** How many recent unique locations stay on the globe. */
   markerRecentCount: number;
-  /** Opacity drop per older marker (newest is 1). */
-  markerAgeFade: number;
+  /** Size drop per older marker (0.1 = each step is 90% of the one before). */
+  markerAgeShrink: number;
   focusPulseScale: number;
   focusMs: number;
 };
 
-export function markerAgeOpacity(age: number, step: number): number {
+export function markerAgeScale(age: number, shrink: number): number {
   if (age < 0) return 0;
-  return Math.max(0, 1 - age * step);
+  if (shrink <= 0) return 1;
+  if (shrink >= 1) return age === 0 ? 1 : 0;
+  return (1 - shrink) ** age;
+}
+
+/** Newest is `markerDotPx`; each older step shrinks, never below the land-dot floor. */
+export function markerDotPxForAge(
+  age: number,
+  config: Pick<ActivityGlobeConfig, "markerDotPx" | "markerAgeShrink">,
+  minPx: number,
+): number {
+  const scaled = config.markerDotPx * markerAgeScale(age, config.markerAgeShrink);
+  const floor = Number.isFinite(minPx) ? Math.max(0, minPx) : 0;
+  return Math.max(floor, scaled);
 }
 
 export function markerDotPxForSize(
@@ -51,11 +64,11 @@ export function markerDotPxForSize(
 }
 
 export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
-  diffuse: 1.2,
-  mapSamples: 16000,
-  mapBrightness: 6,
+  diffuse: 0.6,
+  mapSamples: 19000,
+  mapBrightness: 3.1,
   mapBaseBrightness: 0,
-  mapBrightnessDark: 5,
+  mapBrightnessDark: 6,
   scale: 1,
   offsetX: 0,
   offsetY: 0,
@@ -72,13 +85,13 @@ export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
   markerSizePerLog: 0.007,
   markerMaxSize: 0.05,
 
-  markerDotPx: 6,
+  markerDotPx: 12,
   markerBlurPx: 8,
   markerFadeMs: 300,
-  markerRecentCount: 5,
-  markerAgeFade: 0.2,
-  focusPulseScale: 0.45,
-  focusMs: 1200,
+  markerRecentCount: 10,
+  markerAgeShrink: 0.1,
+  focusPulseScale: 0.75,
+  focusMs: 1400,
 };
 
 export function markerSizeFromCount(

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -1,0 +1,139 @@
+/** Tunable COBE + CSS bindable-marker settings for the activity globe. */
+
+export type RgbTriplet = [number, number, number];
+
+export type ActivityGlobeConfig = {
+  diffuse: number;
+  mapSamples: number;
+  mapBrightness: number;
+  mapBaseBrightness: number;
+  mapBrightnessDark: number;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  opacity: number;
+  markerElevation: number;
+
+  lightBaseColor: RgbTriplet;
+  lightGlowColor: RgbTriplet;
+  darkBaseColor: RgbTriplet;
+  darkGlowColor: RgbTriplet;
+  markerColor: RgbTriplet;
+
+  /** CSS dot scale from visit-count buckets. */
+  markerBaseSize: number;
+  markerSizePerLog: number;
+  markerMaxSize: number;
+
+  /** Bindable CSS dots — same recipe as https://cobe.vercel.app */
+  markerDotPx: number;
+  markerBlurPx: number;
+  markerFadeMs: number;
+  focusPulseScale: number;
+  focusMs: number;
+};
+
+export function markerDotPxForSize(
+  size: number,
+  config: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerDotPx">,
+): number {
+  if (config.markerBaseSize <= 0) return config.markerDotPx;
+  return config.markerDotPx * (size / config.markerBaseSize);
+}
+
+export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
+  diffuse: 1.2,
+  mapSamples: 16000,
+  mapBrightness: 6,
+  mapBaseBrightness: 0,
+  mapBrightnessDark: 5,
+  scale: 1,
+  offsetX: 0,
+  offsetY: 0,
+  opacity: 1,
+  markerElevation: 0,
+
+  lightBaseColor: [1, 1, 1],
+  lightGlowColor: [0.95, 0.95, 0.95],
+  darkBaseColor: [0.3, 0.3, 0.3],
+  darkGlowColor: [0.12, 0.12, 0.12],
+  markerColor: [252 / 255, 83 / 255, 42 / 255],
+
+  markerBaseSize: 0.018,
+  markerSizePerLog: 0.007,
+  markerMaxSize: 0.05,
+
+  markerDotPx: 10,
+  markerBlurPx: 8,
+  markerFadeMs: 300,
+  focusPulseScale: 0.45,
+  focusMs: 1200,
+};
+
+export function markerSizeFromCount(
+  count: number,
+  config: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerSizePerLog" | "markerMaxSize">,
+): number {
+  return Math.min(
+    config.markerMaxSize,
+    config.markerBaseSize + Math.log2(Math.max(1, count)) * config.markerSizePerLog,
+  );
+}
+
+export function globeThemeColors(
+  isDark: boolean,
+  config: ActivityGlobeConfig,
+): { baseColor: RgbTriplet; glowColor: RgbTriplet; mapBrightness: number; dark: number } {
+  return {
+    baseColor: isDark ? config.darkBaseColor : config.lightBaseColor,
+    glowColor: isDark ? config.darkGlowColor : config.lightGlowColor,
+    mapBrightness: isDark ? config.mapBrightnessDark : config.mapBrightness,
+    dark: isDark ? 1 : 0,
+  };
+}
+
+/** COBE create/update fields that come from the tunable config. */
+export function globeCobeOptions(isDark: boolean, config: ActivityGlobeConfig) {
+  const theme = globeThemeColors(isDark, config);
+  return {
+    dark: theme.dark,
+    diffuse: config.diffuse,
+    mapSamples: config.mapSamples,
+    mapBrightness: theme.mapBrightness,
+    mapBaseBrightness: config.mapBaseBrightness,
+    baseColor: theme.baseColor,
+    markerColor: config.markerColor,
+    glowColor: theme.glowColor,
+    markerElevation: config.markerElevation,
+    scale: config.scale,
+    offset: [config.offsetX, config.offsetY] as [number, number],
+    opacity: config.opacity,
+  };
+}
+
+export function rgbCss(color: RgbTriplet): string {
+  const channel = (value: number) => Math.round(Math.min(1, Math.max(0, value)) * 255);
+  return `rgb(${channel(color[0])} ${channel(color[1])} ${channel(color[2])})`;
+}
+
+/** Official COBE bindable-marker visibility: `--cobe-visible-{id}` is `N` or unset. */
+export function cobeMarkerStyle(
+  markerId: string,
+  config: Pick<
+    ActivityGlobeConfig,
+    "markerDotPx" | "markerBlurPx" | "markerFadeMs" | "markerColor"
+  >,
+): Record<string, string | number> {
+  const visible = `--cobe-visible-${markerId}`;
+  return {
+    positionAnchor: `--cobe-${markerId}`,
+    left: "anchor(center)",
+    top: "anchor(center)",
+    width: config.markerDotPx,
+    height: config.markerDotPx,
+    backgroundColor: rgbCss(config.markerColor),
+    opacity: `var(${visible}, 0)`,
+    filter: `blur(calc((1 - var(${visible}, 0)) * ${config.markerBlurPx}px))`,
+    transition: `opacity ${config.markerFadeMs}ms ease, filter ${config.markerFadeMs}ms ease, transform ${config.markerFadeMs}ms ease, background-color ${config.markerFadeMs}ms ease, box-shadow ${config.markerFadeMs}ms ease`,
+  };
+}

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -29,9 +29,18 @@ export type ActivityGlobeConfig = {
   markerDotPx: number;
   markerBlurPx: number;
   markerFadeMs: number;
+  /** How many recent unique locations stay on the globe. */
+  markerRecentCount: number;
+  /** Opacity drop per older marker (newest is 1). */
+  markerAgeFade: number;
   focusPulseScale: number;
   focusMs: number;
 };
+
+export function markerAgeOpacity(age: number, step: number): number {
+  if (age < 0) return 0;
+  return Math.max(0, 1 - age * step);
+}
 
 export function markerDotPxForSize(
   size: number,
@@ -63,9 +72,11 @@ export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
   markerSizePerLog: 0.007,
   markerMaxSize: 0.05,
 
-  markerDotPx: 10,
+  markerDotPx: 6,
   markerBlurPx: 8,
   markerFadeMs: 300,
+  markerRecentCount: 5,
+  markerAgeFade: 0.2,
   focusPulseScale: 0.45,
   focusMs: 1200,
 };
@@ -119,21 +130,15 @@ export function rgbCss(color: RgbTriplet): string {
 /** Official COBE bindable-marker visibility: `--cobe-visible-{id}` is `N` or unset. */
 export function cobeMarkerStyle(
   markerId: string,
-  config: Pick<
-    ActivityGlobeConfig,
-    "markerDotPx" | "markerBlurPx" | "markerFadeMs" | "markerColor"
-  >,
+  config: Pick<ActivityGlobeConfig, "markerBlurPx" | "markerFadeMs">,
 ): Record<string, string | number> {
   const visible = `--cobe-visible-${markerId}`;
   return {
     positionAnchor: `--cobe-${markerId}`,
     left: "anchor(center)",
     top: "anchor(center)",
-    width: config.markerDotPx,
-    height: config.markerDotPx,
-    backgroundColor: rgbCss(config.markerColor),
     opacity: `var(${visible}, 0)`,
     filter: `blur(calc((1 - var(${visible}, 0)) * ${config.markerBlurPx}px))`,
-    transition: `opacity ${config.markerFadeMs}ms ease, filter ${config.markerFadeMs}ms ease, transform ${config.markerFadeMs}ms ease, background-color ${config.markerFadeMs}ms ease, box-shadow ${config.markerFadeMs}ms ease`,
+    transition: `opacity ${config.markerFadeMs}ms ease, filter ${config.markerFadeMs}ms ease`,
   };
 }

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { activityGlobeMarkerIdForLocation, activityGlobeMarkers } from "./activity-geo";
+import { activityGlobeMarkerIdForLocation, activityRecentGlobeMarkers } from "./activity-geo";
 import {
   bindableGlobeMarkers,
   GLOBE_HANG,
@@ -95,13 +95,33 @@ describe("bindableGlobeMarkers", () => {
 
 describe("activityGlobeMarkerIdForLocation", () => {
   test("matches a nearby visit to the existing 0.1° bucket", () => {
-    const markers = activityGlobeMarkers([
-      { meta: { latitude: 37.77, longitude: -122.42 } },
-      { meta: { latitude: 51.51, longitude: -0.13 } },
-    ]);
+    const markers = activityRecentGlobeMarkers(
+      [
+        { id: "sf", meta: { latitude: 37.77, longitude: -122.42 } },
+        { id: "ldn", meta: { latitude: 51.51, longitude: -0.13 } },
+      ],
+      5,
+    );
     expect(activityGlobeMarkerIdForLocation({ lat: 37.81, lng: -122.39 }, markers)).toBe(
       markers[0]?.id,
     );
     expect(activityGlobeMarkerIdForLocation({ lat: 0, lng: 0 }, markers)).toBeUndefined();
+  });
+});
+
+describe("activityRecentGlobeMarkers", () => {
+  test("keeps the newest unique locations and ages the rest", () => {
+    const markers = activityRecentGlobeMarkers(
+      [
+        { id: "tokyo", meta: { latitude: 35.68, longitude: 139.69 } },
+        { id: "tokyo-again", meta: { latitude: 35.68, longitude: 139.69 } },
+        { id: "london", meta: { latitude: 51.51, longitude: -0.13 } },
+        { id: "sf", meta: { latitude: 37.77, longitude: -122.42 } },
+        { id: "sydney", meta: { latitude: -33.87, longitude: 151.21 } },
+      ],
+      3,
+    );
+    expect(markers.map((marker) => marker.eventId)).toEqual(["tokyo", "london", "sf"]);
+    expect(markers.map((marker) => marker.age)).toEqual([0, 1, 2]);
   });
 });

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
+import { activityGlobeMarkerIdForLocation, activityGlobeMarkers } from "./activity-geo";
 import {
+  bindableGlobeMarkers,
+  GLOBE_HANG,
+  globeAimVisibleBias,
   globeMarkerFacing,
   latLngToGlobePose,
+  latLngToVisibleGlobePose,
   projectGlobeMarker,
   shortestAngleDelta,
 } from "./activity-globe";
@@ -16,6 +21,33 @@ describe("latLngToGlobePose", () => {
     const sf = latLngToGlobePose(37.77, -122.42);
     expect(sf.phi).toBeCloseTo(Math.PI - ((-122.42 * Math.PI) / 180 - Math.PI / 2));
     expect(sf.theta).toBeCloseTo((37.77 * Math.PI) / 180);
+  });
+
+  test("visible aim pose sits the location in the unclipped top-left of the mesh", () => {
+    const visibleEdge = 1 - GLOBE_HANG;
+    const samples: Array<[number, number]> = [
+      [0, 0],
+      [37.77, -122.42],
+      [-33.87, 151.21],
+      [51.51, -0.13],
+    ];
+    for (const [lat, lng] of samples) {
+      const { phi, theta } = latLngToVisibleGlobePose(lat, lng);
+      const projected = projectGlobeMarker(lat, lng, phi, theta);
+      expect(projected.x).toBeLessThan(0.5);
+      expect(projected.y).toBeLessThan(0.5);
+      expect(projected.x).toBeGreaterThan(0.25);
+      expect(projected.y).toBeGreaterThan(0.25);
+      expect(projected.x).toBeLessThan(visibleEdge);
+      expect(projected.y).toBeLessThan(visibleEdge);
+      expect(projected.facing).toBeGreaterThan(0.8);
+    }
+  });
+
+  test("visible bias is toward decreasing phi and theta", () => {
+    const { dPhi, dTheta } = globeAimVisibleBias();
+    expect(dPhi).toBeLessThan(0);
+    expect(dTheta).toBeLessThan(0);
   });
 
   test("aimed pose puts the location at the camera apex", () => {
@@ -49,5 +81,27 @@ describe("shortestAngleDelta", () => {
     const target = latLngToGlobePose(0, 0).phi;
     const spun = target + Math.PI * 2 * 3 + 0.4;
     expect(shortestAngleDelta(spun, target)).toBeCloseTo(-0.4);
+  });
+});
+
+describe("bindableGlobeMarkers", () => {
+  test("keeps ids and locations so COBE can bind CSS anchors", () => {
+    const markers = bindableGlobeMarkers([
+      { id: "sf", location: [37.77, -122.42], size: 0.02 },
+    ]);
+    expect(markers).toEqual([{ id: "sf", location: [37.77, -122.42], size: 0 }]);
+  });
+});
+
+describe("activityGlobeMarkerIdForLocation", () => {
+  test("matches a nearby visit to the existing 0.1° bucket", () => {
+    const markers = activityGlobeMarkers([
+      { meta: { latitude: 37.77, longitude: -122.42 } },
+      { meta: { latitude: 51.51, longitude: -0.13 } },
+    ]);
+    expect(activityGlobeMarkerIdForLocation({ lat: 37.81, lng: -122.39 }, markers)).toBe(
+      markers[0]?.id,
+    );
+    expect(activityGlobeMarkerIdForLocation({ lat: 0, lng: 0 }, markers)).toBeUndefined();
   });
 });

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -98,9 +98,7 @@ describe("globeMapDotPx", () => {
 
 describe("bindableGlobeMarkers", () => {
   test("keeps ids and locations so COBE can bind CSS anchors", () => {
-    const markers = bindableGlobeMarkers([
-      { id: "sf", location: [37.77, -122.42], size: 0.02 },
-    ]);
+    const markers = bindableGlobeMarkers([{ id: "sf", location: [37.77, -122.42], size: 0.02 }]);
     expect(markers).toEqual([{ id: "sf", location: [37.77, -122.42], size: 0 }]);
   });
 });

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -4,7 +4,10 @@ import { activityGlobeMarkerIdForLocation, activityRecentGlobeMarkers } from "./
 import {
   bindableGlobeMarkers,
   GLOBE_HANG,
+  GLOBE_MAP_DOT_CHORD,
+  GLOBE_MESH_RADIUS,
   globeAimVisibleBias,
+  globeMapDotPx,
   globeMarkerFacing,
   latLngToGlobePose,
   latLngToVisibleGlobePose,
@@ -84,6 +87,15 @@ describe("shortestAngleDelta", () => {
   });
 });
 
+describe("globeMapDotPx", () => {
+  test("matches a facing-center COBE land dot on the mesh", () => {
+    expect(globeMapDotPx(512)).toBeCloseTo(GLOBE_MAP_DOT_CHORD * GLOBE_MESH_RADIUS * 512);
+    expect(globeMapDotPx(1000)).toBeGreaterThan(globeMapDotPx(512));
+    expect(globeMapDotPx(512, 1.2)).toBeCloseTo(globeMapDotPx(512) * 1.2);
+    expect(globeMapDotPx(0)).toBe(2);
+  });
+});
+
 describe("bindableGlobeMarkers", () => {
   test("keeps ids and locations so COBE can bind CSS anchors", () => {
     const markers = bindableGlobeMarkers([
@@ -123,5 +135,20 @@ describe("activityRecentGlobeMarkers", () => {
     );
     expect(markers.map((marker) => marker.eventId)).toEqual(["tokyo", "london", "sf"]);
     expect(markers.map((marker) => marker.age)).toEqual([0, 1, 2]);
+  });
+
+  test("places GitHub and Notion publish events in San Francisco", () => {
+    const markers = activityRecentGlobeMarkers(
+      [
+        { id: "pr", type: "pr_merged", source: "github" },
+        { id: "stack", type: "stack_added", source: "brios" },
+        { id: "tokyo", meta: { latitude: 35.68, longitude: 139.69 } },
+      ],
+      5,
+    );
+    expect(markers).toHaveLength(2);
+    expect(markers[0]?.location).toEqual([37.77, -122.42]);
+    expect(markers[0]?.eventId).toBe("pr");
+    expect(markers[1]?.location).toEqual([35.68, 139.69]);
   });
 });

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -58,14 +58,35 @@ export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: 
 
 /** Same mesh radius as cobe@2 (`GLOBE_R`). */
 export const GLOBE_MESH_RADIUS = 0.8;
-export const GLOBE_MARKER_ELEVATION = 0.03;
+export const GLOBE_MARKER_ELEVATION = 0;
 
 /** Fraction of the mesh that hangs past the right and bottom edges. */
 export const GLOBE_HANG = 0.4;
 /** Floor so a short pane cannot collapse the sphere back to a marble. */
-export const GLOBE_MESH_MIN = 640;
-/** Mesh is ~90% of pane/window height. No max cap. */
-export const GLOBE_MESH_HEIGHT_RATIO = 0.9;
+export const GLOBE_MESH_MIN = 512;
+/** Mesh is ~72% of pane/window height. No max cap. */
+export const GLOBE_MESH_HEIGHT_RATIO = 0.72;
+
+/**
+ * Phi/theta delta that slides the camera-facing point into the visible
+ * (unclipped) top-left of the mesh. The canvas hangs past the right and
+ * bottom by `GLOBE_HANG`, so the true apex sits low-right of what you see.
+ */
+export function globeAimVisibleBias(hang = GLOBE_HANG): { dPhi: number; dTheta: number } {
+  const visibleEdge = 1 - hang;
+  const discMin = (1 - GLOBE_MESH_RADIUS) / 2;
+  const visibleMid = (discMin + visibleEdge) / 2;
+  const uvOffset = 0.5 - visibleMid;
+  const angle = Math.asin(Math.min(0.95, (uvOffset * 2) / GLOBE_MESH_RADIUS));
+  return { dPhi: -angle, dTheta: -angle };
+}
+
+/** Aim pose that reads as centered in the visible globe, not the full mesh. */
+export function latLngToVisibleGlobePose(lat: number, lng: number): GlobePose {
+  const pose = latLngToGlobePose(lat, lng);
+  const { dPhi, dTheta } = globeAimVisibleBias();
+  return { phi: pose.phi + dPhi, theta: pose.theta + dTheta };
+}
 
 /** Project a lat/lng onto the COBE canvas, matching v2 marker anchors. */
 export function projectGlobeMarker(
@@ -89,8 +110,22 @@ export function projectGlobeMarker(
   };
 }
 
-/** Canvas diameter ≈ 0.9 × pane/window height, clipped off the bottom-right. */
+/** Canvas diameter ≈ 0.72 × pane/window height, clipped off the bottom-right. */
 export function globeDiameterFromHeight(height: number): number {
   if (!Number.isFinite(height) || height <= 0) return GLOBE_MESH_MIN;
   return Math.round(Math.max(GLOBE_MESH_MIN, height * GLOBE_MESH_HEIGHT_RATIO));
+}
+
+/**
+ * Keep marker ids so COBE creates `--cobe-{id}` anchors and `--cobe-visible-{id}`,
+ * but hide the WebGL discs — those do not fade. The CSS dots do.
+ */
+export function bindableGlobeMarkers(
+  markers: ReadonlyArray<{ id: string; location: [number, number]; size?: number }>,
+): Array<{ id: string; location: [number, number]; size: number }> {
+  return markers.map((marker) => ({
+    id: marker.id,
+    location: marker.location,
+    size: 0,
+  }));
 }

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -59,6 +59,11 @@ export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: 
 /** Same mesh radius as cobe@2 (`GLOBE_R`). */
 export const GLOBE_MESH_RADIUS = 0.8;
 export const GLOBE_MARKER_ELEVATION = 0;
+/**
+ * COBE land-dot radius in unit-sphere chord length.
+ * Fragment shader: `smoothstep(8e-3, 0., distanceToLattice)`.
+ */
+export const GLOBE_MAP_DOT_CHORD = 0.008;
 
 /** Fraction of the mesh that hangs past the right and bottom edges. */
 export const GLOBE_HANG = 0.4;
@@ -114,6 +119,13 @@ export function projectGlobeMarker(
 export function globeDiameterFromHeight(height: number): number {
   if (!Number.isFinite(height) || height <= 0) return GLOBE_MESH_MIN;
   return Math.round(Math.max(GLOBE_MESH_MIN, height * GLOBE_MESH_HEIGHT_RATIO));
+}
+
+/** CSS px of one COBE country-shape dot at the facing center of the mesh. */
+export function globeMapDotPx(meshSize: number, scale = 1): number {
+  if (!Number.isFinite(meshSize) || meshSize <= 0) return 2;
+  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  return Math.max(2, GLOBE_MAP_DOT_CHORD * GLOBE_MESH_RADIUS * meshSize * safeScale);
 }
 
 /**

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -58,6 +58,26 @@ export function activityVisitClusterReactKey(
   return `visit-cluster:${cluster.locationKey}:${cluster.anchorId}`;
 }
 
+/** Consecutive same-source actions inside a location cluster. */
+export type ActivityVisitSourceRun = {
+  source: string;
+  actions: ActivityRollup[];
+};
+
+export function visitClusterSourceRuns(actions: ActivityRollup[]): ActivityVisitSourceRun[] {
+  const runs: ActivityVisitSourceRun[] = [];
+  for (const action of actions) {
+    const source = action.latest.source;
+    const current = runs[runs.length - 1];
+    if (current && current.source === source) {
+      current.actions.push(action);
+      continue;
+    }
+    runs.push({ source, actions: [action] });
+  }
+  return runs;
+}
+
 export function activityFeedItemReactKey(item: ActivityFeedItem): string {
   return item.type === "visit-cluster"
     ? activityVisitClusterReactKey(item)

--- a/src/lib/activity-rollup.ts
+++ b/src/lib/activity-rollup.ts
@@ -68,8 +68,8 @@ export function activityFeedItemCount(item: ActivityFeedItem): number {
   return item.type === "visit-cluster" ? item.count : item.stack.count;
 }
 
-export const ACTIVITY_ENTER_STAGGER_STEP = 0.15;
-export const ACTIVITY_ENTER_STAGGER_MAX = 1.2;
+export const ACTIVITY_ENTER_STAGGER_STEP = 0.22;
+export const ACTIVITY_ENTER_STAGGER_MAX = 2;
 
 /**
  * Enter delays for keys that were not on screen last paint. First paint (`previous` null) is empty.

--- a/src/lib/activity-sandbox.test.ts
+++ b/src/lib/activity-sandbox.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { activityEventLocation } from "./activity-geo";
-import { clusterVisitLocationRuns, rollupActivityEvents } from "./activity-rollup";
+import {
+  clusterVisitLocationRuns,
+  rollupActivityEvents,
+  visitClusterSourceRuns,
+} from "./activity-rollup";
 import {
   resetSandboxIds,
   SANDBOX_PAGES,
@@ -9,6 +13,9 @@ import {
   SANDBOX_SCENARIOS,
   sandboxLike,
   sandboxMysteriousVisit,
+  sandboxPullMerged,
+  sandboxSiteAdded,
+  sandboxStackAdded,
   sandboxVisit,
   stampBatch,
 } from "./activity-sandbox";
@@ -39,6 +46,12 @@ describe("sandbox fixtures", () => {
     const event = sandboxMysteriousVisit();
     expect(activityEventLocation(event)).toBeUndefined();
     expect(visitLocationClusterKey(event)).toBe("a mysterious place on earth");
+  });
+
+  test("GitHub and Notion publishes pin to San Francisco", () => {
+    expect(activityEventLocation(sandboxPullMerged())).toEqual({ lat: 37.77, lng: -122.42 });
+    expect(activityEventLocation(sandboxStackAdded())).toEqual({ lat: 37.77, lng: -122.42 });
+    expect(activityEventLocation(sandboxSiteAdded())).toEqual({ lat: 37.77, lng: -122.42 });
   });
 
   test("stampBatch is newest-first", () => {
@@ -78,6 +91,19 @@ describe("sandbox scenarios", () => {
       }),
     );
     expect(coords.size).toBe(events.length);
+  });
+
+  test("property hop stays one location cluster with two source runs", () => {
+    const items = clusterVisitLocationRuns(
+      rollupActivityEvents(SANDBOX_SCENARIOS["property-hop"].build()),
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0]?.type).toBe("visit-cluster");
+    if (items[0]?.type !== "visit-cluster") return;
+    expect(visitClusterSourceRuns(items[0].actions).map((run) => run.source)).toEqual([
+      "brios",
+      "staff-design",
+    ]);
   });
 
   test("interrupted cluster splits SF visits around a like", () => {

--- a/src/lib/activity-sandbox.test.ts
+++ b/src/lib/activity-sandbox.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import { activityEventLocation } from "./activity-geo";
+import { clusterVisitLocationRuns, rollupActivityEvents } from "./activity-rollup";
+import {
+  resetSandboxIds,
+  SANDBOX_PAGES,
+  SANDBOX_PLACES,
+  SANDBOX_SCENARIOS,
+  sandboxLike,
+  sandboxMysteriousVisit,
+  sandboxVisit,
+  stampBatch,
+} from "./activity-sandbox";
+import { isActivitySandboxPath, visitLocationClusterKey } from "./activity-shared";
+
+describe("isActivitySandboxPath", () => {
+  test("matches the sandbox route only", () => {
+    expect(isActivitySandboxPath("/activity/sandbox")).toBe(true);
+    expect(isActivitySandboxPath("/activity/sandbox/")).toBe(true);
+    expect(isActivitySandboxPath("/activity")).toBe(false);
+    expect(isActivitySandboxPath("/activity/nested")).toBe(false);
+  });
+});
+
+describe("sandbox fixtures", () => {
+  test("visits include geo meta so the globe can place a dot", () => {
+    resetSandboxIds();
+    const event = sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.writing);
+    expect(event.type).toBe("visit");
+    expect(event.meta?.city).toBe("San Francisco");
+    expect(event.meta?.latitude).toBe(37.77);
+    expect(event.meta?.longitude).toBe(-122.42);
+    expect(activityEventLocation(event)).toEqual({ lat: 37.77, lng: -122.42 });
+    expect(visitLocationClusterKey(event)).toBe("san francisco, california");
+  });
+
+  test("mysterious visits have no globe location", () => {
+    const event = sandboxMysteriousVisit();
+    expect(activityEventLocation(event)).toBeUndefined();
+    expect(visitLocationClusterKey(event)).toBe("a mysterious place on earth");
+  });
+
+  test("stampBatch is newest-first", () => {
+    const events = stampBatch([
+      sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.ama),
+      sandboxVisit(SANDBOX_PLACES.london, SANDBOX_PAGES.home),
+    ]);
+    expect(Date.parse(events[0]!.ts)).toBeGreaterThan(Date.parse(events[1]!.ts));
+  });
+});
+
+describe("sandbox scenarios", () => {
+  test("SF cluster rolls into one location block with a rail", () => {
+    const items = clusterVisitLocationRuns(
+      rollupActivityEvents(SANDBOX_SCENARIOS["sf-cluster"].build()),
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0]?.type).toBe("visit-cluster");
+    if (items[0]?.type === "visit-cluster") {
+      expect(items[0].actions.length).toBeGreaterThan(1);
+      expect(items[0].locationHeader).toContain("San Francisco");
+    }
+  });
+
+  test("same-page visits stack into one ×N row", () => {
+    const stacks = rollupActivityEvents(SANDBOX_SCENARIOS["same-page-rollup"].build());
+    expect(stacks).toHaveLength(1);
+    expect(stacks[0]?.count).toBe(4);
+  });
+
+  test("globe burst covers many distinct coordinates", () => {
+    const events = SANDBOX_SCENARIOS["globe-burst"].build();
+    const coords = new Set(
+      events.map((event) => {
+        const location = activityEventLocation(event);
+        return location ? `${location.lat},${location.lng}` : "";
+      }),
+    );
+    expect(coords.size).toBe(events.length);
+  });
+
+  test("interrupted cluster splits SF visits around a like", () => {
+    const items = clusterVisitLocationRuns(
+      rollupActivityEvents(SANDBOX_SCENARIOS.interrupt.build()),
+    );
+    expect(items.map((item) => item.type)).toEqual(["visit-cluster", "row", "visit-cluster"]);
+  });
+
+  test("likes stack together", () => {
+    const stacks = rollupActivityEvents([
+      sandboxLike("Cursor", "/stack"),
+      sandboxLike("Listening", "/listening"),
+    ]);
+    expect(stacks).toHaveLength(1);
+    expect(stacks[0]?.likeTargets?.map((target) => target.title)).toEqual(["Cursor", "Listening"]);
+  });
+});

--- a/src/lib/activity-sandbox.ts
+++ b/src/lib/activity-sandbox.ts
@@ -88,7 +88,7 @@ export const SANDBOX_PLACES = {
 } as const satisfies Record<string, SandboxPlace>;
 
 export const SANDBOX_PAGES = {
-  home: { path: "/", label: "the site", kind: "home" },
+  home: { path: "/", label: "Home", kind: "home" },
   ama: { path: "/ama", label: "AMA", kind: "page" },
   listening: { path: "/listening", label: "Listening", kind: "page" },
   writing: {
@@ -107,6 +107,12 @@ export const SANDBOX_PAGES = {
   staffInterview: {
     path: "/interviews/rasmus-andersson",
     label: "Rasmus Andersson",
+    kind: "page",
+    source: "staff-design",
+  },
+  staffVivian: {
+    path: "/interviews/vivian-wang",
+    label: "Vivian Wang",
     kind: "page",
     source: "staff-design",
   },
@@ -226,6 +232,26 @@ export function sandboxPullMerged(overrides: Partial<ActivityEvent> = {}): Activ
   });
 }
 
+export function sandboxStackAdded(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return baseEvent({
+    type: "stack_added",
+    summary: "A stack item was added",
+    subject: { kind: "stack", label: "Cursor", href: "/stack" },
+    meta: { title: "Cursor", href: "/stack" },
+    ...overrides,
+  });
+}
+
+export function sandboxSiteAdded(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return baseEvent({
+    type: "site_added",
+    summary: "A good website was added",
+    subject: { kind: "site", label: "cobe.vercel.app", href: "/sites" },
+    meta: { title: "cobe.vercel.app", href: "/sites" },
+    ...overrides,
+  });
+}
+
 export function sandboxCaffeinated(
   drink = "Latte",
   overrides: Partial<ActivityEvent> = {},
@@ -329,6 +355,18 @@ export const SANDBOX_SCENARIOS = {
         sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.home),
       ]),
   },
+  "property-hop": {
+    label: "Property hop",
+    hint: "One location, brianlovin.com then staff.design",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.staffHome),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.staffVivian),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.stack),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.hn),
+      ]),
+  },
   likes: {
     label: "Like stack",
     hint: "Three likes roll into + others",
@@ -372,6 +410,8 @@ export const SANDBOX_SINGLES = [
   { id: "visit-mystery", label: "Mystery visit", build: () => sandboxMysteriousVisit() },
   { id: "like", label: "Like", build: () => sandboxLike("Cursor", "/stack") },
   { id: "pr", label: "PR merged", build: () => sandboxPullMerged() },
+  { id: "stack", label: "New stack", build: () => sandboxStackAdded() },
+  { id: "site", label: "New site", build: () => sandboxSiteAdded() },
   { id: "coffee", label: "Coffee", build: () => sandboxCaffeinated("Latte") },
   { id: "shiori", label: "Shiori save", build: () => sandboxShioriSave() },
 ] as const;

--- a/src/lib/activity-sandbox.ts
+++ b/src/lib/activity-sandbox.ts
@@ -1,0 +1,377 @@
+/**
+ * Fake activity events for the /activity/sandbox page.
+ * Display-only — never written to Redis.
+ */
+
+import { activityGeoToMeta, formatVisitSummary } from "./activity-geo";
+import type { ActivityEvent, ActivityRef } from "./activity-shared";
+import { ACTIVITY_ENVELOPE_VERSION } from "./activity-shared";
+
+export type SandboxPlace = {
+  city?: string;
+  region?: string;
+  regionName?: string;
+  country: string;
+  countryName: string;
+  latitude?: number;
+  longitude?: number;
+};
+
+export type SandboxPage = {
+  path: string;
+  label: string;
+  kind?: string;
+  source?: string;
+};
+
+export const SANDBOX_PLACES = {
+  sf: {
+    city: "San Francisco",
+    region: "CA",
+    regionName: "California",
+    country: "US",
+    countryName: "United States",
+    latitude: 37.77,
+    longitude: -122.42,
+  },
+  london: {
+    city: "London",
+    country: "GB",
+    countryName: "United Kingdom",
+    latitude: 51.51,
+    longitude: -0.13,
+  },
+  tokyo: {
+    city: "Tokyo",
+    country: "JP",
+    countryName: "Japan",
+    latitude: 35.68,
+    longitude: 139.69,
+  },
+  sydney: {
+    city: "Sydney",
+    region: "NSW",
+    regionName: "New South Wales",
+    country: "AU",
+    countryName: "Australia",
+    latitude: -33.87,
+    longitude: 151.21,
+  },
+  berlin: {
+    city: "Berlin",
+    country: "DE",
+    countryName: "Germany",
+    latitude: 52.52,
+    longitude: 13.4,
+  },
+  singapore: {
+    city: "Singapore",
+    country: "SG",
+    countryName: "Singapore",
+    latitude: 1.35,
+    longitude: 103.82,
+  },
+  nairobi: {
+    city: "Nairobi",
+    country: "KE",
+    countryName: "Kenya",
+    latitude: -1.29,
+    longitude: 36.82,
+  },
+  recife: {
+    city: "Recife",
+    country: "BR",
+    countryName: "Brazil",
+    latitude: -8.05,
+    longitude: -34.9,
+  },
+} as const satisfies Record<string, SandboxPlace>;
+
+export const SANDBOX_PAGES = {
+  home: { path: "/", label: "the site", kind: "home" },
+  ama: { path: "/ama", label: "AMA", kind: "page" },
+  listening: { path: "/listening", label: "Listening", kind: "page" },
+  writing: {
+    path: "/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS",
+    label: "How I'm Feeling About AI in August 2026",
+    kind: "writing",
+  },
+  stack: { path: "/stack", label: "Stack", kind: "page" },
+  hn: { path: "/hn", label: "Hacker News", kind: "page" },
+  staffHome: {
+    path: "/",
+    label: "Staff.design",
+    kind: "page",
+    source: "staff-design",
+  },
+  staffInterview: {
+    path: "/interviews/rasmus-andersson",
+    label: "Rasmus Andersson",
+    kind: "page",
+    source: "staff-design",
+  },
+} as const satisfies Record<string, SandboxPage>;
+
+let sandboxSeq = 0;
+
+export function resetSandboxIds(): void {
+  sandboxSeq = 0;
+}
+
+function nextSandboxId(prefix: string): string {
+  sandboxSeq += 1;
+  return `${prefix}-${sandboxSeq}`;
+}
+
+function nowIso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function baseEvent(
+  overrides: Partial<ActivityEvent> & Pick<ActivityEvent, "type" | "summary">,
+): ActivityEvent {
+  const id = overrides.id ?? nextSandboxId(overrides.type);
+  const ts = overrides.ts ?? nowIso();
+  return {
+    v: ACTIVITY_ENVELOPE_VERSION,
+    id,
+    ts,
+    received_at: overrides.received_at ?? ts,
+    source: "brios",
+    speed: overrides.type === "visit" ? "signal" : "event",
+    visibility: "public",
+    idempotency_key: overrides.idempotency_key ?? id,
+    ...overrides,
+  };
+}
+
+export function sandboxVisit(
+  place: SandboxPlace,
+  page: SandboxPage = SANDBOX_PAGES.home,
+  overrides: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  const source = page.source ?? "brios";
+  const summary = formatVisitSummary({
+    country: place.country,
+    countryName: place.countryName,
+    region: place.region,
+    regionName: place.regionName,
+    city: place.city,
+  });
+  const subject: ActivityRef = {
+    kind: page.kind ?? "page",
+    label: page.label,
+    href: page.path,
+  };
+
+  return baseEvent({
+    type: "visit",
+    source,
+    summary,
+    subject,
+    meta: {
+      ...activityGeoToMeta(place),
+      path: page.path,
+      title: page.label,
+    },
+    ...overrides,
+  });
+}
+
+export function sandboxMysteriousVisit(
+  page: SandboxPage = SANDBOX_PAGES.home,
+  overrides: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  return baseEvent({
+    type: "visit",
+    summary: "Visit",
+    subject: { kind: page.kind ?? "page", label: page.label, href: page.path },
+    meta: { path: page.path, title: page.label },
+    ...overrides,
+  });
+}
+
+export function sandboxLike(
+  title: string,
+  href: string,
+  overrides: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  return baseEvent({
+    type: "like",
+    summary: `Someone liked ${title}`,
+    subject: { kind: "page", label: title, href },
+    meta: { title, href },
+    ...overrides,
+  });
+}
+
+export function sandboxPullMerged(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return baseEvent({
+    type: "pr_merged",
+    source: "github",
+    summary: "Merged a pull request on brios",
+    subject: {
+      kind: "pull_request",
+      label: "Scale down the activity globe",
+      href: "https://github.com/brianlovin/brios/pull/412",
+    },
+    meta: {
+      repo: "brios",
+      number: 412,
+      href: "https://github.com/brianlovin/brios/pull/412",
+      additions: 48,
+      deletions: 12,
+    },
+    ...overrides,
+  });
+}
+
+export function sandboxCaffeinated(
+  drink = "Latte",
+  overrides: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  return baseEvent({
+    type: "caffeinated",
+    summary: `Drank a ${drink.toLowerCase()}`,
+    subject: { kind: "drink", label: drink },
+    meta: { drink },
+    ...overrides,
+  });
+}
+
+export function sandboxShioriSave(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return baseEvent({
+    type: "link_saved",
+    source: "shiori",
+    summary: "Someone saved a link on Shiori",
+    ...overrides,
+  });
+}
+
+/** Newest-first, with slightly older timestamps further down the list. */
+export function stampBatch(events: ActivityEvent[]): ActivityEvent[] {
+  const newest = Date.now();
+  return events.map((event, index) => {
+    const ts = new Date(newest - index * 1000).toISOString();
+    return { ...event, ts, received_at: ts };
+  });
+}
+
+export const SANDBOX_SCENARIOS = {
+  "batch-fetch": {
+    label: "Batch fetch",
+    hint: "Several new rows stagger in",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.writing),
+        sandboxLike("Cursor", "/stack"),
+        sandboxVisit(SANDBOX_PLACES.london, SANDBOX_PAGES.ama),
+        sandboxCaffeinated("Flat white"),
+        sandboxVisit(SANDBOX_PLACES.tokyo, SANDBOX_PAGES.listening),
+        sandboxPullMerged(),
+      ]),
+  },
+  "sf-cluster": {
+    label: "SF cluster",
+    hint: "Same location, different pages — rail",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.staffInterview),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.staffHome),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.writing),
+      ]),
+  },
+  "same-page-rollup": {
+    label: "Same-page ×N",
+    hint: "Four AMA visits from SF stack",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.ama),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.ama),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.ama),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.ama),
+      ]),
+  },
+  "globe-burst": {
+    label: "Globe burst",
+    hint: "New dots in many cities",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.london, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.tokyo, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.sydney, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.berlin, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.singapore, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.nairobi, SANDBOX_PAGES.home),
+        sandboxVisit(SANDBOX_PLACES.recife, SANDBOX_PAGES.home),
+      ]),
+  },
+  "location-hop": {
+    label: "Location hop",
+    hint: "SF → London → Tokyo clusters",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxVisit(SANDBOX_PLACES.tokyo, SANDBOX_PAGES.hn),
+        sandboxVisit(SANDBOX_PLACES.london, SANDBOX_PAGES.listening),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.ama),
+      ]),
+  },
+  interrupt: {
+    label: "Interrupted cluster",
+    hint: "SF visits split by a like",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.stack),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.listening),
+        sandboxLike("How I'm Feeling About AI in August 2026", SANDBOX_PAGES.writing.path),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.ama),
+        sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.home),
+      ]),
+  },
+  likes: {
+    label: "Like stack",
+    hint: "Three likes roll into + others",
+    build: (): ActivityEvent[] =>
+      stampBatch([
+        sandboxLike("Cursor", "/stack"),
+        sandboxLike("Listening", "/listening"),
+        sandboxLike("AMA", "/ama"),
+      ]),
+  },
+  "shiori-burst": {
+    label: "Shiori ×N",
+    hint: "Consecutive saves stack",
+    build: (): ActivityEvent[] => stampBatch(Array.from({ length: 8 }, () => sandboxShioriSave())),
+  },
+  "grow-cluster": {
+    label: "Grow cluster",
+    hint: "Another SF visit — pulse, no enter",
+    build: (): ActivityEvent[] => [sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.hn)],
+  },
+} as const;
+
+export type SandboxScenarioId = keyof typeof SANDBOX_SCENARIOS;
+
+export const SANDBOX_SINGLES = [
+  {
+    id: "visit-sf",
+    label: "SF visit",
+    build: () => sandboxVisit(SANDBOX_PLACES.sf, SANDBOX_PAGES.writing),
+  },
+  {
+    id: "visit-london",
+    label: "London visit",
+    build: () => sandboxVisit(SANDBOX_PLACES.london, SANDBOX_PAGES.ama),
+  },
+  {
+    id: "visit-tokyo",
+    label: "Tokyo visit",
+    build: () => sandboxVisit(SANDBOX_PLACES.tokyo, SANDBOX_PAGES.listening),
+  },
+  { id: "visit-mystery", label: "Mystery visit", build: () => sandboxMysteriousVisit() },
+  { id: "like", label: "Like", build: () => sandboxLike("Cursor", "/stack") },
+  { id: "pr", label: "PR merged", build: () => sandboxPullMerged() },
+  { id: "coffee", label: "Coffee", build: () => sandboxCaffeinated("Latte") },
+  { id: "shiori", label: "Shiori save", build: () => sandboxShioriSave() },
+] as const;

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -254,6 +254,11 @@ export function isActivityPath(pathname: string): boolean {
   return ACTIVITY_PATH.test(path);
 }
 
+export function isActivitySandboxPath(pathname: string): boolean {
+  const path = pathname.split("?")[0] ?? pathname;
+  return path === "/activity/sandbox" || path.startsWith("/activity/sandbox/");
+}
+
 const CRAWLER_PROBE_PATHS = new Set(["/robots.txt", "/sitemap.xml", "/favicon.ico"]);
 const VISIT_ASSET_EXTENSION_RE =
   /\.(?:png|svg|ico|jpg|jpeg|webp|gif|txt|xml|json|map|css|js|woff2?)$/i;

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -973,9 +973,9 @@ function publicPullRequestRepo(event: ActivityEvent): string | undefined {
 }
 
 /** Linked fallback when a visit has no real page title. Never “Home”. */
-export const SITE_VISIT_LABEL = "the site";
+export const SITE_VISIT_LABEL = "brianlovin.com";
 
-/** staff.design home visits use the product name, not “the site”. */
+/** staff.design home visits use the product name, not “brianlovin.com”. */
 export const STAFF_DESIGN_HOME_VISIT_LABEL = "Staff.design";
 
 const ACTIVITY_HOME_VISIT_LABELS: Record<string, string> = {
@@ -1056,7 +1056,7 @@ function locationFromVisitText(text: string): string | undefined {
   if (someoneVisited?.[1]) return someoneVisited[1].trim();
 
   const someoneFromVerb = new RegExp(
-    `^Someone from\\s+(.+?)\\s+${VISIT_SENTENCE_VERB_RE}(?:\\s+the site)?$`,
+    `^Someone from\\s+(.+?)\\s+${VISIT_SENTENCE_VERB_RE}(?:\\s+(?:the site|brianlovin\\.com))?$`,
     "i",
   ).exec(trimmed);
   if (someoneFromVerb?.[1]) return someoneFromVerb[1].trim();

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -3272,19 +3272,20 @@ describe("rollupActivityEvents", () => {
       previous,
     );
     expect([...delays.entries()]).toEqual([
-      ["new-1", 0.6],
-      ["new-2", 0.45],
-      ["new-3", 0.3],
-      ["new-4", 0.15],
+      ["new-1", 0.88],
+      ["new-2", 0.66],
+      ["new-3", 0.44],
+      ["new-4", 0.22],
       ["new-5", 0],
     ]);
 
     const many = Array.from({ length: 16 }, (_, index) => `n-${index}`);
     const capped = activityEnterStaggerDelays(many, new Set());
     expect(capped.get("n-15")).toBe(0);
-    expect(capped.get("n-8")).toBe(1.05);
-    expect(capped.get("n-7")).toBe(1.2);
-    expect(capped.get("n-0")).toBe(1.2);
+    expect(capped.get("n-8")).toBe(1.54);
+    expect(capped.get("n-6")).toBe(1.98);
+    expect(capped.get("n-5")).toBe(2);
+    expect(capped.get("n-0")).toBe(2);
     expect(capped.has("old-1")).toBe(false);
   });
 
@@ -3309,8 +3310,8 @@ describe("rollupActivityEvents", () => {
     const previous = new Set(["old-1"]);
     const next = nextActivityEnterState(["newest", "middle", "oldest-new", "old-1"], previous);
     expect(next.delays.get("oldest-new")).toBe(0);
-    expect(next.delays.get("middle")).toBe(0.15);
-    expect(next.delays.get("newest")).toBe(0.3);
+    expect(next.delays.get("middle")).toBe(0.22);
+    expect(next.delays.get("newest")).toBe(0.44);
     expect(next.delays.has("old-1")).toBe(false);
   });
 

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -3720,12 +3720,7 @@ describe("rollupActivityEvents", () => {
   });
 
   test("groups a location cluster into consecutive property runs", () => {
-    const visit = (
-      id: string,
-      source: string,
-      href: string,
-      label: string,
-    ): ActivityEvent =>
+    const visit = (id: string, source: string, href: string, label: string): ActivityEvent =>
       feedEvent({
         id,
         source,

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -51,6 +51,7 @@ import {
   shouldRecordVisit,
   stripSiteTitleSuffix,
   stripTrailingShortIdToken,
+  visitClusterSourceRuns,
   visitLocationPhrase,
 } from "@/lib/activity";
 import * as activityCms from "@/lib/activity-cms";
@@ -805,7 +806,7 @@ describe("recordVisit", () => {
     expect(row).toEqual({
       summary: "Someone from a mysterious place on earth visited",
       href: "/",
-      label: "the site",
+      label: "brianlovin.com",
     });
   });
 
@@ -851,7 +852,7 @@ describe("recordVisit", () => {
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "Someone from India visited the site",
+      summary: "Someone from India visited brianlovin.com",
     });
     expect(row.summary).not.toMatch(/\p{Regional_Indicator}/u);
   });
@@ -871,7 +872,7 @@ describe("recordVisit", () => {
       meta: { country: "IN" },
     });
     expect(row).toEqual({
-      summary: "Someone from India visited the site",
+      summary: "Someone from India visited brianlovin.com",
     });
   });
 
@@ -1414,6 +1415,33 @@ describe("countryCentroid", () => {
 
     expect(activityEventLocation({ meta: {} })).toBeUndefined();
   });
+
+  test("activityEventLocation pins GitHub and Notion publishes to San Francisco", () => {
+    expect(activityEventLocation({ source: "github", type: "pr_merged" })).toEqual({
+      lat: 37.77,
+      lng: -122.42,
+    });
+    expect(activityEventLocation({ source: "github", type: "repo_starred" })).toEqual({
+      lat: 37.77,
+      lng: -122.42,
+    });
+    expect(activityEventLocation({ type: "pr_opened" })).toEqual({ lat: 37.77, lng: -122.42 });
+    expect(activityEventLocation({ type: "stack_added" })).toEqual({ lat: 37.77, lng: -122.42 });
+    expect(activityEventLocation({ type: "site_added" })).toEqual({ lat: 37.77, lng: -122.42 });
+    expect(activityEventLocation({ type: "writing_published" })).toEqual({
+      lat: 37.77,
+      lng: -122.42,
+    });
+    expect(activityEventLocation({ type: "til_published" })).toEqual({ lat: 37.77, lng: -122.42 });
+    expect(activityEventLocation({ type: "like" })).toBeUndefined();
+    expect(
+      activityEventLocation({
+        source: "github",
+        type: "pr_merged",
+        meta: { latitude: 35.68, longitude: 139.69 },
+      }),
+    ).toEqual({ lat: 37.77, lng: -122.42 });
+  });
 });
 
 describe("getRequestCountry", () => {
@@ -1719,7 +1747,7 @@ describe("getActivityRow page titles", () => {
       subject: { kind: "home", label: "a page", href: "/" },
       meta: { path: "/", title: "a page", country: "FR" },
     });
-    expect(row.label).toBe("the site");
+    expect(row.label).toBe("brianlovin.com");
     expect(row.href).toBe("/");
     expect(row.summary).toBe("Someone from France visited");
     expect(row.summary).not.toContain("Visit from");
@@ -2032,7 +2060,7 @@ describe("getActivityRow visit sentences", () => {
     expect(home.summary).toContain("visited");
     expect(home.summary).not.toContain("read Home");
     expect(home.summary).not.toContain("Visit from");
-    expect(home.label).toBe("the site");
+    expect(home.label).toBe("brianlovin.com");
     expect(home.label).not.toBe("Home");
   });
 
@@ -2170,13 +2198,13 @@ describe("getActivityRow visit sentences", () => {
     );
     expect(home.summary).toBe("Someone from United States visited");
     expect(home.summary).not.toContain("read");
-    expect(home.summary).not.toContain("the site");
+    expect(home.summary).not.toContain("brianlovin.com");
     expect(home.label).toBe("Staff.design");
-    expect(home.label).not.toBe("the site");
+    expect(home.label).not.toBe("brianlovin.com");
     expect(home.href).toBe("https://staff.design");
   });
 
-  test("uses Staff.design — not the site — for an untitled staff.design home visit", () => {
+  test("uses Staff.design — not brianlovin.com — for an untitled staff.design home visit", () => {
     const singapore = {
       country: "SG",
       country_name: "Singapore",
@@ -2193,9 +2221,9 @@ describe("getActivityRow visit sentences", () => {
       ),
     );
     expect(`${home.summary} ${home.label}`).toContain("visited Staff.design");
-    expect(home.summary).not.toContain("the site");
+    expect(home.summary).not.toContain("brianlovin.com");
     expect(home.label).toBe("Staff.design");
-    expect(home.label).not.toBe("the site");
+    expect(home.label).not.toBe("brianlovin.com");
 
     const untitled = getActivityRow({
       v: 1,
@@ -2211,7 +2239,7 @@ describe("getActivityRow visit sentences", () => {
       meta: singapore,
     });
     expect(`${untitled.summary} ${untitled.label}`).toContain("visited Staff.design");
-    expect(untitled.summary).not.toContain("the site");
+    expect(untitled.summary).not.toContain("brianlovin.com");
     expect(untitled.label).toBe("Staff.design");
 
     const interview = getActivityRow(
@@ -2235,9 +2263,9 @@ describe("getActivityRow visit sentences", () => {
         { meta: { country: "SG", country_name: "Singapore", city: "Singapore", path: "/" } },
       ),
     );
-    expect(briosHome.label).toBe("the site");
+    expect(briosHome.label).toBe("brianlovin.com");
     expect(briosHome.label).not.toBe("Staff.design");
-    expect(`${briosHome.summary} ${briosHome.label}`).toContain("visited the site");
+    expect(`${briosHome.summary} ${briosHome.label}`).toContain("visited brianlovin.com");
 
     const shioriHome = getActivityRow({
       v: 1,
@@ -2359,7 +2387,7 @@ describe("formatVisitRowSummary location prefix", () => {
     ).toBe("viewed");
     expect(
       formatVisitRowSummary("San Francisco, California", "visited", false, { omitLocation: true }),
-    ).toBe("visited the site");
+    ).toBe("visited brianlovin.com");
     expect(
       formatVisitRowSummary("Singapore, Singapore", "visited", false, {
         source: "staff-design",
@@ -2376,7 +2404,7 @@ describe("formatVisitRowSummary location prefix", () => {
         omitLocation: true,
         source: "brios",
       }),
-    ).toBe("visited the site");
+    ).toBe("visited brianlovin.com");
   });
 });
 
@@ -3458,7 +3486,7 @@ describe("rollupActivityEvents", () => {
       getActivityRow(action.latest, { omitVisitLocation: true }),
     );
     expect(actions[0]?.summary).toBe("visited");
-    expect(actions[0]?.label).toBe("the site");
+    expect(actions[0]?.label).toBe("brianlovin.com");
     expect(actions[1]?.summary).toBe("viewed");
     expect(actions[1]?.label).toBe("AMA");
     expect(actions[2]?.summary).toBe("viewed");
@@ -3500,8 +3528,8 @@ describe("rollupActivityEvents", () => {
     expect(home?.sectionLabel).toBe("Staff.design");
     const homeRow = getActivityRow(home!.latest, { omitVisitLocation: true });
     expect(`${homeRow.summary} ${homeRow.label}`).toBe("visited Staff.design");
-    expect(homeRow.summary).not.toContain("the site");
-    expect(homeRow.label).not.toBe("the site");
+    expect(homeRow.summary).not.toContain("brianlovin.com");
+    expect(homeRow.label).not.toBe("brianlovin.com");
 
     const interview = items[0].actions.find((action) => action.latest.id === "sg-interview");
     expect(interview?.sectionLabel).toBe("Karla Mickens Cole");
@@ -3689,6 +3717,51 @@ describe("rollupActivityEvents", () => {
     expect(items[2].locationHeader).toContain("Someone from San Francisco");
     expect(items[0].actions).toHaveLength(1);
     expect(items[2].actions).toHaveLength(1);
+  });
+
+  test("groups a location cluster into consecutive property runs", () => {
+    const visit = (
+      id: string,
+      source: string,
+      href: string,
+      label: string,
+    ): ActivityEvent =>
+      feedEvent({
+        id,
+        source,
+        type: "visit",
+        summary: "Visit from San Francisco, California, United States",
+        subject: { kind: href === "/" ? "home" : "page", label, href },
+        meta: {
+          country: "US",
+          country_name: "United States",
+          region: "CA",
+          region_name: "California",
+          city: "San Francisco",
+          path: href,
+          title: label,
+        },
+      });
+
+    const items = clusterVisitLocationRuns(
+      rollupActivityEvents([
+        visit("staff-home", "staff-design", "/", "Home"),
+        visit("staff-vivian", "staff-design", "/interviews/vivian-wang", "Vivian Wang"),
+        visit("brios-stack", "brios", "/stack", "Stack"),
+        visit("brios-home", "brios", "/", "Home"),
+      ]),
+    );
+
+    expect(items).toHaveLength(1);
+    if (items[0]?.type !== "visit-cluster") return;
+    expect(items[0].actions).toHaveLength(4);
+    expect(visitClusterSourceRuns(items[0].actions).map((run) => run.source)).toEqual([
+      "brios",
+      "staff-design",
+    ]);
+    expect(visitClusterSourceRuns(items[0].actions).map((run) => run.actions.length)).toEqual([
+      2, 2,
+    ]);
   });
 
   test("only pulses when the same run's count increments", () => {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -68,6 +68,7 @@ export type {
   ActivityLikeTarget,
   ActivityRollup,
   ActivityVisitCluster,
+  ActivityVisitSourceRun,
 } from "./activity-rollup";
 export {
   ACTIVITY_ENTER_STAGGER_MAX,
@@ -83,6 +84,7 @@ export {
   nextActivityEnterState,
   rollupActivityEvents,
   shouldPulseActivityRollup,
+  visitClusterSourceRuns,
 } from "./activity-rollup";
 export type {
   ActivityEvent,

--- a/src/lib/dial-slider.test.ts
+++ b/src/lib/dial-slider.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  clamp,
+  decimalsForStep,
+  formatDialValue,
+  hashMarkPercents,
+  percentFromValue,
+  roundValue,
+  snapClickValue,
+  snapToDecile,
+} from "./dial-slider";
+
+describe("dial-slider", () => {
+  test("decimalsForStep counts digits after the decimal", () => {
+    expect(decimalsForStep(1)).toBe(0);
+    expect(decimalsForStep(500)).toBe(0);
+    expect(decimalsForStep(0.01)).toBe(2);
+    expect(decimalsForStep(0.005)).toBe(3);
+  });
+
+  test("roundValue snaps to the step without float residue", () => {
+    expect(roundValue(1.234, 0.01)).toBe(1.23);
+    expect(roundValue(16012, 500)).toBe(16000);
+    expect(roundValue(0.127, 0.005)).toBe(0.125);
+  });
+
+  test("snapToDecile only snaps when close to a 10% tick", () => {
+    expect(snapToDecile(0.51, 0, 1)).toBe(0.5);
+    expect(snapToDecile(0.2, 0, 1)).toBe(0.2);
+    expect(snapToDecile(0.44, 0, 1)).toBe(0.44);
+  });
+
+  test("snapClickValue uses steps when the range is coarse", () => {
+    expect(snapClickValue(7.2, 0, 10, 1)).toBe(7);
+    expect(snapClickValue(0.62, 0, 1, 0.01)).toBe(0.6);
+  });
+
+  test("formatDialValue matches the step precision", () => {
+    expect(formatDialValue(1, 0.01)).toBe("1.00");
+    expect(formatDialValue(16000, 500)).toBe("16000");
+  });
+
+  test("percentFromValue and clamp stay in range", () => {
+    expect(percentFromValue(25, 0, 100)).toBe(25);
+    expect(percentFromValue(10, 10, 10)).toBe(0);
+    expect(clamp(-2, 0, 1)).toBe(0);
+    expect(clamp(4, 0, 1)).toBe(1);
+  });
+
+  test("hashMarkPercents uses steps for coarse ranges and deciles otherwise", () => {
+    expect(hashMarkPercents(0, 4, 1)).toEqual([25, 50, 75]);
+    expect(hashMarkPercents(0, 1, 0.01)).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90]);
+  });
+});

--- a/src/lib/dial-slider.ts
+++ b/src/lib/dial-slider.ts
@@ -1,0 +1,60 @@
+/** Math helpers for DialKit-style sliders. */
+
+export function decimalsForStep(step: number): number {
+  const text = step.toString();
+  const dot = text.indexOf(".");
+  return dot === -1 ? 0 : text.length - dot - 1;
+}
+
+export function roundValue(value: number, step: number): number {
+  if (step <= 0) return value;
+  const rounded = Math.round(value / step) * step;
+  return parseFloat(rounded.toFixed(decimalsForStep(step)));
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function percentFromValue(value: number, min: number, max: number): number {
+  if (max === min) return 0;
+  return ((value - min) / (max - min)) * 100;
+}
+
+/** Snap to the nearest 10% tick when the pointer is close enough. */
+export function snapToDecile(rawValue: number, min: number, max: number): number {
+  const range = max - min;
+  if (range === 0) return min;
+  const normalized = (rawValue - min) / range;
+  const nearest = Math.round(normalized * 10) / 10;
+  if (Math.abs(normalized - nearest) <= 0.03125) {
+    return min + nearest * range;
+  }
+  return rawValue;
+}
+
+/** Click-to-snap: coarse ranges snap to steps; finer ranges snap to nearby deciles. */
+export function snapClickValue(rawValue: number, min: number, max: number, step: number): number {
+  if (step <= 0 || max === min) return clamp(rawValue, min, max);
+  const discreteSteps = (max - min) / step;
+  if (discreteSteps <= 10) {
+    return clamp(min + Math.round((rawValue - min) / step) * step, min, max);
+  }
+  return snapToDecile(rawValue, min, max);
+}
+
+export function formatDialValue(value: number, step: number): string {
+  return value.toFixed(decimalsForStep(step));
+}
+
+export function hashMarkPercents(min: number, max: number, step: number): number[] {
+  const range = max - min;
+  if (range <= 0 || step <= 0) return [];
+  const discreteSteps = range / step;
+  if (discreteSteps <= 10) {
+    return Array.from({ length: Math.max(0, Math.round(discreteSteps) - 1) }, (_, index) => {
+      return (((index + 1) * step) / range) * 100;
+    });
+  }
+  return [10, 20, 30, 40, 50, 60, 70, 80, 90];
+}

--- a/src/lib/hooks/useActivity.ts
+++ b/src/lib/hooks/useActivity.ts
@@ -20,16 +20,21 @@ function getServerVisibilitySnapshot(): DocumentVisibilityState {
   return "visible";
 }
 
-export function useActivity(initialEvents: ActivityEvent[], initialCount: number) {
+export function useActivity(
+  initialEvents: ActivityEvent[],
+  initialCount: number,
+  options?: { enabled?: boolean },
+) {
+  const enabled = options?.enabled ?? true;
   const visibilityState = useSyncExternalStore(
     subscribeVisibility,
     getVisibilitySnapshot,
     getServerVisibilitySnapshot,
   );
 
-  const { data } = useSWR<ActivityFeedPayload>("/api/activity/feed", fetcher, {
+  const { data } = useSWR<ActivityFeedPayload>(enabled ? "/api/activity/feed" : null, fetcher, {
     fallbackData: { events: initialEvents, count: initialCount },
-    refreshInterval: activityFeedRefreshInterval(visibilityState),
+    refreshInterval: enabled ? activityFeedRefreshInterval(visibilityState) : 0,
     revalidateOnFocus: false,
     dedupingInterval: ACTIVITY_FEED_DEDUPING_MS,
   });


### PR DESCRIPTION
## Summary
- Fade globe events with COBE's bindable CSS markers (`--cobe-visible-*` opacity + blur) instead of shrinking WebGL discs, and aim row clicks into the unclipped part of the mesh.
- Slow the feed enter stagger and draw the visit-cluster rail as a CSS L-border so actions don't squash on the way in.
- Add a production-gated `/activity/sandbox` for injecting fake events and tuning globe params without writing to Redis.

## Test plan
- [ ] `/activity` on a wide pane: globe hangs off the bottom-right, dots blur/fade in as they rotate into view
- [ ] Click a geo row: globe aims that city into the visible top-left and the matching dot pulses
- [ ] Same-location visit run still shows the L-rail, elbow lined up with the last action
- [ ] New events stagger in without squashing text
- [ ] `/activity/sandbox` (dev only): inject Globe burst / SF cluster, tune fade sliders; production should 404
- [ ] Top bar shows **Sandbox** on the sandbox route and **Live** on `/activity`


Made with [Cursor](https://cursor.com)