### PR TITLE
Add Hacker News to the cache-purge webhook

### DIFF
--- a/src/app/api/purge-cache/route.test.ts
+++ b/src/app/api/purge-cache/route.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+import { GET, POST } from "@/app/api/purge-cache/route";
+import * as activityFromNotion from "@/lib/activity-from-notion";
+import * as activitySchedule from "@/lib/activity-schedule";
+import * as purge from "@/lib/notion/purge";
+
+const TEST_SECRET = "unit-test-purge-secret";
+
+function purgeRequest(method: "GET" | "POST", type: string, body?: unknown): Request {
+  const url = `http://localhost/api/purge-cache?secret=${TEST_SECRET}&type=${type}`;
+  return new Request(url, {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("/api/purge-cache", () => {
+  const previousSecret = process.env.CACHE_PURGE_SECRET;
+
+  beforeEach(() => {
+    process.env.CACHE_PURGE_SECRET = TEST_SECRET;
+  });
+
+  afterEach(() => {
+    if (previousSecret === undefined) {
+      delete process.env.CACHE_PURGE_SECRET;
+    } else {
+      process.env.CACHE_PURGE_SECRET = previousSecret;
+    }
+  });
+
+  test("GET accepts type=hn", async () => {
+    const purgeType = spyOn(purge, "purgeContentType").mockResolvedValue(3);
+
+    const res = await GET(purgeRequest("GET", "hn"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      type: "hn",
+      purged: { hn: 3 },
+    });
+    expect(purgeType).toHaveBeenCalledTimes(1);
+    expect(purgeType).toHaveBeenCalledWith("hn");
+  });
+
+  test("type=all includes hn", async () => {
+    const purgeType = spyOn(purge, "purgeContentType").mockResolvedValue(1);
+
+    const res = await GET(purgeRequest("GET", "all"));
+    expect(res.status).toBe(200);
+    const types = purgeType.mock.calls.map((call) => call[0]);
+    expect(types).toContain("hn");
+    expect(types).toEqual([...purge.PURGEABLE_CONTENT_TYPES]);
+  });
+
+  test("POST type=hn does not ingest a Notion activity event", async () => {
+    spyOn(purge, "purgeContentType").mockResolvedValue(1);
+    const after = spyOn(activitySchedule, "afterActivity");
+    const ingest = spyOn(activityFromNotion, "ingestActivityFromContentPurge");
+
+    const res = await POST(purgeRequest("POST", "hn", { data: { id: "notion-page-id" } }));
+    expect(res.status).toBe(200);
+    expect(after).not.toHaveBeenCalled();
+    expect(ingest).not.toHaveBeenCalled();
+  });
+
+  test("POST type=writing still schedules Notion activity ingest", async () => {
+    spyOn(purge, "purgeContentType").mockResolvedValue(1);
+    const after = spyOn(activitySchedule, "afterActivity");
+
+    const res = await POST(purgeRequest("POST", "writing", { data: { id: "notion-page-id" } }));
+    expect(res.status).toBe(200);
+    expect(after).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/purge-cache/route.test.ts
+++ b/src/app/api/purge-cache/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 import { GET, POST } from "@/app/api/purge-cache/route";
 import * as activityFromNotion from "@/lib/activity-from-notion";
@@ -24,6 +24,7 @@ describe("/api/purge-cache", () => {
   });
 
   afterEach(() => {
+    mock.restore();
     if (previousSecret === undefined) {
       delete process.env.CACHE_PURGE_SECRET;
     } else {
@@ -68,7 +69,7 @@ describe("/api/purge-cache", () => {
 
   test("POST type=writing still schedules Notion activity ingest", async () => {
     spyOn(purge, "purgeContentType").mockResolvedValue(1);
-    const after = spyOn(activitySchedule, "afterActivity");
+    const after = spyOn(activitySchedule, "afterActivity").mockImplementation(() => {});
 
     const res = await POST(purgeRequest("POST", "writing", { data: { id: "notion-page-id" } }));
     expect(res.status).toBe(200);

--- a/src/app/api/purge-cache/route.ts
+++ b/src/app/api/purge-cache/route.ts
@@ -4,6 +4,7 @@ import { ingestActivityFromContentPurge } from "@/lib/activity-from-notion";
 import { afterActivity } from "@/lib/activity-schedule";
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import {
+  type NotionPurgeableContentType,
   PURGE_CACHE_TYPES,
   PURGEABLE_CONTENT_TYPES,
   type PurgeableContentType,
@@ -43,9 +44,9 @@ async function purgeCache(request: Request): Promise<NextResponse> {
     results[t] = await purgeContentType(t);
   }
 
-  if (pageId && type !== "all") {
+  if (pageId && type !== "all" && type !== "hn") {
     afterActivity((store) =>
-      ingestActivityFromContentPurge(type as PurgeableContentType, pageId, store),
+      ingestActivityFromContentPurge(type as NotionPurgeableContentType, pageId, store),
     );
   }
 

--- a/src/lib/activity-from-notion.ts
+++ b/src/lib/activity-from-notion.ts
@@ -10,7 +10,7 @@ import {
 } from "./activity";
 import { notion } from "./notion/client";
 import { richText, select, title, url } from "./notion/properties";
-import { type PurgeableContentType } from "./notion/purge";
+import { type NotionPurgeableContentType } from "./notion/purge";
 import { isFullPage, type PageResponse } from "./notion/types";
 import { buildSlug } from "./short-id";
 
@@ -21,7 +21,7 @@ export function titleFromNotionPage(page: unknown, propertyName = "Name"): strin
 }
 
 export async function ingestActivityFromContentPurge(
-  type: PurgeableContentType,
+  type: NotionPurgeableContentType,
   pageId: string,
   store: ActivityStore,
 ): Promise<void> {

--- a/src/lib/hn-cache.test.ts
+++ b/src/lib/hn-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { clearHnCache, type HnCacheRedis } from "@/lib/hn-cache";
+
+function createFakeHnRedis(init?: { keys?: string[] }): HnCacheRedis & { keys: () => string[] } {
+  const store = new Set(init?.keys ?? []);
+
+  return {
+    keys() {
+      return [...store];
+    },
+    async del(...keys: string[]) {
+      let removed = 0;
+      for (const key of keys) {
+        if (store.delete(key)) removed += 1;
+      }
+      return removed;
+    },
+    async scan(_cursor: string, opts: { match: string; count: number }) {
+      const prefix = opts.match.endsWith("*") ? opts.match.slice(0, -1) : opts.match;
+      const matched = [...store].filter((key) => key.startsWith(prefix));
+      return ["0", matched];
+    },
+  };
+}
+
+describe("clearHnCache", () => {
+  test("returns 0 when Redis is not configured", async () => {
+    await expect(clearHnCache(null)).resolves.toBe(0);
+  });
+
+  test("deletes the top-ids key and every hn:post:* key", async () => {
+    const client = createFakeHnRedis({
+      keys: ["hn:top_ids", "hn:post:1", "hn:post:2", "other:keep"],
+    });
+
+    await expect(clearHnCache(client)).resolves.toBe(3);
+    expect(client.keys().sort()).toEqual(["other:keep"]);
+  });
+
+  test("still deletes scanned post keys when top-ids is already missing", async () => {
+    const client = createFakeHnRedis({
+      keys: ["hn:post:99"],
+    });
+
+    await expect(clearHnCache(client)).resolves.toBe(1);
+    expect(client.keys()).toEqual([]);
+  });
+});

--- a/src/lib/hn-cache.ts
+++ b/src/lib/hn-cache.ts
@@ -131,3 +131,41 @@ export async function setCachedPosts(posts: Map<string, HackerNewsPost>): Promis
     console.error("[HN Cache] Error batch writing to cache:", error);
   }
 }
+
+/** Minimal Redis surface used by `clearHnCache` (HN cache DB only). */
+export type HnCacheRedis = {
+  del: (...keys: string[]) => Promise<number>;
+  scan: (cursor: string, opts: { match: string; count: number }) => Promise<[string, string[]]>;
+};
+
+/**
+ * Delete the top-ids key and every `hn:post:*` entry in the HN Redis DB.
+ * Used by `/api/purge-cache?type=hn` — do not call the Notion cache helper.
+ */
+export async function clearHnCache(client: HnCacheRedis | null = getRedis()): Promise<number> {
+  if (!client) return 0;
+
+  try {
+    let deleted = await client.del(HN_TOP_IDS_KEY);
+
+    let cursor = "0";
+    do {
+      const result: [string, string[]] = await client.scan(cursor, {
+        match: `${HN_POST_KEY_PREFIX}*`,
+        count: 100,
+      });
+      cursor = result[0];
+      const keys = result[1];
+
+      if (keys.length > 0) {
+        deleted += await client.del(...keys);
+      }
+    } while (cursor !== "0");
+
+    console.log(`[HN Cache] Invalidated ${deleted} keys`);
+    return deleted;
+  } catch (error) {
+    console.error("[HN Cache] Error clearing cache:", error);
+    return 0;
+  }
+}

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -11,6 +11,7 @@ mock.module("next/cache", () => ({
   revalidatePath,
 }));
 
+import * as hnCache from "../hn-cache";
 import * as cache from "./cache";
 import {
   PURGE_CACHE_TYPES,
@@ -55,10 +56,17 @@ describe("PURGE_CONFIG", () => {
       paths: ["/sites", "/api/sites"],
       pagePaths: [],
     });
+    expect(PURGE_CONFIG.hn).toEqual({
+      patterns: ["hn:top_ids", "hn:post:*"],
+      tags: ["hn:post-ids", "hn:post", "hn:ranked"],
+      paths: ["/hn"],
+      pagePaths: ["/hn/[id]"],
+    });
   });
 
   test("includes all as a purge-cache type without its own config row", () => {
-    expect(PURGE_CACHE_TYPES).toEqual(["writing", "til", "ama", "stack", "sites", "all"]);
+    expect(PURGE_CACHE_TYPES).toEqual(["writing", "til", "ama", "stack", "sites", "hn", "all"]);
+    expect(PURGE_CACHE_TYPES).toContain("hn");
     expect(PURGE_CONFIG).not.toHaveProperty("all");
   });
 });
@@ -103,6 +111,22 @@ describe("purgeContentType", () => {
     expect(revalidatePath).toHaveBeenCalledTimes(2);
     expect(revalidatePath).toHaveBeenCalledWith("/stack");
     expect(revalidatePath).toHaveBeenCalledWith("/api/stacks");
+  });
+
+  test("clears HN Redis and Next tags/paths without touching Notion Redis", async () => {
+    const clearHn = spyOn(hnCache, "clearHnCache").mockResolvedValue(5);
+    const invalidate = spyOn(cache, "invalidateNotionCache").mockResolvedValue(99);
+
+    await expect(purgeContentType("hn")).resolves.toBe(5);
+    expect(clearHn).toHaveBeenCalledTimes(1);
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(revalidateTag).toHaveBeenCalledTimes(3);
+    expect(revalidateTag).toHaveBeenCalledWith("hn:post-ids", "max");
+    expect(revalidateTag).toHaveBeenCalledWith("hn:post", "max");
+    expect(revalidateTag).toHaveBeenCalledWith("hn:ranked", "max");
+    expect(revalidatePath).toHaveBeenCalledTimes(2);
+    expect(revalidatePath).toHaveBeenCalledWith("/hn");
+    expect(revalidatePath).toHaveBeenCalledWith("/hn/[id]", "page");
   });
 });
 

--- a/src/lib/notion/purge.ts
+++ b/src/lib/notion/purge.ts
@@ -1,9 +1,12 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 
+import { clearHnCache } from "@/lib/hn-cache";
+
 import { invalidateNotionCache } from "./cache";
 
-export const PURGEABLE_CONTENT_TYPES = ["writing", "til", "ama", "stack", "sites"] as const;
+export const PURGEABLE_CONTENT_TYPES = ["writing", "til", "ama", "stack", "sites", "hn"] as const;
 export type PurgeableContentType = (typeof PURGEABLE_CONTENT_TYPES)[number];
+export type NotionPurgeableContentType = Exclude<PurgeableContentType, "hn">;
 
 export const PURGE_CACHE_TYPES = [...PURGEABLE_CONTENT_TYPES, "all"] as const;
 export type PurgeCacheType = (typeof PURGE_CACHE_TYPES)[number];
@@ -19,6 +22,7 @@ export type PurgeCacheType = (typeof PURGE_CACHE_TYPES)[number];
  * - ama → `notion:ama:*`
  * - stack → `notion:stack:*`
  * - sites → `notion:good-websites:*` (list + rss; content type name ≠ Redis prefix)
+ * - hn → `hn:top_ids` + `hn:post:*` in the HN Redis DB (not Notion Redis)
  */
 export const PURGE_CONFIG: Record<
   PurgeableContentType,
@@ -54,18 +58,29 @@ export const PURGE_CONFIG: Record<
     paths: ["/sites", "/api/sites"],
     pagePaths: [],
   },
+  hn: {
+    patterns: ["hn:top_ids", "hn:post:*"],
+    tags: ["hn:post-ids", "hn:post", "hn:ranked"],
+    paths: ["/hn"],
+    pagePaths: ["/hn/[id]"],
+  },
 };
 
 /**
  * Invalidate Upstash + Next.js caches for one content type.
  * Used by `/api/purge-cache` and every webhook that writes Notion.
+ * `hn` clears the HN Redis DB via `clearHnCache`, not Notion Redis.
  */
 export async function purgeContentType(type: PurgeableContentType): Promise<number> {
   const config = PURGE_CONFIG[type];
 
   let deleted = 0;
-  for (const pattern of config.patterns) {
-    deleted += await invalidateNotionCache(pattern);
+  if (type === "hn") {
+    deleted = await clearHnCache();
+  } else {
+    for (const pattern of config.patterns) {
+      deleted += await invalidateNotionCache(pattern);
+    }
   }
 
   // Next 16 requires a cacheLife profile as the second arg; "max" gives


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`/api/purge-cache?secret=…&type=writing` already exists for Notion buttons. HN is a separate cache and was not on `PURGE_CACHE_TYPES`, so `/hn` could not be refreshed when a story was missing.

## What

- Add `hn` to `PURGEABLE_CONTENT_TYPES` / `PURGE_CONFIG` / `PURGE_CACHE_TYPES`.
- `type=hn` (and `type=all`) clears both layers:
  - Upstash HN Redis: `hn:top_ids` and `hn:post:*` via `clearHnCache()` (HN Redis client, not Notion Redis).
  - Next.js: `revalidateTag` for `hn:post-ids`, `hn:post`, `hn:ranked` and `revalidatePath` for `/hn` plus `/hn/[id]` as a page path.
- Same URL and `CACHE_PURGE_SECRET`. GET and POST both still work.
- POST body `pageId` / activity ingest stays Notion-only — `type=hn` does not emit a Notion activity event.

## Tests

- `PURGE_CACHE_TYPES` includes `hn`
- HN purge config has the expected tags/paths
- `clearHnCache` deletes `hn:top_ids` and `hn:post:*`
- Route accepts `type=hn`, includes HN in `type=all`, and skips activity ingest for HN
- `bun run lint` and `bun run build` pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4304d2e9-0cee-44f8-b8e4-ce4480d4c7d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4304d2e9-0cee-44f8-b8e4-ce4480d4c7d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

