### PR TITLE
Cache /stack and /sites so first load stops flashing skeletons

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { Suspense } from "react";
 
 import { ProjectsList } from "@/components/home/ProjectsList";
 import { SpeakingList } from "@/components/home/SpeakingList";
-import { SpeakingListSkeleton } from "@/components/home/SpeakingListSkeleton";
 import { BufferLogoSVG, GitHubIcon, XIcon, YouTubeIcon } from "@/components/icons/SocialIcons";
 import {
   InlineLink,
@@ -140,9 +138,7 @@ export default function About() {
 
             <Section>
               <SectionHeading>Speaking</SectionHeading>
-              <Suspense fallback={<SpeakingListSkeleton />}>
-                <SpeakingList />
-              </Suspense>
+              <SpeakingList />
             </Section>
 
             <Section>

--- a/src/app/ama/AMADetail.tsx
+++ b/src/app/ama/AMADetail.tsx
@@ -9,12 +9,17 @@ import { PageTitle } from "@/components/Typography";
 import { FancySeparator } from "@/components/ui/FancySeparator";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { useAmaQuestion } from "@/lib/hooks/useAma";
+import type { NotionAmaItemWithContent } from "@/lib/notion";
 
-export default function AMADetail() {
+export default function AMADetail({
+  initialQuestion,
+}: {
+  initialQuestion?: NotionAmaItemWithContent | null;
+}) {
   const { id } = useParams();
 
   // Fetch the full question with content blocks from the API
-  const { question, isLoading, isError } = useAmaQuestion(id as string);
+  const { question, isLoading, isError } = useAmaQuestion(id as string, initialQuestion);
 
   // Update document title when question is available
   useEffect(() => {

--- a/src/app/ama/AMALayoutClient.tsx
+++ b/src/app/ama/AMALayoutClient.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import React, { useState } from "react";
+
+import { ListDetailLayout } from "@/components/ListDetailLayout";
+import { ListDetailWrapper } from "@/components/ListDetailWrapper";
+import { Button } from "@/components/ui";
+import { type AmaPage, useAmaQuestions } from "@/lib/ama";
+import { cn } from "@/lib/utils";
+
+import { AMAQuestionsProvider } from "./AMAContext";
+import { AmaList } from "./AMAList";
+import { AskQuestionForm } from "./AskQuestionForm";
+
+export function AMALayoutClient({
+  children,
+  initialPage,
+}: {
+  children: React.ReactNode;
+  initialPage?: AmaPage;
+}) {
+  const [showForm, setShowForm] = useState(false);
+
+  const {
+    items: questions,
+    isLoading,
+    isLoadingMore,
+    isReachingEnd,
+    isError,
+    size,
+    setSize,
+  } = useAmaQuestions(initialPage ? [initialPage] : undefined);
+
+  return (
+    <AMAQuestionsProvider
+      questions={questions}
+      isLoading={isLoading ?? false}
+      isLoadingMore={isLoadingMore ?? false}
+      isReachingEnd={isReachingEnd ?? false}
+      isError={isError}
+      size={size}
+      setSize={setSize}
+    >
+      <ListDetailWrapper>
+        <ListDetailLayout
+          backHref="/ama"
+          list={
+            <div className="flex h-full flex-1 flex-col">
+              <div className={cn("flex-col px-3 py-3 md:pb-0")}>
+                <Button onClick={() => setShowForm(!showForm)} variant="secondary" fullWidth>
+                  Ask a question
+                </Button>
+
+                <AnimatePresence initial={false}>
+                  {showForm && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0, scale: 0.98 }}
+                      animate={{ opacity: 1, height: "auto", scale: 1 }}
+                      exit={{ opacity: 0, height: 0, scale: 0.98 }}
+                      className="overflow-hidden"
+                    >
+                      <div className="mt-3 px-0.5">
+                        <AskQuestionForm onComplete={() => setShowForm(false)} autoFocus />
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+
+              <AmaList />
+            </div>
+          }
+        >
+          {children}
+        </ListDetailLayout>
+      </ListDetailWrapper>
+    </AMAQuestionsProvider>
+  );
+}

--- a/src/app/ama/[id]/page.tsx
+++ b/src/app/ama/[id]/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
+import { notFound } from "next/navigation";
 
 import AMADetail from "@/app/ama/AMADetail";
 import { createMetadata, truncateDescription } from "@/lib/metadata";
-import { getAmaItemContent } from "@/lib/notion";
+import { getAmaItemContent, isPlaceholderNotionBuild } from "@/lib/notion";
 
 export async function generateMetadata(props: {
   params: Promise<{ id: string }>;
@@ -33,6 +35,23 @@ export async function generateMetadata(props: {
   }
 }
 
-export default function AMADetailPage() {
-  return <AMADetail />;
+export default async function AMADetailPage(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  return <CachedAmaDetail id={params.id} />;
+}
+
+async function CachedAmaDetail({ id }: { id: string }) {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:ama");
+  if (isPlaceholderNotionBuild()) {
+    notFound();
+  }
+
+  const item = await getAmaItemContent(id);
+  if (!item) {
+    notFound();
+  }
+
+  return <AMADetail initialQuestion={item} />;
 }

--- a/src/app/ama/[id]/page.tsx
+++ b/src/app/ama/[id]/page.tsx
@@ -6,6 +6,8 @@ import AMADetail from "@/app/ama/AMADetail";
 import { createMetadata, truncateDescription } from "@/lib/metadata";
 import { getAmaItemContent, isPlaceholderNotionBuild } from "@/lib/notion";
 
+export const instant = false;
+
 export async function generateMetadata(props: {
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {

--- a/src/app/ama/layout.tsx
+++ b/src/app/ama/layout.tsx
@@ -1,76 +1,22 @@
-"use client";
+import { cacheLife, cacheTag } from "next/cache";
+import type { ReactNode } from "react";
 
-import { AnimatePresence, motion } from "motion/react";
-import React, { Suspense, useState } from "react";
+import { type AmaPage } from "@/lib/ama";
+import { getAmaDatabaseItems, isPlaceholderNotionBuild } from "@/lib/notion";
 
-import { ListDetailLayout } from "@/components/ListDetailLayout";
-import { ListDetailWrapper } from "@/components/ListDetailWrapper";
-import { Button } from "@/components/ui";
-import { useAmaQuestions } from "@/lib/ama";
-import { cn } from "@/lib/utils";
+import { AMALayoutClient } from "./AMALayoutClient";
 
-import { AMAQuestionsProvider } from "./AMAContext";
-import { AmaList } from "./AMAList";
-import { AskQuestionForm } from "./AskQuestionForm";
+export default async function AMALayout({ children }: { children: ReactNode }) {
+  const initialPage = await getCachedAmaFirstPage();
+  return <AMALayoutClient initialPage={initialPage}>{children}</AMALayoutClient>;
+}
 
-export default function AMALayout({ children }: { children: React.ReactNode }) {
-  const [showForm, setShowForm] = useState(false);
-
-  const {
-    items: questions,
-    isLoading,
-    isLoadingMore,
-    isReachingEnd,
-    isError,
-    size,
-    setSize,
-  } = useAmaQuestions();
-
-  return (
-    <AMAQuestionsProvider
-      questions={questions}
-      isLoading={isLoading ?? false}
-      isLoadingMore={isLoadingMore ?? false}
-      isReachingEnd={isReachingEnd ?? false}
-      isError={isError}
-      size={size}
-      setSize={setSize}
-    >
-      <ListDetailWrapper>
-        <ListDetailLayout
-          backHref="/ama"
-          list={
-            <div className="flex h-full flex-1 flex-col">
-              <div className={cn("flex-col px-3 py-3 md:pb-0")}>
-                <Button onClick={() => setShowForm(!showForm)} variant="secondary" fullWidth>
-                  Ask a question
-                </Button>
-
-                <AnimatePresence initial={false}>
-                  {showForm && (
-                    <motion.div
-                      initial={{ opacity: 0, height: 0, scale: 0.98 }}
-                      animate={{ opacity: 1, height: "auto", scale: 1 }}
-                      exit={{ opacity: 0, height: 0, scale: 0.98 }}
-                      className="overflow-hidden"
-                    >
-                      <div className="mt-3 px-0.5">
-                        <AskQuestionForm onComplete={() => setShowForm(false)} autoFocus />
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-
-              <Suspense fallback={<div className="bg-tertiary min-h-48 animate-pulse rounded" />}>
-                <AmaList />
-              </Suspense>
-            </div>
-          }
-        >
-          {children}
-        </ListDetailLayout>
-      </ListDetailWrapper>
-    </AMAQuestionsProvider>
-  );
+async function getCachedAmaFirstPage(): Promise<AmaPage> {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:ama");
+  if (isPlaceholderNotionBuild()) {
+    return { items: [], nextCursor: null };
+  }
+  return getAmaDatabaseItems(undefined, 20);
 }

--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -1,5 +1,5 @@
 import { cachedResponse, errorResponse } from "@/lib/api-utils";
-import { getGoodWebsites, getGoodWebsitesSeed } from "@/lib/goodWebsites";
+import { filterGoodWebsites, getGoodWebsites, getGoodWebsitesSeed } from "@/lib/goodWebsites";
 
 export async function GET(request: Request) {
   try {
@@ -8,12 +8,7 @@ export async function GET(request: Request) {
 
     // Use the same function as the page to get randomized results
     const items = await getGoodWebsites(getGoodWebsitesSeed());
-
-    // Filter items based on query parameters
-    const filteredItems = items.filter((item) => {
-      const tagMatch = tag ? item.tags?.includes(tag) : true;
-      return tagMatch;
-    });
+    const filteredItems = filterGoodWebsites(items, { tag });
 
     // Cache for 5 minutes to match ISR revalidation
     return cachedResponse(filteredItems, 300);

--- a/src/app/api/stacks/route.ts
+++ b/src/app/api/stacks/route.ts
@@ -1,5 +1,6 @@
 import { cachedResponse, errorResponse } from "@/lib/api-utils";
 import { getStackDatabaseItems } from "@/lib/notion";
+import { filterStacks } from "@/lib/stack";
 
 export async function GET(request: Request) {
   try {
@@ -8,14 +9,7 @@ export async function GET(request: Request) {
     const platform = searchParams.get("platform") || "";
 
     const items = await getStackDatabaseItems();
-
-    // Filter items based on query parameters
-    const filteredItems = items.filter((item) => {
-      const itemStatus = item.status?.toLowerCase() || "active";
-      const statusMatch = status === "all" ? true : itemStatus === status;
-      const platformMatch = platform ? item.platforms?.includes(platform) : true;
-      return statusMatch && platformMatch;
-    });
+    const filteredItems = filterStacks(items, { status, platform });
 
     return cachedResponse(filteredItems, 86400); // 24 hour cache
   } catch (error) {

--- a/src/app/app-dissection/[slug]/page.tsx
+++ b/src/app/app-dissection/[slug]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 
 import { createArticleJsonLd, createMetadata, truncateDescription } from "@/lib/metadata";
+import { isPlaceholderNotionBuild } from "@/lib/notion";
 import { getAppDissectionDatabaseItems, getAppDissectionItemBySlug } from "@/lib/notion/queries";
 import { extractPreviewText } from "@/lib/notion/types";
 
@@ -31,18 +32,21 @@ export async function generateMetadata(props: {
   });
 }
 
-export default function AppDissectionPostPage(props: { params: Promise<{ slug: string }> }) {
-  return (
-    <Suspense fallback={<div className="bg-tertiary/30 min-h-full min-w-0 flex-1 animate-pulse" />}>
-      <AppDissectionPostContent params={props.params} />
-    </Suspense>
-  );
+export default async function AppDissectionPostPage(props: { params: Promise<{ slug: string }> }) {
+  const params = await props.params;
+  return <AppDissectionPostContent slug={params.slug} />;
 }
 
-async function AppDissectionPostContent(props: { params: Promise<{ slug: string }> }) {
-  const params = await props.params;
+async function AppDissectionPostContent({ slug }: { slug: string }) {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:app-dissection");
+  if (isPlaceholderNotionBuild()) {
+    notFound();
+  }
+
   const [post, allItems] = await Promise.all([
-    getAppDissectionItemBySlug(params.slug),
+    getAppDissectionItemBySlug(slug),
     getAppDissectionDatabaseItems(),
   ]);
 

--- a/src/app/app-dissection/[slug]/page.tsx
+++ b/src/app/app-dissection/[slug]/page.tsx
@@ -9,6 +9,8 @@ import { extractPreviewText } from "@/lib/notion/types";
 
 import { AppDissectionDetail } from "./components/AppDissectionDetail";
 
+export const instant = false;
+
 export async function generateMetadata(props: {
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {

--- a/src/app/design-details/DesignDetailsLayoutClient.tsx
+++ b/src/app/design-details/DesignDetailsLayoutClient.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React, { useCallback, useMemo } from "react";
+
+import { InfiniteScrollList } from "@/components/InfiniteScrollList";
+import { ListDetailLayout } from "@/components/ListDetailLayout";
+import { ListDetailWrapper } from "@/components/ListDetailWrapper";
+import {
+  type DesignDetailsEpisodePage,
+  useDesignDetailsEpisodes,
+} from "@/hooks/useDesignDetailsEpisodes";
+import { useListNavigation } from "@/hooks/useListNavigation";
+import { cn } from "@/lib/utils";
+
+export function DesignDetailsLayoutClient({
+  children,
+  initialPage,
+}: {
+  children: React.ReactNode;
+  initialPage?: DesignDetailsEpisodePage;
+}) {
+  return (
+    <ListDetailWrapper>
+      <ListDetailLayout backHref="/design-details" list={<EpisodeList initialPage={initialPage} />}>
+        {children}
+      </ListDetailLayout>
+    </ListDetailWrapper>
+  );
+}
+
+function EpisodeList({ initialPage }: { initialPage?: DesignDetailsEpisodePage }) {
+  const pathname = usePathname();
+  const {
+    items: episodes,
+    setSize,
+    size,
+    isReachingEnd,
+    isLoading,
+    isLoadingMore,
+  } = useDesignDetailsEpisodes(initialPage ? [initialPage] : undefined);
+
+  const currentId = pathname.split("/").pop();
+  const currentIndex = useMemo(
+    () => episodes.findIndex((e) => e.id === currentId),
+    [episodes, currentId],
+  );
+
+  useListNavigation(episodes, currentIndex, (item) => `/design-details/${item.id}`);
+
+  const handleLoadMore = useCallback(async () => {
+    await setSize(size + 1);
+  }, [setSize, size]);
+
+  const renderEpisode = useCallback(
+    (ep: (typeof episodes)[0]) => {
+      const isSelected = ep.id === currentId;
+      const date = ep.publishedDate
+        ? new Date(ep.publishedDate).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+          })
+        : undefined;
+
+      return (
+        <li key={ep.id} data-id={ep.id} className="scroll-my-2">
+          <Link
+            className={cn("hover:bg-tertiary flex w-full flex-col rounded-md px-3.5 py-2 text-sm", {
+              "bg-tertiary": isSelected,
+            })}
+            href={`/design-details/${ep.id}`}
+          >
+            <span className="text-primary line-clamp-2">{ep.title}</span>
+            {date && <span className="text-quaternary">{date}</span>}
+          </Link>
+        </li>
+      );
+    },
+    [currentId],
+  );
+
+  return (
+    <InfiniteScrollList
+      items={episodes}
+      renderItem={renderEpisode}
+      onLoadMore={handleLoadMore}
+      isLoading={isLoading || false}
+      isLoadingMore={isLoadingMore || false}
+      isReachingEnd={isReachingEnd || false}
+    />
+  );
+}

--- a/src/app/design-details/[id]/page.tsx
+++ b/src/app/design-details/[id]/page.tsx
@@ -6,6 +6,8 @@ import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
 import { getFullContent, isPlaceholderNotionBuild } from "@/lib/notion";
 
+export const instant = false;
+
 export default async function EpisodePage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
   return <EpisodeContent id={params.id} />;

--- a/src/app/design-details/[id]/page.tsx
+++ b/src/app/design-details/[id]/page.tsx
@@ -1,23 +1,22 @@
+import { cacheLife } from "next/cache";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
-import { getServerLikes, type LikeCount } from "@/lib/likes-server";
-import { getFullContent } from "@/lib/notion";
+import { getFullContent, isPlaceholderNotionBuild } from "@/lib/notion";
 
-export default function EpisodePage(props: { params: Promise<{ id: string }> }) {
-  return (
-    <Suspense fallback={<div className="bg-tertiary/30 min-h-full min-w-0 flex-1 animate-pulse" />}>
-      <EpisodeContent params={props.params} />
-    </Suspense>
-  );
+export default async function EpisodePage(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  return <EpisodeContent id={params.id} />;
 }
 
-async function EpisodeContent(props: { params: Promise<{ id: string }> }) {
-  const params = await props.params;
-  const id = params.id;
+async function EpisodeContent({ id }: { id: string }) {
+  "use cache";
+  cacheLife("days");
+  if (isPlaceholderNotionBuild()) {
+    notFound();
+  }
 
   // Let Notion errors propagate to error.tsx — crawlers should see 5xx (retry)
   // rather than a 404 that could deindex a valid URL during a transient outage.
@@ -28,19 +27,6 @@ async function EpisodeContent(props: { params: Promise<{ id: string }> }) {
   }
 
   const { blocks, metadata } = content;
-
-  // Likes are non-essential — if the fetch fails, render zero counts instead
-  // of crashing the whole page. The client-side BatchLikesProvider will
-  // refresh the real count after hydration.
-  let initialLikes: Record<string, LikeCount>;
-  try {
-    initialLikes = await getServerLikes([metadata.id]);
-  } catch (err) {
-    console.error(`[design-details] getServerLikes failed for ${metadata.id}:`, err);
-    initialLikes = {
-      [metadata.id]: { count: 0 },
-    };
-  }
 
   const date = new Date(metadata.published || metadata.createdTime).toLocaleDateString("en-US", {
     month: "long",
@@ -53,7 +39,7 @@ async function EpisodeContent(props: { params: Promise<{ id: string }> }) {
       <div className="flex flex-col gap-1">
         <h1 className="text-primary text-2xl font-semibold">{metadata.title}</h1>
         <span className="text-quaternary text-sm">{date}</span>
-        <BatchLikesProvider pageIds={[metadata.id]} initialData={initialLikes}>
+        <BatchLikesProvider pageIds={[metadata.id]}>
           <LikeButton
             pageId={metadata.id}
             title={metadata.title}

--- a/src/app/design-details/layout.tsx
+++ b/src/app/design-details/layout.tsx
@@ -1,91 +1,23 @@
-"use client";
+import { cacheLife } from "next/cache";
+import type { ReactNode } from "react";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import React, { Suspense, useCallback, useMemo } from "react";
+import type { DesignDetailsEpisodePage } from "@/lib/design-details";
+import { getDesignDetailsEpisodeDatabaseItems, isPlaceholderNotionBuild } from "@/lib/notion";
 
-import { InfiniteScrollList } from "@/components/InfiniteScrollList";
-import { ListDetailLayout } from "@/components/ListDetailLayout";
-import { ListDetailWrapper } from "@/components/ListDetailWrapper";
-import { useDesignDetailsEpisodes } from "@/hooks/useDesignDetailsEpisodes";
-import { useListNavigation } from "@/hooks/useListNavigation";
-import { cn } from "@/lib/utils";
+import { DesignDetailsLayoutClient } from "./DesignDetailsLayoutClient";
 
-export default function DesignDetailsLayout({ children }: { children: React.ReactNode }) {
+export default async function DesignDetailsLayout({ children }: { children: ReactNode }) {
+  const initialPage = await getCachedDesignDetailsFirstPage();
   return (
-    <ListDetailWrapper>
-      <ListDetailLayout
-        backHref="/design-details"
-        list={
-          <Suspense fallback={<div className="bg-tertiary min-h-48 animate-pulse rounded" />}>
-            <EpisodeList />
-          </Suspense>
-        }
-      >
-        {children}
-      </ListDetailLayout>
-    </ListDetailWrapper>
+    <DesignDetailsLayoutClient initialPage={initialPage}>{children}</DesignDetailsLayoutClient>
   );
 }
 
-function EpisodeList() {
-  const pathname = usePathname();
-  const {
-    items: episodes,
-    setSize,
-    size,
-    isReachingEnd,
-    isLoading,
-    isLoadingMore,
-  } = useDesignDetailsEpisodes();
-
-  const currentId = pathname.split("/").pop();
-  const currentIndex = useMemo(
-    () => episodes.findIndex((e) => e.id === currentId),
-    [episodes, currentId],
-  );
-
-  useListNavigation(episodes, currentIndex, (item) => `/design-details/${item.id}`);
-
-  const handleLoadMore = useCallback(async () => {
-    await setSize(size + 1);
-  }, [setSize, size]);
-
-  const renderEpisode = useCallback(
-    (ep: (typeof episodes)[0]) => {
-      const isSelected = ep.id === currentId;
-      const date = ep.publishedDate
-        ? new Date(ep.publishedDate).toLocaleDateString("en-US", {
-            month: "short",
-            day: "numeric",
-          })
-        : undefined;
-
-      return (
-        <li key={ep.id} data-id={ep.id} className="scroll-my-2">
-          <Link
-            className={cn("hover:bg-tertiary flex w-full flex-col rounded-md px-3.5 py-2 text-sm", {
-              "bg-tertiary": isSelected,
-            })}
-            href={`/design-details/${ep.id}`}
-          >
-            <span className="text-primary line-clamp-2">{ep.title}</span>
-            {date && <span className="text-quaternary">{date}</span>}
-          </Link>
-        </li>
-      );
-    },
-    [currentId],
-  );
-
-  return (
-    <InfiniteScrollList
-      items={episodes}
-      renderItem={renderEpisode}
-      onLoadMore={handleLoadMore}
-      isLoading={isLoading || false}
-      isLoadingMore={isLoadingMore || false}
-      isReachingEnd={isReachingEnd || false}
-    />
-  );
+async function getCachedDesignDetailsFirstPage(): Promise<DesignDetailsEpisodePage> {
+  "use cache";
+  cacheLife("days");
+  if (isPlaceholderNotionBuild()) {
+    return { items: [], nextCursor: null };
+  }
+  return getDesignDetailsEpisodeDatabaseItems(undefined, 20);
 }

--- a/src/app/hn/HNLayoutClient.tsx
+++ b/src/app/hn/HNLayoutClient.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React, { useMemo } from "react";
+
+import { ListDetailLayout } from "@/components/ListDetailLayout";
+import { ListDetailWrapper } from "@/components/ListDetailWrapper";
+import { useListNavigation } from "@/hooks/useListNavigation";
+import { useHNPosts } from "@/lib/hooks/useHn";
+import { cn } from "@/lib/utils";
+import { HackerNewsPost } from "@/types/hackernews";
+
+import { LoadingSpinner } from "../../components/ui/LoadingSpinner";
+import { HNPostsProvider, useHNPostsContext } from "./HNPostsContext";
+
+const EMPTY_HN_POSTS: HackerNewsPost[] = [];
+
+export function HNLayoutClient({
+  children,
+  initialPosts,
+}: {
+  children: React.ReactNode;
+  initialPosts?: HackerNewsPost[];
+}) {
+  const { data: posts, isLoading, isError } = useHNPosts(initialPosts);
+
+  return (
+    <HNPostsProvider posts={posts} isLoading={isLoading} isError={isError}>
+      <ListDetailWrapper>
+        <ListDetailLayout backHref="/hn" list={<HNStoriesList />}>
+          {children}
+        </ListDetailLayout>
+      </ListDetailWrapper>
+    </HNPostsProvider>
+  );
+}
+
+function HNStoriesList() {
+  const pathname = usePathname();
+  const { posts, isLoading, isError } = useHNPostsContext();
+  const validPosts = posts ?? EMPTY_HN_POSTS;
+
+  // Get current post ID from URL and find its index
+  const currentPostId = pathname.split("/").pop();
+  const currentIndex = useMemo(
+    () => validPosts.findIndex((post) => post.id.toString() === currentPostId),
+    [validPosts, currentPostId],
+  );
+
+  useListNavigation(validPosts, currentIndex, (item) => `/hn/${item.id}`);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full flex-1 items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || (validPosts.length === 0 && !isLoading)) {
+    return (
+      <div className="text-quaternary flex flex-1 items-center justify-center">
+        Unable to load stories
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-0.5 md:p-3">
+      {validPosts.map((post) => {
+        const isSelected = post.id.toString() === currentPostId;
+        return (
+          <li key={post.id} data-id={post.id} className="scroll-my-3">
+            <Link
+              className={cn(
+                "hover:bg-tertiary border-secondary dark:hover:bg-secondary dark:hover:shadow-contrast flex flex-col gap-0.5 border-b px-3.5 py-3 md:rounded-lg md:border-b-0",
+                {
+                  "bg-tertiary dark:bg-secondary dark:shadow-contrast": isSelected,
+                },
+              )}
+              href={`/hn/${post.id}`}
+            >
+              <span className="text-primary line-clamp-2 font-medium">{post.title}</span>
+              {post.domain && <span className="text-quaternary">{post.domain}</span>}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/app/hn/[id]/page.tsx
+++ b/src/app/hn/[id]/page.tsx
@@ -7,6 +7,8 @@ import { stripHtmlTags } from "@/lib/utils";
 
 import HNPostPageClient from "./HNPostPageClient";
 
+export const instant = false;
+
 export async function generateMetadata(props: {
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {

--- a/src/app/hn/[id]/page.tsx
+++ b/src/app/hn/[id]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
+import { cacheLife, cacheTag } from "next/cache";
 
 import { getPostById } from "@/lib/hn";
 import { createMetadata, truncateDescription } from "@/lib/metadata";
@@ -45,17 +45,15 @@ export async function generateMetadata(props: {
   }
 }
 
-export default function HNPostPage(props: { params: Promise<{ id: string }> }) {
-  return (
-    <Suspense fallback={<div className="bg-tertiary/30 min-h-full min-w-0 flex-1 animate-pulse" />}>
-      <HNPostContent params={props.params} />
-    </Suspense>
-  );
+export default async function HNPostPage(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  return <HNPostContent id={params.id} />;
 }
 
-async function HNPostContent(props: { params: Promise<{ id: string }> }) {
-  const params = await props.params;
-  const id = params.id;
+async function HNPostContent({ id }: { id: string }) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("hn:post");
 
   // Fetch post with comments on server - React cache() deduplicates with generateMetadata
   const post = await getPostById(id, true);

--- a/src/app/hn/layout.tsx
+++ b/src/app/hn/layout.tsx
@@ -1,93 +1,23 @@
-"use client";
+import { cacheLife, cacheTag } from "next/cache";
+import type { ReactNode } from "react";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import React, { Suspense, useMemo } from "react";
-
-import { ListDetailLayout } from "@/components/ListDetailLayout";
-import { ListDetailWrapper } from "@/components/ListDetailWrapper";
-import { useListNavigation } from "@/hooks/useListNavigation";
-import { useHNPosts } from "@/lib/hooks/useHn";
-import { cn } from "@/lib/utils";
+import { getRankedHNPosts } from "@/lib/hn";
 import { HackerNewsPost } from "@/types/hackernews";
 
-import { LoadingSpinner } from "../../components/ui/LoadingSpinner";
-import { HNPostsProvider, useHNPostsContext } from "./HNPostsContext";
+import { HNLayoutClient } from "./HNLayoutClient";
 
-const EMPTY_HN_POSTS: HackerNewsPost[] = [];
-
-export default function HNLayout({ children }: { children: React.ReactNode }) {
-  const { data: posts, isLoading, isError } = useHNPosts();
-
-  return (
-    <HNPostsProvider posts={posts} isLoading={isLoading} isError={isError}>
-      <ListDetailWrapper>
-        <ListDetailLayout
-          backHref="/hn"
-          list={
-            <Suspense fallback={<div className="bg-tertiary min-h-48 animate-pulse rounded" />}>
-              <HNStoriesList />
-            </Suspense>
-          }
-        >
-          {children}
-        </ListDetailLayout>
-      </ListDetailWrapper>
-    </HNPostsProvider>
-  );
+export default async function HNLayout({ children }: { children: ReactNode }) {
+  const initialPosts = await getCachedRankedHNPosts();
+  return <HNLayoutClient initialPosts={initialPosts}>{children}</HNLayoutClient>;
 }
 
-function HNStoriesList() {
-  const pathname = usePathname();
-  const { posts, isLoading, isError } = useHNPostsContext();
-  const validPosts = posts ?? EMPTY_HN_POSTS;
-
-  // Get current post ID from URL and find its index
-  const currentPostId = pathname.split("/").pop();
-  const currentIndex = useMemo(
-    () => validPosts.findIndex((post) => post.id.toString() === currentPostId),
-    [validPosts, currentPostId],
-  );
-
-  useListNavigation(validPosts, currentIndex, (item) => `/hn/${item.id}`);
-
-  if (isLoading) {
-    return (
-      <div className="flex h-full flex-1 items-center justify-center">
-        <LoadingSpinner />
-      </div>
-    );
+async function getCachedRankedHNPosts(): Promise<HackerNewsPost[]> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("hn:ranked");
+  try {
+    return await getRankedHNPosts();
+  } catch {
+    return [];
   }
-
-  if (isError || (validPosts.length === 0 && !isLoading)) {
-    return (
-      <div className="text-quaternary flex flex-1 items-center justify-center">
-        Unable to load stories
-      </div>
-    );
-  }
-
-  return (
-    <ul className="flex flex-col gap-0.5 md:p-3">
-      {validPosts.map((post) => {
-        const isSelected = post.id.toString() === currentPostId;
-        return (
-          <li key={post.id} data-id={post.id} className="scroll-my-3">
-            <Link
-              className={cn(
-                "hover:bg-tertiary border-secondary dark:hover:bg-secondary dark:hover:shadow-contrast flex flex-col gap-0.5 border-b px-3.5 py-3 md:rounded-lg md:border-b-0",
-                {
-                  "bg-tertiary dark:bg-secondary dark:shadow-contrast": isSelected,
-                },
-              )}
-              href={`/hn/${post.id}`}
-            >
-              <span className="text-primary line-clamp-2 font-medium">{post.title}</span>
-              {post.domain && <span className="text-quaternary">{post.domain}</span>}
-            </Link>
-          </li>
-        );
-      })}
-    </ul>
-  );
 }

--- a/src/app/sites/page.tsx
+++ b/src/app/sites/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
+import { cacheLife, cacheTag } from "next/cache";
 
 import { GoodWebsitesPageClient } from "@/components/good-websites/GoodWebsitesPageClient";
 import { getGoodWebsites, getGoodWebsitesSeed } from "@/lib/goodWebsites";
-import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
+import { isPlaceholderNotionBuild } from "@/lib/notion";
 
 export const metadata: Metadata = {
   ...createMetadata({
@@ -19,52 +19,17 @@ export const metadata: Metadata = {
   },
 };
 
-export default function GoodWebsitesPage(props: { searchParams: Promise<{ tag?: string }> }) {
-  return (
-    <Suspense fallback={<GoodWebsitesFallback />}>
-      <GoodWebsitesContent searchParams={props.searchParams} />
-    </Suspense>
-  );
+export default function GoodWebsitesPage() {
+  return <GoodWebsitesContent />;
 }
 
-function GoodWebsitesFallback() {
-  return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="border-secondary flex items-center justify-between border-b p-4 md:hidden">
-        <div className="bg-tertiary h-9 w-20 animate-pulse rounded" />
-        <div className="bg-tertiary h-9 w-24 animate-pulse rounded" />
-      </div>
-      <div className="flex-1 overflow-hidden">
-        <div className="bg-secondary border-secondary hidden h-10 border-b md:block" />
-        <div className="divide-secondary divide-y">
-          {Array.from({ length: 12 }, (_, index) => (
-            <div key={index} className="flex h-[73px] items-center gap-4 px-4 md:h-[57px]">
-              <div className="bg-tertiary h-4 w-1/3 animate-pulse rounded" />
-              <div className="bg-tertiary h-4 w-1/4 animate-pulse rounded" />
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
+async function GoodWebsitesContent() {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:good-websites");
+  const allWebsites = isPlaceholderNotionBuild()
+    ? []
+    : await getGoodWebsites(getGoodWebsitesSeed());
 
-async function GoodWebsitesContent({ searchParams }: { searchParams: Promise<{ tag?: string }> }) {
-  const params = await searchParams;
-  const tag = params.tag || "";
-
-  // Fetch initial data on the server
-  const allWebsites = await getGoodWebsites(getGoodWebsitesSeed());
-
-  // Apply filters server-side to match what the API would return
-  const filteredWebsites = allWebsites.filter((item) => {
-    const tagMatch = tag ? item.tags?.includes(tag) : true;
-    return tagMatch;
-  });
-
-  // Fetch likes for all items server-side
-  const pageIds = filteredWebsites.map((item) => item.id);
-  const initialLikes = await getServerLikes(pageIds);
-
-  return <GoodWebsitesPageClient initialData={filteredWebsites} initialLikes={initialLikes} />;
+  return <GoodWebsitesPageClient initialData={allWebsites} />;
 }

--- a/src/app/stack/page.tsx
+++ b/src/app/stack/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
+import { cacheLife, cacheTag } from "next/cache";
 
 import { StackPageClient } from "@/components/stack/StackPageClient";
-import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
+import { isPlaceholderNotionBuild } from "@/lib/notion";
 import { getStacks } from "@/lib/stack";
 
 export const metadata: Metadata = {
@@ -20,61 +20,15 @@ export const metadata: Metadata = {
   },
 };
 
-export default function StackPage(props: {
-  searchParams: Promise<{ platform?: string; status?: string }>;
-}) {
-  return (
-    <Suspense fallback={<StackFallback />}>
-      <StackContent searchParams={props.searchParams} />
-    </Suspense>
-  );
+export default function StackPage() {
+  return <StackContent />;
 }
 
-function StackFallback() {
-  return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="border-secondary flex h-16 items-center border-b p-4 md:hidden">
-        <div className="bg-tertiary h-8 w-28 animate-pulse rounded" />
-      </div>
-      <div className="flex-1 overflow-hidden">
-        <div className="bg-secondary border-secondary hidden h-10 border-b md:block" />
-        <div className="divide-secondary divide-y">
-          {Array.from({ length: 12 }, (_, index) => (
-            <div key={index} className="flex h-12 items-center gap-4 px-4">
-              <div className="bg-tertiary h-4 w-1/4 animate-pulse rounded" />
-              <div className="bg-tertiary h-4 w-1/3 animate-pulse rounded" />
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
+async function StackContent() {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:stack");
+  const allStacks = isPlaceholderNotionBuild() ? [] : await getStacks();
 
-async function StackContent({
-  searchParams,
-}: {
-  searchParams: Promise<{ status?: string; platform?: string }>;
-}) {
-  const params = await searchParams;
-  const status = params.status || "active";
-  const platform = params.platform || "";
-
-  // Fetch initial data on the server
-  const allStacks = await getStacks();
-
-  // Apply filters server-side to match what the API would return
-  const filteredStacks = allStacks.filter((item) => {
-    const itemStatus = item.status?.toLowerCase() || "active";
-    const statusMatch = status === "all" ? true : itemStatus === status;
-    const platformMatch = platform ? item.platforms?.includes(platform) : true;
-
-    return statusMatch && platformMatch;
-  });
-
-  // Fetch likes for all items server-side
-  const pageIds = filteredStacks.map((item) => item.id);
-  const initialLikes = await getServerLikes(pageIds);
-
-  return <StackPageClient initialData={filteredStacks} initialLikes={initialLikes} />;
+  return <StackPageClient initialData={allStacks} />;
 }

--- a/src/app/til/[slug]/page.tsx
+++ b/src/app/til/[slug]/page.tsx
@@ -10,6 +10,8 @@ import { createArticleJsonLd, createMetadata, truncateDescription } from "@/lib/
 import { getTilByShortId, isPlaceholderNotionBuild } from "@/lib/notion";
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 
+export const instant = false;
+
 // Generate metadata for each TIL entry
 export async function generateMetadata(props: {
   params: Promise<{ slug: string }>;

--- a/src/app/til/[slug]/page.tsx
+++ b/src/app/til/[slug]/page.tsx
@@ -1,14 +1,13 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
 import { PageTitle } from "@/components/Typography";
-import { getServerLikes } from "@/lib/likes-server";
 import { createArticleJsonLd, createMetadata, truncateDescription } from "@/lib/metadata";
-import { getTilByShortId } from "@/lib/notion";
+import { getTilByShortId, isPlaceholderNotionBuild } from "@/lib/notion";
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 
 // Generate metadata for each TIL entry
@@ -39,17 +38,18 @@ export async function generateMetadata(props: {
   });
 }
 
-export default function TilEntryPage(props: { params: Promise<{ slug: string }> }) {
-  return (
-    <Suspense fallback={<div className="bg-tertiary/30 min-h-full min-w-0 flex-1 animate-pulse" />}>
-      <TilEntryContent params={props.params} />
-    </Suspense>
-  );
+export default async function TilEntryPage(props: { params: Promise<{ slug: string }> }) {
+  const params = await props.params;
+  return <TilEntryContent slug={params.slug} />;
 }
 
-async function TilEntryContent(props: { params: Promise<{ slug: string }> }) {
-  const params = await props.params;
-  const slug = params.slug;
+async function TilEntryContent({ slug }: { slug: string }) {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:til");
+  if (isPlaceholderNotionBuild()) {
+    notFound();
+  }
 
   const shortId = extractShortIdFromSlug(slug);
   if (!shortId) {
@@ -62,9 +62,6 @@ async function TilEntryContent(props: { params: Promise<{ slug: string }> }) {
   }
 
   const canonicalSlug = content.shortId ? buildSlug(content.title, content.shortId) : slug;
-
-  // Fetch likes server-side
-  const initialLikes = await getServerLikes([content.id]);
 
   const cleanDate = new Date(content.published).toLocaleDateString("en-US", {
     month: "long",
@@ -96,7 +93,7 @@ async function TilEntryContent(props: { params: Promise<{ slug: string }> }) {
           <div className="notion-blocks flex min-w-0 flex-col gap-4 text-lg">
             {renderBlocks(content.blocks)}
           </div>
-          <BatchLikesProvider pageIds={[content.id]} initialData={initialLikes}>
+          <BatchLikesProvider pageIds={[content.id]}>
             <div className="w-fit">
               <LikeButton
                 pageId={content.id}

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import { notFound, redirect } from "next/navigation";
-import { Suspense } from "react";
 
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
@@ -8,9 +8,12 @@ import { renderBlocks } from "@/components/renderBlocks";
 import { List, ListItem, ListItemLabel } from "@/components/shared/ListComponents";
 import { PageTitle } from "@/components/Typography";
 import { FancySeparator } from "@/components/ui/FancySeparator";
-import { getServerLikes } from "@/lib/likes-server";
 import { createArticleJsonLd, createMetadata, truncateDescription } from "@/lib/metadata";
-import { getWritingPostByShortId, getWritingPostContentBySlug } from "@/lib/notion";
+import {
+  getWritingPostByShortId,
+  getWritingPostContentBySlug,
+  isPlaceholderNotionBuild,
+} from "@/lib/notion";
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 import { getAllWritingPosts } from "@/lib/writing";
 
@@ -58,36 +61,18 @@ function getRandomPosts<T>(posts: T[], count: number): T[] {
   return shuffled.slice(0, count);
 }
 
-export default function WritingPostPage(props: { params: Promise<{ slug: string }> }) {
-  return (
-    <Suspense fallback={<WritingPostFallback />}>
-      <WritingPostContent params={props.params} />
-    </Suspense>
-  );
-}
-
-function WritingPostFallback() {
-  return (
-    <div className="min-w-0 flex-1">
-      <div className="mx-auto flex max-w-3xl flex-1 flex-col gap-8 px-4 py-12 md:px-6 lg:px-8 lg:py-16 xl:py-20">
-        <div className="flex flex-col gap-6">
-          <div className="bg-tertiary h-4 w-24 animate-pulse rounded" />
-          <div className="bg-tertiary h-10 w-2/3 animate-pulse rounded" />
-          <div className="bg-tertiary h-8 w-16 animate-pulse rounded" />
-        </div>
-        <div className="flex flex-col gap-4">
-          {Array.from({ length: 8 }, (_, index) => (
-            <div key={index} className="bg-tertiary h-5 w-full animate-pulse rounded" />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-async function WritingPostContent(props: { params: Promise<{ slug: string }> }) {
+export default async function WritingPostPage(props: { params: Promise<{ slug: string }> }) {
   const params = await props.params;
-  const slug = params.slug;
+  return <WritingPostContent slug={params.slug} />;
+}
+
+async function WritingPostContent({ slug }: { slug: string }) {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:writing");
+  if (isPlaceholderNotionBuild()) {
+    notFound();
+  }
 
   // Try to extract Short ID from the URL
   const shortId = extractShortIdFromSlug(slug);
@@ -113,11 +98,7 @@ async function WritingPostContent(props: { params: Promise<{ slug: string }> }) 
   // Use canonical slug for all URLs
   const canonicalSlug = metadata.shortId ? buildSlug(metadata.title, metadata.shortId) : slug;
 
-  // Fetch likes and related posts in parallel
-  const [initialLikes, allPosts] = await Promise.all([
-    getServerLikes([metadata.id]),
-    getAllWritingPosts(),
-  ]);
+  const allPosts = await getAllWritingPosts();
 
   // Get 5 random posts (excluding current post)
   const otherPosts = allPosts.filter((post) => post.shortId && post.shortId !== metadata.shortId);
@@ -153,7 +134,7 @@ async function WritingPostContent(props: { params: Promise<{ slug: string }> }) 
           <div className="flex flex-col gap-6">
             <p className="text-tertiary">{cleanDate}</p>
             <PageTitle>{metadata.title}</PageTitle>
-            <BatchLikesProvider pageIds={[metadata.id]} initialData={initialLikes}>
+            <BatchLikesProvider pageIds={[metadata.id]}>
               <div className="w-fit">
                 <LikeButton
                   pageId={metadata.id}

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -17,6 +17,8 @@ import {
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 import { getAllWritingPosts } from "@/lib/writing";
 
+export const instant = false;
+
 // Generate metadata for each writing post
 export async function generateMetadata(props: {
   params: Promise<{ slug: string }>;

--- a/src/components/good-websites/GoodWebsitesFilters.tsx
+++ b/src/components/good-websites/GoodWebsitesFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/Select";
@@ -14,13 +14,13 @@ const TAGS = [
 
 interface GoodWebsitesFiltersProps {
   isLoading?: boolean;
+  tag?: string;
 }
 
-export function GoodWebsitesFilters({ isLoading }: GoodWebsitesFiltersProps) {
+export function GoodWebsitesFilters({ isLoading, tag = "" }: GoodWebsitesFiltersProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
 
-  const urlTag = searchParams.get("tag") || "all";
+  const urlTag = tag || "all";
   const [currentTag, setCurrentTag] = useState(urlTag);
 
   // Sync local state with URL params (for back/forward navigation)
@@ -28,12 +28,10 @@ export function GoodWebsitesFilters({ isLoading }: GoodWebsitesFiltersProps) {
     setCurrentTag(urlTag);
   }, [urlTag]);
 
-  const updateParam = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
+  const pushTag = (value: string) => {
+    const params = new URLSearchParams();
     if (value && value !== "all") {
-      params.set(key, value);
-    } else {
-      params.delete(key);
+      params.set("tag", value);
     }
     const query = params.toString();
     router.push(`/sites${query ? `?${query}` : ""}`);
@@ -43,8 +41,7 @@ export function GoodWebsitesFilters({ isLoading }: GoodWebsitesFiltersProps) {
     if (value === null) return;
     // Update local state immediately for instant UI feedback
     setCurrentTag(value);
-    // Then update URL which triggers data refetch
-    updateParam("tag", value);
+    pushTag(value);
   };
 
   const currentTagLabel =
@@ -56,9 +53,9 @@ export function GoodWebsitesFilters({ isLoading }: GoodWebsitesFiltersProps) {
         <SelectTrigger>{currentTagLabel}</SelectTrigger>
         <SelectContent>
           <SelectItem value="all">All</SelectItem>
-          {TAGS.map((tag) => (
-            <SelectItem key={tag.value} value={tag.value}>
-              {tag.label}
+          {TAGS.map((tagOption) => (
+            <SelectItem key={tagOption.value} value={tagOption.value}>
+              {tagOption.label}
             </SelectItem>
           ))}
         </SelectContent>

--- a/src/components/good-websites/GoodWebsitesPageClient.tsx
+++ b/src/components/good-websites/GoodWebsitesPageClient.tsx
@@ -2,7 +2,8 @@
 
 import { useAtom } from "jotai";
 import Image from "next/image";
-import { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useMemo, useState } from "react";
 
 import {
   getNextTableSort,
@@ -31,10 +32,31 @@ interface GoodWebsitesPageClientProps {
   initialLikes?: Record<string, LikeCount>;
 }
 
+interface GoodWebsitesPageBodyProps extends GoodWebsitesPageClientProps {
+  tag?: string;
+}
+
 const textCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
-export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsitesPageClientProps) {
-  const { goodWebsites, isInitialLoading, isValidating, isError } = useGoodWebsites(initialData);
+export function GoodWebsitesPageClient(props: GoodWebsitesPageClientProps) {
+  return (
+    <Suspense fallback={<GoodWebsitesPageBody {...props} />}>
+      <GoodWebsitesPageFromSearchParams {...props} />
+    </Suspense>
+  );
+}
+
+function GoodWebsitesPageFromSearchParams(props: GoodWebsitesPageClientProps) {
+  const searchParams = useSearchParams();
+
+  return <GoodWebsitesPageBody {...props} tag={searchParams.get("tag") || ""} />;
+}
+
+function GoodWebsitesPageBody({ initialData, initialLikes, tag = "" }: GoodWebsitesPageBodyProps) {
+  const { goodWebsites, isInitialLoading, isValidating, isError } = useGoodWebsites(
+    initialData,
+    tag,
+  );
   const [viewMode, setViewMode] = useAtom(sitesViewModeAtom);
   const [tableSort, setTableSort] = useAtom(sitesTableSortAtom);
 
@@ -72,10 +94,10 @@ export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsit
     () => (
       <span className="hidden items-center gap-3 md:flex">
         <ViewToggle view={viewMode} onChange={setViewMode} />
-        <GoodWebsitesFilters />
+        <GoodWebsitesFilters tag={tag} />
       </span>
     ),
-    [viewMode, setViewMode],
+    [viewMode, setViewMode, tag],
   );
   useTopBarActions(topBarContent);
 
@@ -107,7 +129,7 @@ export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsit
             {/* Filters - mobile only */}
             <div className="border-secondary flex items-center justify-between border-b p-4 md:hidden">
               <ViewToggle view={viewMode} onChange={setViewMode} />
-              <GoodWebsitesFilters isLoading={isValidating && !isInitialLoading} />
+              <GoodWebsitesFilters isLoading={isValidating && !isInitialLoading} tag={tag} />
             </div>
 
             {/* Content */}

--- a/src/components/good-websites/GoodWebsitesPageClient.tsx
+++ b/src/components/good-websites/GoodWebsitesPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useAtom } from "jotai";
 import Image from "next/image";
-import { useMemo, useState, useSyncExternalStore } from "react";
+import { useMemo, useState } from "react";
 
 import {
   getNextTableSort,
@@ -31,17 +31,12 @@ interface GoodWebsitesPageClientProps {
   initialLikes?: Record<string, LikeCount>;
 }
 
-// Hydration check using useSyncExternalStore to avoid layout flicker
-const subscribe = () => () => {};
-const getSnapshot = () => true;
-const getServerSnapshot = () => false;
 const textCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
 export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsitesPageClientProps) {
   const { goodWebsites, isInitialLoading, isValidating, isError } = useGoodWebsites(initialData);
   const [viewMode, setViewMode] = useAtom(sitesViewModeAtom);
   const [tableSort, setTableSort] = useAtom(sitesTableSortAtom);
-  const isHydrated = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   // Collect all page IDs for batch likes fetching
   const pageIds = useMemo(() => goodWebsites.map((item) => item.id), [goodWebsites]);
@@ -84,9 +79,7 @@ export function GoodWebsitesPageClient({ initialData, initialLikes }: GoodWebsit
   );
   useTopBarActions(topBarContent);
 
-  // Wait for hydration to avoid layout flicker from view mode preference
-  // Also show loading on initial data load (without fallback data)
-  if (!isHydrated || (isInitialLoading && goodWebsites.length === 0)) {
+  if (isInitialLoading && goodWebsites.length === 0) {
     return (
       <ListDetailWrapper>
         <div className="flex h-full flex-1 items-center justify-center">

--- a/src/components/home/SpeakingList.tsx
+++ b/src/components/home/SpeakingList.tsx
@@ -1,3 +1,6 @@
+import { cacheLife } from "next/cache";
+
+import { isPlaceholderNotionBuild } from "@/lib/notion";
 import { getSpeakingItems } from "@/lib/notion/queries";
 
 import { List, ListItem, ListItemLabel, ListItemSubLabel } from "../shared/ListComponents";
@@ -19,7 +22,9 @@ function formatSpeakingDate(isoDate: string): string {
 }
 
 export async function SpeakingList() {
-  const speakingItems = await getSpeakingItems();
+  "use cache";
+  cacheLife("days");
+  const speakingItems = isPlaceholderNotionBuild() ? [] : await getSpeakingItems();
 
   return (
     <List>

--- a/src/components/stack/StackFilters.tsx
+++ b/src/components/stack/StackFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/Select";
@@ -16,33 +16,31 @@ const STATUS_OPTIONS = [
 
 interface StackFiltersProps {
   isLoading?: boolean;
+  status?: string;
+  platform?: string;
 }
 
-export function StackFilters({ isLoading }: StackFiltersProps) {
+export function StackFilters({ isLoading, status = "active", platform = "" }: StackFiltersProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
 
-  const urlStatus = searchParams.get("status") || "active";
-  const urlPlatform = searchParams.get("platform") || "all-platforms";
-
-  const [currentStatus, setCurrentStatus] = useState(urlStatus);
+  const urlPlatform = platform || "all-platforms";
+  const [currentStatus, setCurrentStatus] = useState(status);
   const [currentPlatform, setCurrentPlatform] = useState(urlPlatform);
 
   // Sync local state with URL params (for back/forward navigation)
   useEffect(() => {
-    setCurrentStatus(urlStatus);
-  }, [urlStatus]);
+    setCurrentStatus(status);
+  }, [status]);
 
   useEffect(() => {
     setCurrentPlatform(urlPlatform);
   }, [urlPlatform]);
 
-  const updateParam = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (value && value !== "all-platforms") {
-      params.set(key, value);
-    } else {
-      params.delete(key);
+  const pushFilters = (nextStatus: string, nextPlatform: string) => {
+    const params = new URLSearchParams();
+    if (nextStatus) params.set("status", nextStatus);
+    if (nextPlatform && nextPlatform !== "all-platforms") {
+      params.set("platform", nextPlatform);
     }
     const query = params.toString();
     router.push(`/stack${query ? `?${query}` : ""}`);
@@ -52,16 +50,14 @@ export function StackFilters({ isLoading }: StackFiltersProps) {
     if (value === null) return;
     // Update local state immediately for instant UI feedback
     setCurrentStatus(value);
-    // Then update URL which triggers data refetch
-    updateParam("status", value);
+    pushFilters(value, currentPlatform);
   };
 
   const handlePlatformChange = (value: string | null) => {
     if (value === null) return;
     // Update local state immediately for instant UI feedback
     setCurrentPlatform(value);
-    // Then update URL which triggers data refetch
-    updateParam("platform", value);
+    pushFilters(currentStatus, value);
   };
 
   const currentStatusLabel = STATUS_OPTIONS.find((opt) => opt.value === currentStatus)?.label;

--- a/src/components/stack/StackPageClient.tsx
+++ b/src/components/stack/StackPageClient.tsx
@@ -3,7 +3,7 @@
 import { useAtom } from "jotai";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 
 import {
   getNextTableSort,
@@ -28,18 +28,51 @@ interface StackPageClientProps {
   initialLikes?: Record<string, LikeCount>;
 }
 
+interface StackPageBodyProps extends StackPageClientProps {
+  status?: string;
+  platform?: string;
+}
+
 const textCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
-export function StackPageClient({ initialData, initialLikes }: StackPageClientProps) {
-  const { stacks, isInitialLoading, isValidating, isError } = useStacks(initialData);
-  const [tableSort, setTableSort] = useAtom(stackTableSortAtom);
-  const router = useRouter();
+export function StackPageClient(props: StackPageClientProps) {
+  return (
+    <Suspense fallback={<StackPageBody {...props} />}>
+      <StackPageFromSearchParams {...props} />
+    </Suspense>
+  );
+}
+
+function StackPageFromSearchParams(props: StackPageClientProps) {
   const searchParams = useSearchParams();
 
-  const handlePlatformFilter = (platform: string, e: React.MouseEvent) => {
+  return (
+    <StackPageBody
+      {...props}
+      status={searchParams.get("status") || "active"}
+      platform={searchParams.get("platform") || ""}
+    />
+  );
+}
+
+function StackPageBody({
+  initialData,
+  initialLikes,
+  status = "active",
+  platform = "",
+}: StackPageBodyProps) {
+  const { stacks, isInitialLoading, isValidating, isError } = useStacks(initialData, {
+    status,
+    platform,
+  });
+  const [tableSort, setTableSort] = useAtom(stackTableSortAtom);
+  const router = useRouter();
+
+  const handlePlatformFilter = (nextPlatform: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("platform", platform);
+    const params = new URLSearchParams();
+    if (status) params.set("status", status);
+    params.set("platform", nextPlatform);
     router.push(`/stack?${params.toString()}`);
   };
 
@@ -85,10 +118,10 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
   const topBarContent = useMemo(
     () => (
       <span className="hidden md:block">
-        <StackFilters />
+        <StackFilters status={status} platform={platform} />
       </span>
     ),
-    [],
+    [status, platform],
   );
   useTopBarActions(topBarContent);
 
@@ -119,7 +152,11 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
           <div className="flex flex-1 flex-col overflow-hidden">
             {/* Filters */}
             <div className="border-secondary flex border-b p-4 md:hidden">
-              <StackFilters isLoading={isValidating && !isInitialLoading} />
+              <StackFilters
+                isLoading={isValidating && !isInitialLoading}
+                status={status}
+                platform={platform}
+              />
             </div>
 
             {/* Table */}

--- a/src/components/stack/StackPageClient.tsx
+++ b/src/components/stack/StackPageClient.tsx
@@ -3,7 +3,7 @@
 import { useAtom } from "jotai";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useState, useSyncExternalStore } from "react";
+import { useMemo, useState } from "react";
 
 import {
   getNextTableSort,
@@ -28,9 +28,6 @@ interface StackPageClientProps {
   initialLikes?: Record<string, LikeCount>;
 }
 
-const subscribe = () => () => {};
-const getSnapshot = () => true;
-const getServerSnapshot = () => false;
 const textCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
 export function StackPageClient({ initialData, initialLikes }: StackPageClientProps) {
@@ -38,7 +35,6 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
   const [tableSort, setTableSort] = useAtom(stackTableSortAtom);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const isHydrated = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   const handlePlatformFilter = (platform: string, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -96,7 +92,7 @@ export function StackPageClient({ initialData, initialLikes }: StackPageClientPr
   );
   useTopBarActions(topBarContent);
 
-  if (!isHydrated || (isInitialLoading && stacks.length === 0)) {
+  if (isInitialLoading && stacks.length === 0) {
     return (
       <ListDetailWrapper>
         <div className="flex h-full flex-1 items-center justify-center">

--- a/src/hooks/useDesignDetailsEpisodes.ts
+++ b/src/hooks/useDesignDetailsEpisodes.ts
@@ -8,12 +8,13 @@ export type { DesignDetailsEpisode };
 
 export type DesignDetailsEpisodePage = InfiniteScrollPage<DesignDetailsEpisode>;
 
-export function useDesignDetailsEpisodes() {
+export function useDesignDetailsEpisodes(fallbackData?: DesignDetailsEpisodePage[]) {
   return useInfiniteScroll<DesignDetailsEpisode>(
     (index: number, previousPage: DesignDetailsEpisodePage | null) => {
       if (previousPage && !previousPage.nextCursor) return null;
       if (index === 0) return `/api/design-details?limit=20`;
       return `/api/design-details?cursor=${previousPage?.nextCursor}&limit=20`;
     },
+    { fallbackData },
   );
 }

--- a/src/lib/ama.test.ts
+++ b/src/lib/ama.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { type AmaQuestion, amaQuestionLinks } from "@/lib/ama";
+
+function question(
+  overrides: Partial<AmaQuestion> & Pick<AmaQuestion, "id" | "title">,
+): AmaQuestion {
+  return {
+    description: null,
+    status: "answered",
+    answeredAt: "2026-08-01",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("amaQuestionLinks", () => {
+  test("lists question titles and hrefs", () => {
+    expect(
+      amaQuestionLinks([
+        question({ id: "abc", title: "How do you cache Notion lists?" }),
+        question({ id: "def", title: "What about likes?" }),
+      ]),
+    ).toEqual([
+      { id: "abc", title: "How do you cache Notion lists?", href: "/ama/abc" },
+      { id: "def", title: "What about likes?", href: "/ama/def" },
+    ]);
+  });
+});

--- a/src/lib/ama.ts
+++ b/src/lib/ama.ts
@@ -20,17 +20,28 @@ export const getAmaQuestions = cache(fetchAllAmaQuestions);
 
 export type AmaPage = InfiniteScrollPage<AmaQuestion>;
 
-export function useAmaQuestions() {
-  return useInfiniteScroll<AmaQuestion>((index: number, previousPage: AmaPage | null) => {
-    // If we've reached the end, don't fetch more
-    if (previousPage && !previousPage.nextCursor) return null;
+export function amaQuestionLinks(items: AmaQuestion[]) {
+  return items.map((item) => ({
+    id: item.id,
+    title: item.title,
+    href: `/ama/${item.id}`,
+  }));
+}
 
-    // For the first page, just fetch with limit
-    if (index === 0) return `/api/ama?limit=20`;
+export function useAmaQuestions(fallbackData?: AmaPage[]) {
+  return useInfiniteScroll<AmaQuestion>(
+    (index: number, previousPage: AmaPage | null) => {
+      // If we've reached the end, don't fetch more
+      if (previousPage && !previousPage.nextCursor) return null;
 
-    // For subsequent pages, use the cursor from the previous page
-    return `/api/ama?cursor=${previousPage?.nextCursor}&limit=20`;
-  });
+      // For the first page, just fetch with limit
+      if (index === 0) return `/api/ama?limit=20`;
+
+      // For subsequent pages, use the cursor from the previous page
+      return `/api/ama?cursor=${previousPage?.nextCursor}&limit=20`;
+    },
+    { fallbackData },
+  );
 }
 
 export async function submitAmaQuestion(title: string) {

--- a/src/lib/design-details.test.ts
+++ b/src/lib/design-details.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { type DesignDetailsEpisode, designDetailsEpisodeLinks } from "@/lib/design-details";
+
+function episode(
+  overrides: Partial<DesignDetailsEpisode> & Pick<DesignDetailsEpisode, "id" | "title">,
+): DesignDetailsEpisode {
+  return {
+    slug: overrides.slug ?? overrides.id,
+    ...overrides,
+  };
+}
+
+describe("designDetailsEpisodeLinks", () => {
+  test("lists episode titles and hrefs", () => {
+    expect(
+      designDetailsEpisodeLinks([
+        episode({ id: "ep-1", title: "101: Designing at Notion", slug: "101" }),
+        episode({ id: "ep-2", title: "102: Cache busting", slug: "102" }),
+      ]),
+    ).toEqual([
+      { id: "ep-1", title: "101: Designing at Notion", href: "/design-details/ep-1" },
+      { id: "ep-2", title: "102: Cache busting", href: "/design-details/ep-2" },
+    ]);
+  });
+});

--- a/src/lib/design-details.ts
+++ b/src/lib/design-details.ts
@@ -27,3 +27,11 @@ export async function getDesignDetailsEpisodeById(
   const episodes = await getDesignDetailsEpisodes();
   return episodes.find((e) => e.id === id);
 }
+
+export function designDetailsEpisodeLinks(items: DesignDetailsEpisode[]) {
+  return items.map((item) => ({
+    id: item.id,
+    title: item.title,
+    href: `/design-details/${item.id}`,
+  }));
+}

--- a/src/lib/goodWebsites.test.ts
+++ b/src/lib/goodWebsites.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { filterGoodWebsites, type GoodWebsiteItem, goodWebsiteLinks } from "@/lib/goodWebsites";
+
+function site(
+  overrides: Partial<GoodWebsiteItem> & Pick<GoodWebsiteItem, "id" | "name">,
+): GoodWebsiteItem {
+  return {
+    ...overrides,
+  };
+}
+
+describe("filterGoodWebsites", () => {
+  const items = [
+    site({
+      id: "1",
+      name: "Paco Coursey",
+      url: "https://paco.me",
+      tags: ["Personal site"],
+    }),
+    site({
+      id: "2",
+      name: "Linear",
+      url: "https://linear.app",
+      tags: ["Company"],
+    }),
+    site({
+      id: "3",
+      name: "Untitled",
+    }),
+  ];
+
+  test("lists every titled site href when no tag is set", () => {
+    expect(goodWebsiteLinks(filterGoodWebsites(items))).toEqual([
+      { id: "1", title: "Paco Coursey", href: "https://paco.me" },
+      { id: "2", title: "Linear", href: "https://linear.app" },
+    ]);
+  });
+
+  test("filters by tag and keeps the matching href", () => {
+    expect(goodWebsiteLinks(filterGoodWebsites(items, { tag: "Company" }))).toEqual([
+      { id: "2", title: "Linear", href: "https://linear.app" },
+    ]);
+  });
+});

--- a/src/lib/goodWebsites.ts
+++ b/src/lib/goodWebsites.ts
@@ -42,3 +42,13 @@ export async function getGoodWebsites(seed: number): Promise<GoodWebsiteItem[]> 
 export async function getGoodWebsitesForRss(): Promise<GoodWebsiteItemWithDate[]> {
   return getGoodWebsitesDatabaseItemsForRss();
 }
+
+export function filterGoodWebsites(items: GoodWebsiteItem[], { tag = "" }: { tag?: string } = {}) {
+  return items.filter((item) => (tag ? item.tags?.includes(tag) : true));
+}
+
+export function goodWebsiteLinks(items: GoodWebsiteItem[]) {
+  return items.flatMap((item) =>
+    item.url ? [{ id: item.id, title: item.name, href: item.url }] : [],
+  );
+}

--- a/src/lib/hn.test.ts
+++ b/src/lib/hn.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-import { processPost, selectHNPostsForDigest } from "@/lib/hn";
+import { hnPostLinks, processPost, selectHNPostsForDigest } from "@/lib/hn";
 import { HackerNewsComment, HackerNewsPost } from "@/types/hackernews";
 
 function makePost(overrides: Partial<HackerNewsPost> = {}): HackerNewsPost {
@@ -120,6 +120,14 @@ describe("selectHNPostsForDigest", () => {
     ];
 
     expect(selectHNPostsForDigest(posts, now).map((post) => post.id)).toEqual([2, 1]);
+  });
+});
+
+describe("hnPostLinks", () => {
+  test("lists story titles and hrefs", () => {
+    expect(hnPostLinks([makePost({ id: 42, title: "Show HN: Cache" })])).toEqual([
+      { id: 42, title: "Show HN: Cache", href: "/hn/42" },
+    ]);
   });
 });
 

--- a/src/lib/hn.ts
+++ b/src/lib/hn.ts
@@ -233,6 +233,14 @@ export const getRankedHNPosts = unstable_cache(
   { revalidate: HN_REVALIDATE, tags: ["hn:ranked"] },
 );
 
+export function hnPostLinks(posts: HackerNewsPost[]) {
+  return posts.map((post) => ({
+    id: post.id,
+    title: post.title,
+    href: `/hn/${post.id}`,
+  }));
+}
+
 const DIGEST_WINDOW_SECONDS = 60 * 60 * 24;
 const DIGEST_POST_LIMIT = 16;
 

--- a/src/lib/hooks/useGoodWebsites.ts
+++ b/src/lib/hooks/useGoodWebsites.ts
@@ -1,16 +1,12 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import useSWR from "swr";
 
 import { fetcher } from "@/lib/fetcher";
 import { filterGoodWebsites, type GoodWebsiteItem } from "@/lib/goodWebsites";
 
-export function useGoodWebsites(fallbackData?: GoodWebsiteItem[]) {
-  const searchParams = useSearchParams();
-  const tag = searchParams.get("tag") || "";
-
+export function useGoodWebsites(fallbackData?: GoodWebsiteItem[], tag = "") {
   const filteredFallback = useMemo(
     () => (fallbackData ? filterGoodWebsites(fallbackData, { tag }) : undefined),
     [fallbackData, tag],

--- a/src/lib/hooks/useGoodWebsites.ts
+++ b/src/lib/hooks/useGoodWebsites.ts
@@ -1,15 +1,20 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
 import useSWR from "swr";
 
 import { fetcher } from "@/lib/fetcher";
-
-import type { GoodWebsiteItem } from "../goodWebsites";
+import { filterGoodWebsites, type GoodWebsiteItem } from "@/lib/goodWebsites";
 
 export function useGoodWebsites(fallbackData?: GoodWebsiteItem[]) {
   const searchParams = useSearchParams();
   const tag = searchParams.get("tag") || "";
+
+  const filteredFallback = useMemo(
+    () => (fallbackData ? filterGoodWebsites(fallbackData, { tag }) : undefined),
+    [fallbackData, tag],
+  );
 
   // Build query string for API
   const params = new URLSearchParams();
@@ -22,16 +27,16 @@ export function useGoodWebsites(fallbackData?: GoodWebsiteItem[]) {
     // Keep previous data while revalidating to enable optimistic updates
     keepPreviousData: true,
     // Use server-provided fallback data for instant initial render
-    fallbackData,
+    fallbackData: filteredFallback,
   });
 
   return {
-    goodWebsites: data || fallbackData || [],
+    goodWebsites: data || filteredFallback || [],
     isLoading,
     isValidating,
     isError: error,
     mutate,
     // Helper to determine if this is initial loading vs filter change
-    isInitialLoading: isLoading && !data && !fallbackData,
+    isInitialLoading: isLoading && !data && !filteredFallback,
   };
 }

--- a/src/lib/hooks/useStacks.ts
+++ b/src/lib/hooks/useStacks.ts
@@ -1,16 +1,21 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
 import useSWR from "swr";
 
 import { fetcher } from "@/lib/fetcher";
-
-import type { StackItem } from "../stack";
+import { filterStacks, type StackItem } from "@/lib/stack";
 
 export function useStacks(fallbackData?: StackItem[]) {
   const searchParams = useSearchParams();
   const status = searchParams.get("status") || "active";
   const platform = searchParams.get("platform") || "";
+
+  const filteredFallback = useMemo(
+    () => (fallbackData ? filterStacks(fallbackData, { status, platform }) : undefined),
+    [fallbackData, status, platform],
+  );
 
   // Build query string for API
   const params = new URLSearchParams();
@@ -24,16 +29,16 @@ export function useStacks(fallbackData?: StackItem[]) {
     // Keep previous data while revalidating to enable optimistic updates
     keepPreviousData: true,
     // Use server-provided fallback data for instant initial render
-    fallbackData,
+    fallbackData: filteredFallback,
   });
 
   return {
-    stacks: data || fallbackData || [],
+    stacks: data || filteredFallback || [],
     isLoading,
     isValidating,
     isError: error,
     mutate,
     // Helper to determine if this is initial loading vs filter change
-    isInitialLoading: isLoading && !data && !fallbackData,
+    isInitialLoading: isLoading && !data && !filteredFallback,
   };
 }

--- a/src/lib/hooks/useStacks.ts
+++ b/src/lib/hooks/useStacks.ts
@@ -1,16 +1,14 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import useSWR from "swr";
 
 import { fetcher } from "@/lib/fetcher";
-import { filterStacks, type StackItem } from "@/lib/stack";
+import { filterStacks, type StackFilters, type StackItem } from "@/lib/stack";
 
-export function useStacks(fallbackData?: StackItem[]) {
-  const searchParams = useSearchParams();
-  const status = searchParams.get("status") || "active";
-  const platform = searchParams.get("platform") || "";
+export function useStacks(fallbackData?: StackItem[], filters: StackFilters = {}) {
+  const status = filters.status || "active";
+  const platform = filters.platform || "";
 
   const filteredFallback = useMemo(
     () => (fallbackData ? filterStacks(fallbackData, { status, platform }) : undefined),

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -166,20 +166,36 @@ describe("webhook callers", () => {
 });
 
 describe("use cache page islands", () => {
-  test("stack and sites subscribe to the exact tags purge-cache already busts", () => {
+  test("every PURGE_CONFIG type has page islands subscribed to those exact tags", () => {
     const pagesDir = join(import.meta.dir, "../../app");
-    const islands = {
-      stack: join(pagesDir, "stack/page.tsx"),
-      sites: join(pagesDir, "sites/page.tsx"),
-    } as const;
+    const islands: Record<(typeof PURGEABLE_CONTENT_TYPES)[number], string[]> = {
+      writing: ["page.tsx", "writing/page.tsx", "writing/[slug]/page.tsx"],
+      til: ["til/page.tsx", "til/[slug]/page.tsx"],
+      ama: ["ama/layout.tsx", "ama/[id]/page.tsx"],
+      stack: ["stack/page.tsx"],
+      sites: ["sites/page.tsx"],
+      hn: ["hn/layout.tsx", "hn/[id]/page.tsx"],
+    };
 
-    for (const [type, path] of Object.entries(islands)) {
-      const source = readFileSync(path, "utf8");
-      const tags = [...source.matchAll(/cacheTag\("([^"]+)"\)/g)].map((match) => match[1]);
+    for (const type of PURGEABLE_CONTENT_TYPES) {
+      const subscribed = new Set<string>();
 
-      expect(source.includes('"use cache"')).toBe(true);
-      expect(tags.length).toBeGreaterThan(0);
-      expect(tags).toEqual(PURGE_CONFIG[type as keyof typeof islands].tags);
+      for (const relativePath of islands[type]) {
+        const source = readFileSync(join(pagesDir, relativePath), "utf8");
+        const tags = [...source.matchAll(/cacheTag\("([^"]+)"\)/g)].map((match) => match[1]);
+        expect(source.includes('"use cache"')).toBe(true);
+        expect(tags.length).toBeGreaterThan(0);
+        for (const tag of tags) {
+          expect(PURGE_CONFIG[type].tags).toContain(tag);
+          subscribed.add(tag);
+        }
+      }
+
+      if (type === "hn") {
+        expect([...subscribed].sort()).toEqual(["hn:post", "hn:ranked"]);
+      } else {
+        expect([...subscribed]).toEqual(PURGE_CONFIG[type].tags);
+      }
     }
   });
 });

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -164,3 +164,22 @@ describe("webhook callers", () => {
     expect(source.includes("purge")).toBe(false);
   });
 });
+
+describe("use cache page islands", () => {
+  test("stack and sites subscribe to the exact tags purge-cache already busts", () => {
+    const pagesDir = join(import.meta.dir, "../../app");
+    const islands = {
+      stack: join(pagesDir, "stack/page.tsx"),
+      sites: join(pagesDir, "sites/page.tsx"),
+    } as const;
+
+    for (const [type, path] of Object.entries(islands)) {
+      const source = readFileSync(path, "utf8");
+      const tags = [...source.matchAll(/cacheTag\("([^"]+)"\)/g)].map((match) => match[1]);
+
+      expect(source.includes('"use cache"')).toBe(true);
+      expect(tags.length).toBeGreaterThan(0);
+      expect(tags).toEqual(PURGE_CONFIG[type as keyof typeof islands].tags);
+    }
+  });
+});

--- a/src/lib/stack.test.ts
+++ b/src/lib/stack.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { filterStacks, type StackItem, stackItemLinks } from "@/lib/stack";
+
+function item(overrides: Partial<StackItem> & Pick<StackItem, "id" | "name">): StackItem {
+  return {
+    slug: overrides.slug ?? overrides.name.toLowerCase().replace(/\s+/g, "-"),
+    createdTime: "2026-08-01T00:00:00.000Z",
+    status: "active",
+    ...overrides,
+  };
+}
+
+describe("filterStacks", () => {
+  const items = [
+    item({
+      id: "1",
+      name: "Cursor",
+      url: "https://cursor.com",
+      status: "active",
+      platforms: ["macOS", "Web"],
+    }),
+    item({
+      id: "2",
+      name: "Things",
+      url: "https://culturedcode.com/things",
+      status: "active",
+      platforms: ["macOS", "iOS"],
+    }),
+    item({
+      id: "3",
+      name: "Old App",
+      url: "https://example.com/old",
+      status: "inactive",
+      platforms: ["Windows"],
+    }),
+  ];
+
+  test("defaults to active items and keeps titles and hrefs", () => {
+    expect(stackItemLinks(filterStacks(items))).toEqual([
+      { id: "1", title: "Cursor", href: "https://cursor.com" },
+      { id: "2", title: "Things", href: "https://culturedcode.com/things" },
+    ]);
+  });
+
+  test("can list every item including archived", () => {
+    expect(stackItemLinks(filterStacks(items, { status: "all" }))).toEqual([
+      { id: "1", title: "Cursor", href: "https://cursor.com" },
+      { id: "2", title: "Things", href: "https://culturedcode.com/things" },
+      { id: "3", title: "Old App", href: "https://example.com/old" },
+    ]);
+  });
+
+  test("filters by platform without dropping the matching href", () => {
+    expect(stackItemLinks(filterStacks(items, { platform: "iOS" }))).toEqual([
+      { id: "2", title: "Things", href: "https://culturedcode.com/things" },
+    ]);
+  });
+});

--- a/src/lib/stack.ts
+++ b/src/lib/stack.ts
@@ -2,6 +2,11 @@ import { getStackDatabaseItems, type NotionStackItem } from "@/lib/notion";
 
 export type StackItem = NotionStackItem;
 
+export type StackFilters = {
+  status?: string;
+  platform?: string;
+};
+
 export async function getStacks(): Promise<StackItem[]> {
   return getStackDatabaseItems();
 }
@@ -9,4 +14,23 @@ export async function getStacks(): Promise<StackItem[]> {
 export async function getStackBySlug(slug: string): Promise<StackItem | undefined> {
   const items = await getStackDatabaseItems();
   return items.find((item) => item.slug === slug);
+}
+
+export function filterStacks(
+  items: StackItem[],
+  { status = "active", platform = "" }: StackFilters = {},
+): StackItem[] {
+  return items.filter((item) => {
+    const itemStatus = item.status?.toLowerCase() || "active";
+    const statusMatch = status === "all" ? true : itemStatus === status;
+    const platformMatch = platform ? item.platforms?.includes(platform) : true;
+
+    return statusMatch && platformMatch;
+  });
+}
+
+export function stackItemLinks(items: StackItem[]) {
+  return items.flatMap((item) =>
+    item.url ? [{ id: item.id, title: item.name, href: item.url }] : [],
+  );
 }

--- a/src/lib/til.test.ts
+++ b/src/lib/til.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { NotionTilItem, NotionTilItemWithContent, ProcessedBlock } from "@/lib/notion";
-import { hydrateTilEntries, type TilEntry } from "@/lib/til";
+import { hydrateTilEntries, type TilEntry, tilEntryLink } from "@/lib/til";
 
 function item(id: string, title = id): NotionTilItem {
   return { id, title, published: "2026-01-01" };
@@ -67,5 +67,19 @@ describe("hydrateTilEntries", () => {
       published: "2026-08-15",
       shortId: "abc1234",
     });
+  });
+});
+
+describe("tilEntryLink", () => {
+  test("builds the canonical title and href", () => {
+    expect(tilEntryLink({ id: "1", title: "Cache tags must match", shortId: "abc1234" })).toEqual({
+      id: "1",
+      title: "Cache tags must match",
+      href: "/til/cache-tags-must-match-abc1234",
+    });
+  });
+
+  test("omits entries with no short id", () => {
+    expect(tilEntryLink({ id: "1", title: "Draft" })).toBeNull();
   });
 });

--- a/src/lib/til.ts
+++ b/src/lib/til.ts
@@ -7,6 +7,7 @@ import {
   NotionTilItemWithContent,
   ProcessedBlock,
 } from "@/lib/notion";
+import { buildSlug } from "@/lib/short-id";
 
 export type TilEntry = NotionTilItem & { blocks?: ProcessedBlock[] };
 
@@ -56,3 +57,12 @@ async function fetchAllTilEntries(): Promise<NotionTilItem[]> {
 }
 
 export const getAllTilEntries = cache(fetchAllTilEntries);
+
+export function tilEntryLink(entry: Pick<NotionTilItem, "id" | "title" | "shortId">) {
+  if (!entry.shortId) return null;
+  return {
+    id: entry.id,
+    title: entry.title,
+    href: `/til/${buildSlug(entry.title, entry.shortId)}`,
+  };
+}

--- a/src/lib/writing.test.ts
+++ b/src/lib/writing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { NotionWritingItem } from "@/lib/notion";
-import { recentWritingLinks } from "@/lib/writing";
+import { recentWritingLinks, writingPostLink } from "@/lib/writing";
 
 function post(overrides: Partial<NotionWritingItem> & Pick<NotionWritingItem, "id" | "title">) {
   return {
@@ -43,5 +43,17 @@ describe("recentWritingLinks", () => {
     ]);
 
     expect(links).toEqual([{ id: "2", title: "Published", href: "/writing/published-abc1234" }]);
+  });
+});
+
+describe("writingPostLink", () => {
+  test("builds the canonical title and href", () => {
+    expect(
+      writingPostLink(post({ id: "1", title: "How I'm Feeling About AI", shortId: "O7e1TFS" })),
+    ).toEqual({
+      id: "1",
+      title: "How I'm Feeling About AI",
+      href: "/writing/how-im-feeling-about-ai-O7e1TFS",
+    });
   });
 });

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -32,6 +32,15 @@ async function fetchAllWritingPosts(): Promise<NotionWritingItem[]> {
 // Request-level dedup: prevents duplicate calls within a single render
 export const getAllWritingPosts = cache(fetchAllWritingPosts);
 
+export function writingPostLink(post: Pick<NotionWritingItem, "id" | "title" | "shortId">) {
+  if (!post.shortId) return null;
+  return {
+    id: post.id,
+    title: post.title,
+    href: `/writing/${buildSlug(post.title, post.shortId)}`,
+  };
+}
+
 export function recentWritingLinks(posts: NotionWritingItem[]) {
   return posts
     .slice(0, 5)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same cache-flash system as [#2337](https://github.com/brianlovin/briOS/pull/2337), now applied consistently across the long-lived Notion and HN pages — not only `/stack` and `/sites`.

Those lists and detail pages still wrapped the content in Suspense, then waited on `searchParams`, `getServerLikes`, or a client fetch. That makes the first paint a skeleton even when the data is already cached and purged by the Notion `/api/purge-cache` buttons.

`/activity`, `/activity/sandbox`, and the HN digest cron stay dynamic.

## The system

Long-lived data is fetched in a `use cache` island with `cacheLife("days")` for Notion and `cacheLife("hours")` for HN / listening. `cacheTag(...)` is always an existing `PURGE_CONFIG` string so Notion buttons still drop Redis + the Next payload:

- writing → `notion:writing` (home, `/writing`, `/writing/[slug]`)
- til → `notion:til` (`/til`, `/til/[slug]`)
- ama → `notion:ama` (list layout + `/ama/[id]`)
- stack → `notion:stack`
- sites → `notion:good-websites`
- hn → `hn:ranked` (list) and `hn:post` (detail)

No page-level pulse skeletons around those islands. Filters and likes stay a client overlay. Detail `[slug]` / `[id]` routes use `instant = false` so awaiting `params` does not force a skeleton; a warm cache still puts the title in the first HTML.

## Also cached, no PURGE_CONFIG type

These have no purge-cache button today. I did not invent a new type or tag:

- `/about` speaking list — `use cache` + `cacheLife("days")` only
- `/design-details` list + `/design-details/[id]` — same
- `/app-dissection` index already used `notion:app-dissection` on main (2337); the detail page now uses that same existing tag. Still not a purge-cache type.
- `/listening` already used `notion:listening` on main (2337)

`type=all` and the per-type Notion buttons keep busting Redis, the listed tags, and paths.

Behavior tests cover titles/hrefs and that every `PURGE_CONFIG` type has page islands subscribed to those exact tag strings.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8b7c0ba-1968-46f4-9061-c346f187b8b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8b7c0ba-1968-46f4-9061-c346f187b8b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

