### PR TITLE
Cache long-lived Notion lists so the homepage writing block stops flashing skeletons

### DIFF
--- a/src/app/app-dissection/page.tsx
+++ b/src/app/app-dissection/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
-import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
@@ -53,7 +53,9 @@ function AppDissectionFallback() {
 }
 
 async function AppDissectionGrid() {
-  await connection();
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:app-dissection");
   const items = await getAppDissectionDatabaseItems();
 
   return (

--- a/src/app/app-dissection/page.tsx
+++ b/src/app/app-dissection/page.tsx
@@ -2,10 +2,9 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
-import { Suspense } from "react";
 
-import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
+import { isPlaceholderNotionBuild } from "@/lib/notion";
 import { getAppDissectionDatabaseItems } from "@/lib/notion/queries";
 import { formatPublishedDate, type NotionAppDissectionItem } from "@/lib/notion/types";
 
@@ -27,27 +26,8 @@ export default function AppDissectionIndex() {
   return (
     <div className="@container flex flex-1 flex-col overflow-hidden">
       <div className="flex-1 overflow-y-auto">
-        <Suspense fallback={<AppDissectionFallback />}>
-          <AppDissectionGrid />
-        </Suspense>
+        <AppDissectionGrid />
       </div>
-    </div>
-  );
-}
-
-function AppDissectionFallback() {
-  return (
-    <div className="mx-auto grid w-full grid-cols-3 gap-1 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 lg:p-8">
-      {Array.from({ length: 15 }, (_, index) => (
-        <div
-          key={index}
-          className="relative flex flex-none flex-col items-center justify-center gap-3 overflow-hidden rounded-xl px-3 py-6"
-        >
-          <LoadingSkeleton className="size-12 rounded-xl" />
-          <LoadingSkeleton className="h-3.5 w-24" />
-          <LoadingSkeleton className="h-3 w-16" />
-        </div>
-      ))}
     </div>
   );
 }
@@ -56,7 +36,7 @@ async function AppDissectionGrid() {
   "use cache";
   cacheLife("days");
   cacheTag("notion:app-dissection");
-  const items = await getAppDissectionDatabaseItems();
+  const items = isPlaceholderNotionBuild() ? [] : await getAppDissectionDatabaseItems();
 
   return (
     <div className="mx-auto grid w-full grid-cols-3 gap-1 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 lg:p-8">

--- a/src/app/listening/page.tsx
+++ b/src/app/listening/page.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
-import { Suspense } from "react";
 
-import { ListDetailWrapper } from "@/components/ListDetailWrapper";
 import { ListeningHistory } from "@/components/ListeningHistory";
-import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { createMetadata } from "@/lib/metadata";
-import { getListeningHistoryDatabaseItems } from "@/lib/notion";
+import { getListeningHistoryDatabaseItems, isPlaceholderNotionBuild } from "@/lib/notion";
 
 export const metadata: Metadata = createMetadata({
   title: "Listening",
@@ -15,29 +12,16 @@ export const metadata: Metadata = createMetadata({
 });
 
 export default function ListeningPage() {
-  return (
-    <Suspense fallback={<ListeningFallback />}>
-      <ListeningContent />
-    </Suspense>
-  );
-}
-
-function ListeningFallback() {
-  return (
-    <ListDetailWrapper>
-      <div className="flex h-full flex-1 items-center justify-center">
-        <LoadingSpinner />
-      </div>
-    </ListDetailWrapper>
-  );
+  return <ListeningContent />;
 }
 
 async function ListeningContent() {
   "use cache";
   cacheLife("hours");
   cacheTag("notion:listening");
-  // Fetch initial page of music data on the server
-  const initialPage = await getListeningHistoryDatabaseItems(undefined, 20);
+  const initialPage = isPlaceholderNotionBuild()
+    ? { items: [], nextCursor: null }
+    : await getListeningHistoryDatabaseItems(undefined, 20);
 
   return <ListeningHistory initialData={[initialPage]} />;
 }

--- a/src/app/listening/page.tsx
+++ b/src/app/listening/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { connection } from "next/server";
+import { cacheLife, cacheTag } from "next/cache";
 import { Suspense } from "react";
 
 import { ListDetailWrapper } from "@/components/ListDetailWrapper";
@@ -33,7 +33,9 @@ function ListeningFallback() {
 }
 
 async function ListeningContent() {
-  await connection();
+  "use cache";
+  cacheLife("hours");
+  cacheTag("notion:listening");
   // Fetch initial page of music data on the server
   const initialPage = await getListeningHistoryDatabaseItems(undefined, 20);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import Link from "next/link";
-import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { HomeHero } from "@/components/home/HomeHero";
@@ -16,8 +16,7 @@ import {
 } from "@/components/shared/ListComponents";
 import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
 import { createMetadata, createPersonJsonLd } from "@/lib/metadata";
-import { buildSlug } from "@/lib/short-id";
-import { getAllWritingPosts } from "@/lib/writing";
+import { getAllWritingPosts, recentWritingLinks } from "@/lib/writing";
 
 export const metadata: Metadata = createMetadata({
   title: "Brian Lovin",
@@ -98,19 +97,18 @@ function RecentWritingFallback() {
 }
 
 async function RecentWriting() {
-  await connection();
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:writing");
   const allPosts = await getAllWritingPosts();
 
   return (
     <List>
-      {allPosts
-        .slice(0, 5)
-        .filter((post) => post.shortId)
-        .map((post) => (
-          <ListItem key={post.id} href={`/writing/${buildSlug(post.title, post.shortId!)}`}>
-            <ListItemLabel className="line-clamp-none">{post.title}</ListItemLabel>
-          </ListItem>
-        ))}
+      {recentWritingLinks(allPosts).map((post) => (
+        <ListItem key={post.id} href={post.href}>
+          <ListItemLabel className="line-clamp-none">{post.title}</ListItemLabel>
+        </ListItem>
+      ))}
     </List>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 import Link from "next/link";
-import { Suspense } from "react";
 
 import { HomeHero } from "@/components/home/HomeHero";
 import { ProjectsList } from "@/components/home/ProjectsList";
@@ -14,8 +13,8 @@ import {
   Section,
   SectionHeading,
 } from "@/components/shared/ListComponents";
-import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
 import { createMetadata, createPersonJsonLd } from "@/lib/metadata";
+import { isPlaceholderNotionBuild } from "@/lib/notion";
 import { getAllWritingPosts, recentWritingLinks } from "@/lib/writing";
 
 export const metadata: Metadata = createMetadata({
@@ -68,9 +67,7 @@ export default async function Home() {
                   className="text-quaternary group-hover:text-primary transition-all duration-150 group-hover:translate-x-0.5"
                 />
               </Link>
-              <Suspense fallback={<RecentWritingFallback />}>
-                <RecentWriting />
-              </Suspense>
+              <RecentWriting />
             </Section>
 
             <Section>
@@ -84,23 +81,11 @@ export default async function Home() {
   );
 }
 
-function RecentWritingFallback() {
-  return (
-    <List>
-      {Array.from({ length: 5 }, (_, index) => (
-        <ListItem key={index} className="py-1">
-          <LoadingSkeleton className="h-3.5 max-w-sm flex-1" />
-        </ListItem>
-      ))}
-    </List>
-  );
-}
-
 async function RecentWriting() {
   "use cache";
   cacheLife("days");
   cacheTag("notion:writing");
-  const allPosts = await getAllWritingPosts();
+  const allPosts = isPlaceholderNotionBuild() ? [] : await getAllWritingPosts();
 
   return (
     <List>

--- a/src/app/til/page.tsx
+++ b/src/app/til/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
-import { connection } from "next/server";
+import { cacheLife, cacheTag } from "next/cache";
 import { Suspense } from "react";
 
 import { TilFeed } from "@/components/TilFeed";
 import { PageTitle } from "@/components/Typography";
 import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
-import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
 import { getTilDatabaseItems, getTilItemContent } from "@/lib/notion";
 import { hydrateTilEntries } from "@/lib/til";
@@ -62,18 +61,11 @@ function TilFeedFallback() {
 }
 
 async function TilFeedContent() {
-  await connection();
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:til");
   const { items, nextCursor } = await getTilDatabaseItems(undefined, 10);
-  const pageIds = items.map((entry) => entry.id);
-  const [contents, initialLikes] = await Promise.all([
-    Promise.all(items.map((entry) => getTilItemContent(entry.id))),
-    getServerLikes(pageIds),
-  ]);
+  const contents = await Promise.all(items.map((entry) => getTilItemContent(entry.id)));
 
-  return (
-    <TilFeed
-      fallbackData={[{ items: hydrateTilEntries(items, contents), nextCursor }]}
-      initialLikes={initialLikes}
-    />
-  );
+  return <TilFeed fallbackData={[{ items: hydrateTilEntries(items, contents), nextCursor }]} />;
 }

--- a/src/app/til/page.tsx
+++ b/src/app/til/page.tsx
@@ -1,12 +1,10 @@
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
-import { Suspense } from "react";
 
 import { TilFeed } from "@/components/TilFeed";
 import { PageTitle } from "@/components/Typography";
-import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
-import { getTilDatabaseItems, getTilItemContent } from "@/lib/notion";
+import { getTilDatabaseItems, getTilItemContent, isPlaceholderNotionBuild } from "@/lib/notion";
 import { hydrateTilEntries } from "@/lib/til";
 
 export const metadata: Metadata = {
@@ -30,32 +28,8 @@ export default function TilPage() {
           <div className="hidden sm:block" />
           <PageTitle>TIL</PageTitle>
         </div>
-        <Suspense fallback={<TilFeedFallback />}>
-          <TilFeedContent />
-        </Suspense>
+        <TilFeedContent />
       </div>
-    </div>
-  );
-}
-
-function TilFeedFallback() {
-  return (
-    <div className="flex flex-col gap-12 px-4">
-      {Array.from({ length: 5 }, (_, index) => (
-        <div
-          key={index}
-          className="grid grid-cols-1 gap-2 sm:grid-cols-[140px_1fr] sm:items-baseline sm:gap-6 md:grid-cols-[180px_1fr]"
-        >
-          <LoadingSkeleton className="h-4 w-24" />
-          <div className="flex flex-col gap-3">
-            <LoadingSkeleton className="h-5 w-3/4" />
-            <div className="flex flex-col gap-2">
-              <LoadingSkeleton className="h-4 w-full" />
-              <LoadingSkeleton className="h-4 w-2/3" />
-            </div>
-          </div>
-        </div>
-      ))}
     </div>
   );
 }
@@ -64,6 +38,9 @@ async function TilFeedContent() {
   "use cache";
   cacheLife("days");
   cacheTag("notion:til");
+  if (isPlaceholderNotionBuild()) {
+    return <TilFeed fallbackData={[{ items: [], nextCursor: null }]} />;
+  }
   const { items, nextCursor } = await getTilDatabaseItems(undefined, 10);
   const contents = await Promise.all(items.map((entry) => getTilItemContent(entry.id)));
 

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { connection } from "next/server";
+import { cacheLife, cacheTag } from "next/cache";
 import { Suspense } from "react";
 
 import {
@@ -52,7 +52,9 @@ function WritingPostsFallback() {
 }
 
 async function WritingPosts() {
-  await connection();
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:writing");
   const posts = await getAllWritingPosts();
 
   // Group posts by year

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
-import { Suspense } from "react";
 
 import {
   List,
@@ -10,8 +9,8 @@ import {
   SectionHeading,
 } from "@/components/shared/ListComponents";
 import { PageTitle } from "@/components/Typography";
-import { LoadingSkeleton } from "@/components/ui/LoadingSkeleton";
 import { createMetadata } from "@/lib/metadata";
+import { isPlaceholderNotionBuild } from "@/lib/notion";
 import { buildSlug } from "@/lib/short-id";
 import { getAllWritingPosts } from "@/lib/writing";
 
@@ -29,25 +28,9 @@ export default function WritingPage() {
         <Section>
           <PageTitle>Writing</PageTitle>
         </Section>
-        <Suspense fallback={<WritingPostsFallback />}>
-          <WritingPosts />
-        </Suspense>
+        <WritingPosts />
       </div>
     </div>
-  );
-}
-
-function WritingPostsFallback() {
-  return (
-    <Section>
-      <List>
-        {Array.from({ length: 6 }, (_, index) => (
-          <ListItem key={index} className="py-1">
-            <LoadingSkeleton className="h-3.5 max-w-sm flex-1" />
-          </ListItem>
-        ))}
-      </List>
-    </Section>
   );
 }
 
@@ -55,7 +38,7 @@ async function WritingPosts() {
   "use cache";
   cacheLife("days");
   cacheTag("notion:writing");
-  const posts = await getAllWritingPosts();
+  const posts = isPlaceholderNotionBuild() ? [] : await getAllWritingPosts();
 
   // Group posts by year
   const postsByYear: Record<string, typeof posts> = {};

--- a/src/lib/notion/cache.test.ts
+++ b/src/lib/notion/cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { CONTENT_CACHE_VERSION, notionContentCacheKey } from "./cache";
+import { CONTENT_CACHE_VERSION, isPlaceholderNotionBuild, notionContentCacheKey } from "./cache";
 
 describe("notionContentCacheKey", () => {
   test("bumps processed content keys to v2", () => {
@@ -16,5 +16,20 @@ describe("notionContentCacheKey", () => {
     expect(notionContentCacheKey("app-dissection", "instagram")).toBe(
       "notion:app-dissection:content:v2:instagram",
     );
+  });
+});
+
+describe("isPlaceholderNotionBuild", () => {
+  test("is true only for the CI placeholder Notion token", () => {
+    const previous = process.env.NOTION_TOKEN;
+    process.env.NOTION_TOKEN = "build-placeholder";
+    expect(isPlaceholderNotionBuild()).toBe(true);
+    process.env.NOTION_TOKEN = "secret_live_token";
+    expect(isPlaceholderNotionBuild()).toBe(false);
+    if (previous === undefined) {
+      delete process.env.NOTION_TOKEN;
+    } else {
+      process.env.NOTION_TOKEN = previous;
+    }
   });
 });

--- a/src/lib/notion/cache.ts
+++ b/src/lib/notion/cache.ts
@@ -24,6 +24,11 @@ interface CachedEntry<T> {
   cachedAt: number;
 }
 
+/** CI sets `NOTION_TOKEN=build-placeholder` so prerender must not call Notion. */
+export function isPlaceholderNotionBuild(): boolean {
+  return process.env.NOTION_TOKEN === "build-placeholder";
+}
+
 export const CACHE_TTLS = {
   /** Listings (1 hour) */
   LIST: 3600,

--- a/src/lib/notion/index.ts
+++ b/src/lib/notion/index.ts
@@ -96,7 +96,12 @@ export {
 } from "./queries";
 
 // Cache
-export { CONTENT_CACHE_VERSION, invalidateNotionCache, notionContentCacheKey } from "./cache";
+export {
+  CONTENT_CACHE_VERSION,
+  invalidateNotionCache,
+  isPlaceholderNotionBuild,
+  notionContentCacheKey,
+} from "./cache";
 
 // Mutations
 export {

--- a/src/lib/writing.test.ts
+++ b/src/lib/writing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import type { NotionWritingItem } from "@/lib/notion";
+import { recentWritingLinks } from "@/lib/writing";
+
+function post(overrides: Partial<NotionWritingItem> & Pick<NotionWritingItem, "id" | "title">) {
+  return {
+    slug: "",
+    published: "2026-08-01",
+    createdTime: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("recentWritingLinks", () => {
+  test("lists the five most recent published titles and hrefs", () => {
+    const links = recentWritingLinks([
+      post({ id: "1", title: "How I'm Feeling About AI", shortId: "O7e1TFS" }),
+      post({ id: "2", title: "Second Post", shortId: "abc1234" }),
+      post({ id: "3", title: "Third Post", shortId: "def5678" }),
+      post({ id: "4", title: "Fourth Post", shortId: "ghi9012" }),
+      post({ id: "5", title: "Fifth Post", shortId: "jkl3456" }),
+      post({ id: "6", title: "Sixth Post", shortId: "mno7890" }),
+    ]);
+
+    expect(links).toEqual([
+      {
+        id: "1",
+        title: "How I'm Feeling About AI",
+        href: "/writing/how-im-feeling-about-ai-O7e1TFS",
+      },
+      { id: "2", title: "Second Post", href: "/writing/second-post-abc1234" },
+      { id: "3", title: "Third Post", href: "/writing/third-post-def5678" },
+      { id: "4", title: "Fourth Post", href: "/writing/fourth-post-ghi9012" },
+      { id: "5", title: "Fifth Post", href: "/writing/fifth-post-jkl3456" },
+    ]);
+  });
+
+  test("omits posts that have no short id", () => {
+    const links = recentWritingLinks([
+      post({ id: "1", title: "Draft" }),
+      post({ id: "2", title: "Published", shortId: "abc1234" }),
+    ]);
+
+    expect(links).toEqual([{ id: "2", title: "Published", href: "/writing/published-abc1234" }]);
+  });
+});

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -2,6 +2,7 @@ import { cache } from "react";
 
 import { InfiniteScrollPage, useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { getWritingDatabaseItems, NotionWritingItem } from "@/lib/notion";
+import { buildSlug } from "@/lib/short-id";
 
 export type WritingPage = InfiniteScrollPage<NotionWritingItem>;
 
@@ -30,3 +31,14 @@ async function fetchAllWritingPosts(): Promise<NotionWritingItem[]> {
 
 // Request-level dedup: prevents duplicate calls within a single render
 export const getAllWritingPosts = cache(fetchAllWritingPosts);
+
+export function recentWritingLinks(posts: NotionWritingItem[]) {
+  return posts
+    .slice(0, 5)
+    .filter((post): post is NotionWritingItem & { shortId: string } => Boolean(post.shortId))
+    .map((post) => ({
+      id: post.id,
+      title: post.title,
+      href: `/writing/${buildSlug(post.title, post.shortId)}`,
+    }));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`connection()` on `RecentWriting` made that island request-dynamic. Combined with a Suspense fallback, every full refresh of `/` painted writing skeletons first, even though the posts are long-lived Notion data (Redis + `notion:writing`, purged by `/api/purge-cache`).

The same `connection()` hole existed on `/writing`, `/til`, `/app-dissection`, and `/listening`. Those lists do not need the incoming request.

## Changes

- Removed `connection()` from those list islands. Left it on `/activity` (live feed) and the HN digest cron.
- Opted each island into `use cache` with `cacheLife` (`days` for writing / TIL / app-dissection, `hours` for listening) and the existing tags (`notion:writing`, `notion:til`, `notion:app-dissection`, `notion:listening`) so `/api/purge-cache` still busts them.
- Stopped loading TIL likes in the cached list. Entries stay cached; likes stay a client-side overlay.
- Did not `force-static` the homepage. It becomes a static route because writing was the only server hole; visits / activity / geo stay client or request-bound elsewhere.
- Dropped the Suspense wrappers around these cached islands. A warm `use cache` result inside Suspense still serialized as a completed boundary, so the first paint was skeletons even when the five titles were already in the document. Rendering the cached list directly puts the titles in the first HTML. A cold miss blocks once while the cache fills.
- CI builds use `NOTION_TOKEN=build-placeholder` and skip the Notion call so `bun run build` still passes without credentials.

Behavior test covers homepage writing titles and hrefs.

[Homepage first HTML writing list](https://cursor.com/agents/bc-1c06b19d-a8e8-4159-ab7c-3e39031bd1b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_writing_first_html.html)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c06b19d-a8e8-4159-ab7c-3e39031bd1b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c06b19d-a8e8-4159-ab7c-3e39031bd1b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

