### PR TITLE
Say The United States in country-only visit copy

### DIFF
--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -187,7 +187,7 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from United States viewed");
+    expect(markup).toContain("Someone from The United States viewed");
     expect(markup).not.toContain("Visit from");
     expect(markup).toContain("Hacker News");
     expect(markup).toContain('href="/hn"');
@@ -225,7 +225,7 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(markup).toContain("Someone from United States read");
+    expect(markup).toContain("Someone from The United States read");
     expect(markup).not.toContain("Visit from");
     expect(markup).toContain(">Some HN Story<");
     expect(markup).toContain('href="/hn/42991019"');
@@ -283,7 +283,7 @@ describe("ActivityRow", () => {
     );
 
     expect(visit).toContain("/activity/favicons/tax-ui.png");
-    expect(visit).toContain("Someone from United States visited");
+    expect(visit).toContain("Someone from The United States visited");
     expect(visit).not.toContain("Visit from");
     expect(visit).not.toContain("🇺🇸");
     expect(download).toContain("/activity/favicons/design-details.png");
@@ -294,7 +294,7 @@ describe("ActivityRow", () => {
     expect(download).toContain('target="_blank"');
     expect(download).toContain("noopener noreferrer");
     expect(unknown).not.toContain("/activity/favicons/");
-    expect(unknown).toContain("Someone from United States visited brianlovin.com");
+    expect(unknown).toContain("Someone from The United States visited brianlovin.com");
     expect(unknown).not.toContain("Visit from");
     expect(unknown).not.toContain("🇺🇸");
   });
@@ -959,7 +959,7 @@ describe("ActivityRow", () => {
       />,
     );
 
-    expect(staff).toContain("Someone from United States visited");
+    expect(staff).toContain("Someone from The United States visited");
     expect(staff).not.toContain("Visit from");
     expect(staff).not.toContain("🇺🇸");
     expect(staff).toContain(">Staff.design<");
@@ -1224,7 +1224,7 @@ describe("ActivityFeed", () => {
     expect(cityState).toContain("Someone from San Francisco, California viewed");
     expect(cityState).toContain("Listening");
     expect(cityState).not.toContain("United States");
-    expect(countryOnly).toContain("Someone from United States viewed");
+    expect(countryOnly).toContain("Someone from The United States viewed");
     expect(countryOnly).toContain("Stack");
   });
 

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -1114,7 +1114,8 @@ export function visitLocationClusterKey(event: ActivityEvent): string | undefine
 }
 
 export function formatVisitLocationHeader(location: string): string {
-  return `Someone from ${location}`;
+  const name = /^united states$/i.test(location.trim()) ? "The United States" : location;
+  return `Someone from ${name}`;
 }
 
 export function formatVisitRowSummary(

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -20,6 +20,7 @@ import {
   formatActivityTitle,
   formatDownloadSummary,
   formatLikeOthersLabel,
+  formatVisitLocationHeader,
   formatVisitRowSummary,
   formatVisitSummary,
   getActivityRow,
@@ -2117,7 +2118,7 @@ describe("getActivityRow visit sentences", () => {
         { meta: { country: "US", path: "/stack" } },
       ),
     );
-    expect(stack.summary).toBe("Someone from United States viewed");
+    expect(stack.summary).toBe("Someone from The United States viewed");
     expect(stack.summary).toContain("viewed");
     expect(stack.summary).not.toContain("read");
     expect(stack.summary).not.toContain("Visit from");
@@ -2144,7 +2145,7 @@ describe("getActivityRow visit sentences", () => {
         { meta: { country: "US", path: "/hn" } },
       ),
     );
-    expect(index.summary).toBe("Someone from United States viewed");
+    expect(index.summary).toBe("Someone from The United States viewed");
     expect(index.summary).toContain("viewed");
     expect(index.summary).not.toContain("read");
     expect(index.summary).not.toContain("Visit from");
@@ -2269,7 +2270,7 @@ describe("getActivityRow visit sentences", () => {
         },
       ),
     );
-    expect(home.summary).toBe("Someone from United States visited");
+    expect(home.summary).toBe("Someone from The United States visited");
     expect(home.summary).not.toContain("read");
     expect(home.summary).not.toContain("brianlovin.com");
     expect(home.label).toBe("Staff.design");
@@ -2379,7 +2380,7 @@ describe("getActivityRow visit sentences", () => {
         },
       ),
     );
-    expect(taxUi.summary).toBe("Someone from United States visited");
+    expect(taxUi.summary).toBe("Someone from The United States visited");
     expect(taxUi.label).toBe("Tax UI");
     expect(taxUi.href).toBe("https://tax-ui.brianlovin.com/");
   });
@@ -2451,6 +2452,17 @@ describe("visitLocationPhrase US display", () => {
 });
 
 describe("formatVisitRowSummary location prefix", () => {
+  test("adds The before a country-only United States location", () => {
+    expect(formatVisitRowSummary("United States", "visited", false, { source: "staff-design" })).toBe(
+      "Someone from The United States visited Staff.design",
+    );
+    expect(formatVisitLocationHeader("United States")).toBe("Someone from The United States");
+    expect(formatVisitLocationHeader("The United States")).toBe("Someone from The United States");
+    expect(formatVisitLocationHeader("San Francisco, California")).toBe(
+      "Someone from San Francisco, California",
+    );
+  });
+
   test("can omit the someone/location prefix and keep the action", () => {
     expect(formatVisitRowSummary("San Francisco, California", "viewed", true)).toBe(
       "Someone from San Francisco, California viewed",
@@ -2569,7 +2581,7 @@ describe("getActivityRow source metadata", () => {
         }),
       ),
     ).toEqual({
-      summary: "Someone from United States visited",
+      summary: "Someone from The United States visited",
       href: "https://designdetails.fm",
       label: "Design Details",
     });

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -2453,9 +2453,9 @@ describe("visitLocationPhrase US display", () => {
 
 describe("formatVisitRowSummary location prefix", () => {
   test("adds The before a country-only United States location", () => {
-    expect(formatVisitRowSummary("United States", "visited", false, { source: "staff-design" })).toBe(
-      "Someone from The United States visited Staff.design",
-    );
+    expect(
+      formatVisitRowSummary("United States", "visited", false, { source: "staff-design" }),
+    ).toBe("Someone from The United States visited Staff.design");
     expect(formatVisitLocationHeader("United States")).toBe("Someone from The United States");
     expect(formatVisitLocationHeader("The United States")).toBe("Someone from The United States");
     expect(formatVisitLocationHeader("San Francisco, California")).toBe(


### PR DESCRIPTION
## Summary
Country-only US visits now say “Someone from The United States…” instead of dropping the article. City and state visits still omit the country, and stored ingest summaries are unchanged.

## Test plan
- [ ] Confirm a US-only visit reads “Someone from The United States visited …”
- [ ] Confirm a San Francisco visit still reads “Someone from San Francisco, California …”
- [ ] Confirm a non-US country visit is unchanged (e.g. “Someone from China visited …”)


Made with [Cursor](https://cursor.com)