### PR TITLE
Normalize activity icons and fix the globe hydration mismatch

### DIFF
--- a/schemas/MusicSchema.json
+++ b/schemas/MusicSchema.json
@@ -41,7 +41,7 @@
       "description": null,
       "type": "formula",
       "formula": {
-        "expression": "     {{notion:block_property:MWCP:1eac711c-0ceb-8035-87fa-000bbec76c6e:30816cbc-deb8-4977-8ae8-d92f0669fb36}} + \"-\" +\n     formatDate({{notion:block_property:rVH%3D:1eac711c-0ceb-8035-87fa-000bbec76c6e:30816cbc-deb8-4977-8ae8-d92f0669fb36}}, \"yyyy-MM-dd'T'HH:mm:ssX\")"
+        "expression": "     prop(\"Spotify ID\") + \"-\" +\n     formatDate(prop(\"Played At\"), \"yyyy-MM-dd'T'HH:mm:ssX\")"
       }
     },
     "Artist": {

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -29,11 +29,13 @@ function ActivityFallback() {
         <div data-scrollable className="relative min-w-0 flex-1 overflow-auto">
           <div className="divide-secondary divide-y">
             {Array.from({ length: 8 }, (_, index) => (
-              <div key={index} className="flex items-center gap-3 px-4 py-3">
-                <div className="flex size-8 flex-none items-center justify-center">
-                  <LoadingSkeleton className="size-6" />
+              <div key={index} className="flex items-center gap-3 px-4 py-3 md:py-2">
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <div className="flex size-8 flex-none items-center justify-center">
+                    <LoadingSkeleton className="size-4" />
+                  </div>
+                  <LoadingSkeleton className="h-3 w-2/3" />
                 </div>
-                <LoadingSkeleton className="h-3 w-2/3" />
               </div>
             ))}
           </div>

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -56,23 +56,46 @@ import {
 import { useActivity } from "@/lib/hooks/useActivity";
 import { cn } from "@/lib/utils";
 
+const ACTIVITY_EVENT_ICON_SIZE = 16;
+/** Iconic 24-up artwork sits in ~4–20. Crop so it fills the 16px favicon slot. */
+const ACTIVITY_STROKE_ICON_VIEWBOX = "4 4 16 16";
+
+function ActivityEventIcon({ children }: { children: ReactNode }) {
+  return (
+    <span className="flex size-4 items-center justify-center [&_img]:block [&_img]:size-4 [&_svg]:block [&_svg]:size-4">
+      {children}
+    </span>
+  );
+}
+
 function ActivitySourceFavicon({ src }: { src: string }) {
   const [failed, setFailed] = useState(false);
   if (failed) {
-    return <World size={16} className="text-tertiary" aria-hidden />;
+    return (
+      <ActivityEventIcon>
+        <World
+          size={ACTIVITY_EVENT_ICON_SIZE}
+          viewBox={ACTIVITY_STROKE_ICON_VIEWBOX}
+          className="text-tertiary"
+          aria-hidden
+        />
+      </ActivityEventIcon>
+    );
   }
 
   return (
-    /* eslint-disable-next-line @next/next/no-img-element -- tiny static favicon */
-    <img
-      src={src}
-      alt=""
-      width={16}
-      height={16}
-      className="block size-4 rounded-[3px]"
-      aria-hidden
-      onError={() => setFailed(true)}
-    />
+    <ActivityEventIcon>
+      {/* eslint-disable-next-line @next/next/no-img-element -- tiny static favicon */}
+      <img
+        src={src}
+        alt=""
+        width={ACTIVITY_EVENT_ICON_SIZE}
+        height={ACTIVITY_EVENT_ICON_SIZE}
+        className="rounded-[3px]"
+        aria-hidden
+        onError={() => setFailed(true)}
+      />
+    </ActivityEventIcon>
   );
 }
 
@@ -87,45 +110,104 @@ function isGithubActivity(event: ActivityEvent): boolean {
 
 function ActivityRowIcon({ event, icon }: { event: ActivityEvent; icon?: string }) {
   if (event.source === "shiori") {
-    return <Shiori size={16} />;
+    return (
+      <ActivityEventIcon>
+        <Shiori size={ACTIVITY_EVENT_ICON_SIZE} />
+      </ActivityEventIcon>
+    );
   }
 
   if (event.source === "staff-design") {
-    return <StaffDesign size={20} className="text-primary" aria-hidden />;
+    return (
+      <ActivityEventIcon>
+        <StaffDesign size={ACTIVITY_EVENT_ICON_SIZE} className="text-primary" aria-hidden />
+      </ActivityEventIcon>
+    );
   }
 
   if (event.type === "like") {
-    return <Heart size={24} className="fill-current text-red-500" aria-hidden />;
+    return (
+      <ActivityEventIcon>
+        <Heart
+          size={ACTIVITY_EVENT_ICON_SIZE}
+          viewBox="4 5 16 13.5"
+          className="fill-current text-red-500"
+          aria-hidden
+        />
+      </ActivityEventIcon>
+    );
   }
 
   if (isGithubActivity(event)) {
-    return <Github size={20} className="text-primary" aria-hidden />;
+    return (
+      <ActivityEventIcon>
+        <Github
+          size={ACTIVITY_EVENT_ICON_SIZE}
+          viewBox="2 2 20 20"
+          className="text-primary"
+          aria-hidden
+        />
+      </ActivityEventIcon>
+    );
   }
 
   if (event.type === "visit" || event.type === "visit_country_first" || event.type === "download") {
     if (isHnActivityEvent(event)) {
-      return <YCombinator size={16} />;
+      return (
+        <ActivityEventIcon>
+          <YCombinator size={ACTIVITY_EVENT_ICON_SIZE} />
+        </ActivityEventIcon>
+      );
     }
     const faviconSrc = activitySourceFaviconSrc(event.source);
     if (faviconSrc) {
       return <ActivitySourceFavicon src={faviconSrc} />;
     }
-    return <World size={16} className="text-tertiary" aria-hidden />;
+    return (
+      <ActivityEventIcon>
+        <World
+          size={ACTIVITY_EVENT_ICON_SIZE}
+          viewBox={ACTIVITY_STROKE_ICON_VIEWBOX}
+          className="text-tertiary"
+          aria-hidden
+        />
+      </ActivityEventIcon>
+    );
   }
 
   if (event.type === "caffeinated") {
     return (
-      <span className="text-base leading-none" aria-hidden>
-        {icon ?? "🥤"}
-      </span>
+      <ActivityEventIcon>
+        <span className="text-base leading-none" aria-hidden>
+          {icon ?? "🥤"}
+        </span>
+      </ActivityEventIcon>
     );
   }
 
   if (event.type === "site_added") {
-    return <Compass size={16} className="text-tertiary" aria-hidden />;
+    return (
+      <ActivityEventIcon>
+        <Compass
+          size={ACTIVITY_EVENT_ICON_SIZE}
+          viewBox={ACTIVITY_STROKE_ICON_VIEWBOX}
+          className="text-tertiary"
+          aria-hidden
+        />
+      </ActivityEventIcon>
+    );
   }
 
-  return <Activity size={16} className="text-tertiary" aria-hidden />;
+  return (
+    <ActivityEventIcon>
+      <Activity
+        size={ACTIVITY_EVENT_ICON_SIZE}
+        viewBox={ACTIVITY_STROKE_ICON_VIEWBOX}
+        className="text-tertiary"
+        aria-hidden
+      />
+    </ActivityEventIcon>
+  );
 }
 
 function isAbsoluteHttpUrl(href: string): boolean {

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -27,6 +27,7 @@ import {
 import {
   type ActivityGlobeConfig,
   cobeMarkerStyle,
+  cssPx,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
   markerDotPxForAge,
@@ -60,6 +61,25 @@ function subscribeDark(onChange: () => void): () => void {
 
 function isDarkClass(): boolean {
   return document.documentElement.classList.contains("dark");
+}
+
+function subscribeNoop(): () => void {
+  return () => {};
+}
+
+/**
+ * The CSS dots are inert until COBE exists: they sit at `opacity: 0` and anchor
+ * to `--cobe-*` positions that only the client creates. Rendering them on the
+ * server buys nothing and costs two hydration mismatches — `useReducedMotion()`
+ * reads the media query during render, and dot sizes come out of `**`, which is
+ * not correctly rounded and so differs in the last bit between Bun and Chrome.
+ */
+function useHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribeNoop,
+    () => true,
+    () => false,
+  );
 }
 
 function useIsDark(): boolean {
@@ -122,6 +142,7 @@ export function ActivityGlobe({
   const lastXRef = useRef(0);
   const lastYRef = useRef(0);
   const lastTRef = useRef(0);
+  const hydrated = useHydrated();
   const isDark = useIsDark();
   const prefersReducedMotion = useReducedMotion() === true;
   const [layout, setLayout] = useState({ hasRoom: true, size: GLOBE_MESH_MIN });
@@ -428,38 +449,45 @@ export function ActivityGlobe({
           onPointerCancel={endDrag}
         />
       </div>
-      {markers.map((marker) => {
-        const px = markerDotPxForAge(marker.age, config, globeMapDotPx(layout.size, config.scale));
-        return (
-          <span
-            key={marker.id}
-            className="activity-globe-dot"
-            style={
-              {
-                ...cobeMarkerStyle(marker.id, {
-                  markerBlurPx: config.markerBlurPx,
-                  markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
-                }),
-                "--activity-globe-focus-scale": 1 + config.focusPulseScale,
-                "--activity-globe-focus-ms": `${config.focusMs}ms`,
-              } as CSSProperties
-            }
-          >
-            <span
-              key={focusId === marker.eventId ? focusId : "idle"}
-              className={cn("activity-globe-dot-core", focusId === marker.eventId && "is-focused")}
-              style={
-                {
-                  width: px,
-                  height: px,
-                  backgroundColor: rgbCss(config.markerColor),
-                  "--activity-globe-dot-px": `${px}px`,
-                } as CSSProperties
-              }
-            />
-          </span>
-        );
-      })}
+      {hydrated
+        ? markers.map((marker) => {
+            const px = cssPx(
+              markerDotPxForAge(marker.age, config, globeMapDotPx(layout.size, config.scale)),
+            );
+            return (
+              <span
+                key={marker.id}
+                className="activity-globe-dot"
+                style={
+                  {
+                    ...cobeMarkerStyle(marker.id, {
+                      markerBlurPx: config.markerBlurPx,
+                      markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
+                    }),
+                    "--activity-globe-focus-scale": 1 + config.focusPulseScale,
+                    "--activity-globe-focus-ms": `${config.focusMs}ms`,
+                  } as CSSProperties
+                }
+              >
+                <span
+                  key={focusId === marker.eventId ? focusId : "idle"}
+                  className={cn(
+                    "activity-globe-dot-core",
+                    focusId === marker.eventId && "is-focused",
+                  )}
+                  style={
+                    {
+                      width: px,
+                      height: px,
+                      backgroundColor: rgbCss(config.markerColor),
+                      "--activity-globe-dot-px": px,
+                    } as CSSProperties
+                  }
+                />
+              </span>
+            );
+          })
+        : null}
     </div>
   );
 }

--- a/src/components/icons/YCombinator.tsx
+++ b/src/components/icons/YCombinator.tsx
@@ -16,7 +16,7 @@ export function YCombinator({ size = 16, className, ...rest }: IconProps) {
       <path
         fill="currentColor"
         fillRule="evenodd"
-        d="M0 0h24v24H0V0zm12.7 18.5h-1.4v-6.2L7.1 5.5h1.7l3.2 6.3c.1.2.2.5.3.8h.1c.1-.3.2-.6.3-.8l3.2-6.3h1.7l-4.2 6.8v6.2z"
+        d="m0 0h24v24h-24zm12.8 13.446 4.339-8.303h-1.871q-2.143 4.018-2.839 5.786l-.375.96-.32-.75c-.96-2.374-1.931-4.348-3.022-6.243l.129.243h-1.984l4.286 8.2v5.52h1.657z"
       />
     </svg>
   );

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   cobeMarkerStyle,
+  cssPx,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
   globeThemeColors,
@@ -9,6 +10,7 @@ import {
   markerDotPxForAge,
   markerDotPxForSize,
   markerSizeFromCount,
+  rgbCss,
 } from "./activity-globe-config";
 
 describe("activity-globe-config", () => {
@@ -60,5 +62,16 @@ describe("activity-globe-config", () => {
     expect(markerDotPxForAge(0, cfg, 5)).toBeCloseTo(cfg.markerDotPx);
     expect(markerDotPxForAge(9, cfg, 5)).toBe(5);
     expect(markerDotPxForAge(9, cfg, 0)).toBeCloseTo(cfg.markerDotPx * 0.9 ** 9);
+  });
+
+  test("cssPx rounds floats so SSR and client serialize the same", () => {
+    expect(cssPx(7.8732000000000015)).toBe("7.87px");
+    expect(cssPx(7.873200000000001)).toBe("7.87px");
+    expect(cssPx(12)).toBe("12px");
+    expect(cssPx(Number.NaN)).toBe("0px");
+  });
+
+  test("rgbCss emits a hex color", () => {
+    expect(rgbCss(DEFAULT_ACTIVITY_GLOBE_CONFIG.markerColor)).toBe("#fc532a");
   });
 });

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -135,9 +135,26 @@ export function globeCobeOptions(isDark: boolean, config: ActivityGlobeConfig) {
   };
 }
 
+/**
+ * Rounded `Npx` string for inline styles.
+ *
+ * `**` is not correctly rounded, so the SSR runtime and the browser can disagree
+ * in the last bit: `12 * 0.9 ** 4` is `7.8732000000000015` in Bun/Node and
+ * `7.873200000000001` in Chrome. React hydration compares the raw `style`
+ * attribute string, so that one bit is a mismatch. Rounding kills it.
+ */
+export function cssPx(value: number): string {
+  if (!Number.isFinite(value)) return "0px";
+  return `${Number(value.toFixed(2))}px`;
+}
+
+/** Hex keeps the marker color one stable token in the serialized style attribute. */
 export function rgbCss(color: RgbTriplet): string {
-  const channel = (value: number) => Math.round(Math.min(1, Math.max(0, value)) * 255);
-  return `rgb(${channel(color[0])} ${channel(color[1])} ${channel(color[2])})`;
+  const channel = (value: number) =>
+    Math.round(Math.min(1, Math.max(0, value)) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${channel(color[0])}${channel(color[1])}${channel(color[2])}`;
 }
 
 /** Official COBE bindable-marker visibility: `--cobe-visible-{id}` is `N` or unset. */


### PR DESCRIPTION
Three fixes to the activity page, all visible on a hard reload.

## Icons render at one optical size

Rows drew each icon at whatever size its source artwork wanted — `Heart` at 24, `Github` and `StaffDesign` at 20, the rest at 16 — so marks in the same column read as different weights. Every icon now goes through a single `ActivityEventIcon` box at 16px, with a cropped `viewBox` per icon so stroke artwork drawn in a 24-up grid actually fills the slot instead of floating inside its own padding. The Y Combinator mark is redrawn to match the others.

## Globe dots no longer warn on hydration

Hard reloading `/activity` logged a hydration mismatch on the marker dots:

```
- --activity-globe-dot-px: "7.8732000000000015px"   (server)
+ --activity-globe-dot-px: "7.873200000000001px"    (client)
```

Dot size is `12 * (1 - 0.1) ** age`. `**` is not correctly rounded, so the SSR runtime and the browser can differ in the last bit — Bun/JSC gives `7.8732000000000015` where Chrome/V8 gives `7.873200000000001`. React's `diffHydratedStyles` compares the raw `style` attribute string, and custom properties are stored verbatim, so that single bit is a real mismatch.

The `width`/`height`/`background-color` lines in the original warning were red herrings: once React detects any style difference it reports the whole declaration by reading it back through the CSSOM, which rounds `7.8732000000000015px` to `7.8732px` and rewrites `rgb(252 83 42)` as `rgb(252, 83, 42)`. Only the custom property was actually diverging.

Sizes now round through `cssPx`, and the dots render only after hydration. This was not dev-only — engines other than V8 can round `**` differently in production too.

## Skeleton rows match real rows

`ActivityRow` uses `px-4 py-3 md:py-2`, but the loading fallback kept `py-3` at every width. With a 32px icon slot driving height, skeleton rows were 56px against real rows' 48px on desktop, so the feed jumped when data landed. The fallback now mirrors the real row's padding and inner structure, and its icon placeholder matches the real 16px icon inside the 32px slot.

## Also included

`schemas/MusicSchema.json` picked up unrelated generated drift — Notion now serializes the formula as `prop("Spotify ID")` instead of raw block-property UUIDs. No behavior change.

## Test plan

- [x] `bun run lint`
- [x] `bun run test` — 523 pass, 0 fail
- [x] `bun run build`
- [x] Verified React's hydration comparison path against `react-dom-client.development.js` and confirmed the CSSOM round-trip behavior in a real browser, rather than assuming which style property was at fault
- [ ] Hard reload `/activity` and confirm the console is clean
- [ ] Throttle the network and confirm the skeleton doesn't shift the feed when it swaps to real rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)