### PR TITLE
Restore first-paint like counts without list skeletons

### DIFF
--- a/src/app/ama/[id]/page.tsx
+++ b/src/app/ama/[id]/page.tsx
@@ -3,8 +3,14 @@ import { cacheLife, cacheTag } from "next/cache";
 import { notFound } from "next/navigation";
 
 import AMADetail from "@/app/ama/AMADetail";
+import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
+import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, truncateDescription } from "@/lib/metadata";
-import { getAmaItemContent, isPlaceholderNotionBuild } from "@/lib/notion";
+import {
+  getAmaItemContent,
+  isPlaceholderNotionBuild,
+  type NotionAmaItemWithContent,
+} from "@/lib/notion";
 
 export const instant = false;
 
@@ -39,10 +45,17 @@ export async function generateMetadata(props: {
 
 export default async function AMADetailPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
-  return <CachedAmaDetail id={params.id} />;
+  const item = await getCachedAmaDetail(params.id);
+  const initialLikes = await getServerLikes([item.id]);
+
+  return (
+    <BatchLikesProvider pageIds={[item.id]} initialData={initialLikes}>
+      <AMADetail initialQuestion={item} />
+    </BatchLikesProvider>
+  );
 }
 
-async function CachedAmaDetail({ id }: { id: string }) {
+async function getCachedAmaDetail(id: string): Promise<NotionAmaItemWithContent> {
   "use cache";
   cacheLife("days");
   cacheTag("notion:ama");
@@ -55,5 +68,5 @@ async function CachedAmaDetail({ id }: { id: string }) {
     notFound();
   }
 
-  return <AMADetail initialQuestion={item} />;
+  return item;
 }

--- a/src/app/api/likes/[id]/route.test.ts
+++ b/src/app/api/likes/[id]/route.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const revalidateTag = mock(() => {});
+
+mock.module("next/cache", () => ({
+  revalidateTag,
+}));
+
+const addLike = mock(async () => 507);
+const removeLike = mock(async () => ({ count: 506, userLikes: 0 }));
+const getUserLikeCount = mock(async () => 0);
+const checkRateLimit = mock(async () => false);
+const getMaxLikesPerUser = mock(() => 16);
+const getLikeCount = mock(async () => 506);
+
+mock.module("@/lib/likes-redis", () => ({
+  addLike,
+  removeLike,
+  getUserLikeCount,
+  checkRateLimit,
+  getMaxLikesPerUser,
+  getLikeCount,
+}));
+
+mock.module("@/lib/activity-redis", () => ({
+  getActivityStore: () => null,
+}));
+
+import { DELETE, GET, POST } from "@/app/api/likes/[id]/route";
+import { LIKES_SERVER_CACHE_TAG } from "@/lib/likes-constants";
+
+function likesRequest(method: string, id = "page-1", body?: unknown) {
+  return new Request(`https://brianlovin.com/api/likes/${id}`, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      "x-forwarded-for": "1.2.3.4",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const params = { params: Promise.resolve({ id: "page-1" }) };
+
+describe("POST/DELETE /api/likes/[id]", () => {
+  afterEach(() => {
+    revalidateTag.mockClear();
+    addLike.mockClear();
+    removeLike.mockClear();
+    getUserLikeCount.mockClear();
+    checkRateLimit.mockClear();
+  });
+
+  test("POST revalidates the likes:server snapshot after a successful write", async () => {
+    getUserLikeCount.mockResolvedValueOnce(0);
+    const res = await POST(
+      likesRequest("POST", "page-1", { title: "Cursor", href: "/stack", content_type: "stack" }),
+      params,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 507, userLikes: 1 });
+    expect(addLike).toHaveBeenCalledTimes(1);
+    expect(revalidateTag).toHaveBeenCalledTimes(1);
+    expect(revalidateTag).toHaveBeenCalledWith(LIKES_SERVER_CACHE_TAG, "max");
+  });
+
+  test("DELETE revalidates the likes:server snapshot after a successful write", async () => {
+    getUserLikeCount.mockResolvedValueOnce(1);
+    const res = await DELETE(likesRequest("DELETE"), params);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 506, userLikes: 0 });
+    expect(removeLike).toHaveBeenCalledTimes(1);
+    expect(revalidateTag).toHaveBeenCalledTimes(1);
+    expect(revalidateTag).toHaveBeenCalledWith(LIKES_SERVER_CACHE_TAG, "max");
+  });
+
+  test("does not revalidate when the write is rejected", async () => {
+    checkRateLimit.mockResolvedValueOnce(true);
+    const limited = await POST(
+      likesRequest("POST", "page-1", { title: "Cursor", href: "/stack", content_type: "stack" }),
+      params,
+    );
+    expect(limited.status).toBe(429);
+    expect(addLike).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+
+    getUserLikeCount.mockResolvedValueOnce(0);
+    const nothingToRemove = await DELETE(likesRequest("DELETE"), params);
+    expect(nothingToRemove.status).toBe(400);
+    expect(removeLike).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  test("GET does not revalidate likes:server", async () => {
+    const res = await GET(likesRequest("GET"), params);
+    expect(res.status).toBe(200);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/likes/[id]/route.ts
+++ b/src/app/api/likes/[id]/route.ts
@@ -1,9 +1,11 @@
+import { revalidateTag } from "next/cache";
 import { after, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { getRequestGeo, likeMetaFromRequest, recordLike } from "@/lib/activity";
 import { getActivityStore } from "@/lib/activity-redis";
 import { errorResponse } from "@/lib/api-utils";
+import { LIKES_SERVER_CACHE_TAG } from "@/lib/likes-constants";
 import {
   addLike,
   checkRateLimit,
@@ -13,6 +15,10 @@ import {
   removeLike,
 } from "@/lib/likes-redis";
 import { getClientIp, hashUserIp } from "@/lib/user-hash";
+
+function bustLikesServerSnapshot() {
+  revalidateTag(LIKES_SERVER_CACHE_TAG, "max");
+}
 
 const paramsSchema = z.object({
   id: z.string().min(1).max(50),
@@ -70,6 +76,7 @@ export async function POST(request: Request, props: { params: Promise<{ id: stri
 
     // Add the like
     const newCount = await addLike(userId, id);
+    bustLikesServerSnapshot();
 
     let body: { title?: string; href?: string; content_type?: string } = {};
     try {
@@ -130,6 +137,7 @@ export async function DELETE(request: Request, props: { params: Promise<{ id: st
 
     // Remove the like
     const { count: newCount, userLikes: newUserLikes } = await removeLike(userId, id);
+    bustLikesServerSnapshot();
 
     return NextResponse.json({
       count: newCount,

--- a/src/app/design-details/[id]/page.tsx
+++ b/src/app/design-details/[id]/page.tsx
@@ -4,16 +4,37 @@ import { notFound } from "next/navigation";
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
-import { getFullContent, isPlaceholderNotionBuild } from "@/lib/notion";
+import { getServerLikes, type LikeCount } from "@/lib/likes-server";
+import {
+  getFullContent,
+  isPlaceholderNotionBuild,
+  type NotionItem,
+  type ProcessedBlock,
+} from "@/lib/notion";
 
 export const instant = false;
 
+type CachedEpisode = {
+  blocks: ProcessedBlock[];
+  metadata: NotionItem;
+  date: string;
+  id: string;
+};
+
 export default async function EpisodePage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
-  return <EpisodeContent id={params.id} />;
+  const episode = await getCachedEpisode(params.id);
+  let initialLikes: Record<string, LikeCount> = {};
+  try {
+    initialLikes = await getServerLikes([episode.metadata.id]);
+  } catch (err) {
+    console.error(`[design-details] getServerLikes failed for ${episode.metadata.id}:`, err);
+  }
+
+  return <EpisodeView episode={episode} initialLikes={initialLikes} />;
 }
 
-async function EpisodeContent({ id }: { id: string }) {
+async function getCachedEpisode(id: string): Promise<CachedEpisode> {
   "use cache";
   cacheLife("days");
   if (isPlaceholderNotionBuild()) {
@@ -36,12 +57,24 @@ async function EpisodeContent({ id }: { id: string }) {
     year: "numeric",
   });
 
+  return { blocks, metadata, date, id };
+}
+
+function EpisodeView({
+  episode,
+  initialLikes,
+}: {
+  episode: CachedEpisode;
+  initialLikes: Record<string, LikeCount>;
+}) {
+  const { blocks, metadata, date, id } = episode;
+
   return (
     <div className="flex max-w-2xl flex-col gap-6 p-4 md:p-8">
       <div className="flex flex-col gap-1">
         <h1 className="text-primary text-2xl font-semibold">{metadata.title}</h1>
         <span className="text-quaternary text-sm">{date}</span>
-        <BatchLikesProvider pageIds={[metadata.id]}>
+        <BatchLikesProvider pageIds={[metadata.id]} initialData={initialLikes}>
           <LikeButton
             pageId={metadata.id}
             title={metadata.title}

--- a/src/app/sites/page.tsx
+++ b/src/app/sites/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { GoodWebsitesPageClient } from "@/components/good-websites/GoodWebsitesPageClient";
-import { getGoodWebsites, getGoodWebsitesSeed } from "@/lib/goodWebsites";
+import { getGoodWebsites, getGoodWebsitesSeed, type GoodWebsiteItem } from "@/lib/goodWebsites";
+import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
 import { isPlaceholderNotionBuild } from "@/lib/notion";
 
@@ -19,17 +20,16 @@ export const metadata: Metadata = {
   },
 };
 
-export default function GoodWebsitesPage() {
-  return <GoodWebsitesContent />;
+export default async function GoodWebsitesPage() {
+  const allWebsites = await getCachedGoodWebsites();
+  const initialLikes = await getServerLikes(allWebsites.map((item) => item.id));
+
+  return <GoodWebsitesPageClient initialData={allWebsites} initialLikes={initialLikes} />;
 }
 
-async function GoodWebsitesContent() {
+async function getCachedGoodWebsites(): Promise<GoodWebsiteItem[]> {
   "use cache";
   cacheLife("days");
   cacheTag("notion:good-websites");
-  const allWebsites = isPlaceholderNotionBuild()
-    ? []
-    : await getGoodWebsites(getGoodWebsitesSeed());
-
-  return <GoodWebsitesPageClient initialData={allWebsites} />;
+  return isPlaceholderNotionBuild() ? [] : await getGoodWebsites(getGoodWebsitesSeed());
 }

--- a/src/app/stack/page.tsx
+++ b/src/app/stack/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { StackPageClient } from "@/components/stack/StackPageClient";
+import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
 import { isPlaceholderNotionBuild } from "@/lib/notion";
-import { getStacks } from "@/lib/stack";
+import { getStacks, type StackItem } from "@/lib/stack";
 
 export const metadata: Metadata = {
   ...createMetadata({
@@ -20,15 +21,16 @@ export const metadata: Metadata = {
   },
 };
 
-export default function StackPage() {
-  return <StackContent />;
+export default async function StackPage() {
+  const allStacks = await getCachedStacks();
+  const initialLikes = await getServerLikes(allStacks.map((item) => item.id));
+
+  return <StackPageClient initialData={allStacks} initialLikes={initialLikes} />;
 }
 
-async function StackContent() {
+async function getCachedStacks(): Promise<StackItem[]> {
   "use cache";
   cacheLife("days");
   cacheTag("notion:stack");
-  const allStacks = isPlaceholderNotionBuild() ? [] : await getStacks();
-
-  return <StackPageClient initialData={allStacks} />;
+  return isPlaceholderNotionBuild() ? [] : await getStacks();
 }

--- a/src/app/til/[slug]/page.tsx
+++ b/src/app/til/[slug]/page.tsx
@@ -6,8 +6,13 @@ import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
 import { renderBlocks } from "@/components/renderBlocks";
 import { PageTitle } from "@/components/Typography";
+import { getServerLikes, type LikeCount } from "@/lib/likes-server";
 import { createArticleJsonLd, createMetadata, truncateDescription } from "@/lib/metadata";
-import { getTilByShortId, isPlaceholderNotionBuild } from "@/lib/notion";
+import {
+  getTilByShortId,
+  isPlaceholderNotionBuild,
+  type NotionTilItemWithContent,
+} from "@/lib/notion";
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 
 export const instant = false;
@@ -40,12 +45,22 @@ export async function generateMetadata(props: {
   });
 }
 
+type CachedTilEntry = {
+  content: NotionTilItemWithContent;
+  canonicalSlug: string;
+  cleanDate: string;
+  articleJsonLd: ReturnType<typeof createArticleJsonLd>;
+};
+
 export default async function TilEntryPage(props: { params: Promise<{ slug: string }> }) {
   const params = await props.params;
-  return <TilEntryContent slug={params.slug} />;
+  const entry = await getCachedTilEntry(params.slug);
+  const initialLikes = await getServerLikes([entry.content.id]);
+
+  return <TilEntryView entry={entry} initialLikes={initialLikes} />;
 }
 
-async function TilEntryContent({ slug }: { slug: string }) {
+async function getCachedTilEntry(slug: string): Promise<CachedTilEntry> {
   "use cache";
   cacheLife("days");
   cacheTag("notion:til");
@@ -79,6 +94,18 @@ async function TilEntryContent({ slug }: { slug: string }) {
     publishedTime: content.published,
   });
 
+  return { content, canonicalSlug, cleanDate, articleJsonLd };
+}
+
+function TilEntryView({
+  entry,
+  initialLikes,
+}: {
+  entry: CachedTilEntry;
+  initialLikes: Record<string, LikeCount>;
+}) {
+  const { content, canonicalSlug, cleanDate, articleJsonLd } = entry;
+
   return (
     <>
       <script
@@ -95,7 +122,7 @@ async function TilEntryContent({ slug }: { slug: string }) {
           <div className="notion-blocks flex min-w-0 flex-col gap-4 text-lg">
             {renderBlocks(content.blocks)}
           </div>
-          <BatchLikesProvider pageIds={[content.id]}>
+          <BatchLikesProvider pageIds={[content.id]} initialData={initialLikes}>
             <div className="w-fit">
               <LikeButton
                 pageId={content.id}

--- a/src/app/til/page.tsx
+++ b/src/app/til/page.tsx
@@ -3,9 +3,10 @@ import { cacheLife, cacheTag } from "next/cache";
 
 import { TilFeed } from "@/components/TilFeed";
 import { PageTitle } from "@/components/Typography";
+import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
 import { getTilDatabaseItems, getTilItemContent, isPlaceholderNotionBuild } from "@/lib/notion";
-import { hydrateTilEntries } from "@/lib/til";
+import { hydrateTilEntries, type TilPage } from "@/lib/til";
 
 export const metadata: Metadata = {
   ...createMetadata({
@@ -28,21 +29,28 @@ export default function TilPage() {
           <div className="hidden sm:block" />
           <PageTitle>TIL</PageTitle>
         </div>
-        <TilFeedContent />
+        <TilFeedWithLikes />
       </div>
     </div>
   );
 }
 
-async function TilFeedContent() {
+async function TilFeedWithLikes() {
+  const page = await getCachedTilFeed();
+  const initialLikes = await getServerLikes(page.items.map((entry) => entry.id));
+
+  return <TilFeed fallbackData={[page]} initialLikes={initialLikes} />;
+}
+
+async function getCachedTilFeed(): Promise<TilPage> {
   "use cache";
   cacheLife("days");
   cacheTag("notion:til");
   if (isPlaceholderNotionBuild()) {
-    return <TilFeed fallbackData={[{ items: [], nextCursor: null }]} />;
+    return { items: [], nextCursor: null };
   }
   const { items, nextCursor } = await getTilDatabaseItems(undefined, 10);
   const contents = await Promise.all(items.map((entry) => getTilItemContent(entry.id)));
 
-  return <TilFeed fallbackData={[{ items: hydrateTilEntries(items, contents), nextCursor }]} />;
+  return { items: hydrateTilEntries(items, contents), nextCursor };
 }

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -8,11 +8,14 @@ import { renderBlocks } from "@/components/renderBlocks";
 import { List, ListItem, ListItemLabel } from "@/components/shared/ListComponents";
 import { PageTitle } from "@/components/Typography";
 import { FancySeparator } from "@/components/ui/FancySeparator";
+import { getServerLikes, type LikeCount } from "@/lib/likes-server";
 import { createArticleJsonLd, createMetadata, truncateDescription } from "@/lib/metadata";
 import {
   getWritingPostByShortId,
   getWritingPostContentBySlug,
   isPlaceholderNotionBuild,
+  type NotionWritingItem,
+  type ProcessedBlock,
 } from "@/lib/notion";
 import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 import { getAllWritingPosts } from "@/lib/writing";
@@ -63,12 +66,24 @@ function getRandomPosts<T>(posts: T[], count: number): T[] {
   return shuffled.slice(0, count);
 }
 
+type CachedWritingPost = {
+  blocks: ProcessedBlock[];
+  metadata: NotionWritingItem;
+  canonicalSlug: string;
+  randomPosts: NotionWritingItem[];
+  articleJsonLd: ReturnType<typeof createArticleJsonLd>;
+  cleanDate: string;
+};
+
 export default async function WritingPostPage(props: { params: Promise<{ slug: string }> }) {
   const params = await props.params;
-  return <WritingPostContent slug={params.slug} />;
+  const post = await getCachedWritingPost(params.slug);
+  const initialLikes = await getServerLikes([post.metadata.id]);
+
+  return <WritingPostView post={post} initialLikes={initialLikes} />;
 }
 
-async function WritingPostContent({ slug }: { slug: string }) {
+async function getCachedWritingPost(slug: string): Promise<CachedWritingPost> {
   "use cache";
   cacheLife("days");
   cacheTag("notion:writing");
@@ -125,6 +140,18 @@ async function WritingPostContent({ slug }: { slug: string }) {
     },
   );
 
+  return { blocks, metadata, canonicalSlug, randomPosts, articleJsonLd, cleanDate };
+}
+
+function WritingPostView({
+  post,
+  initialLikes,
+}: {
+  post: CachedWritingPost;
+  initialLikes: Record<string, LikeCount>;
+}) {
+  const { blocks, metadata, canonicalSlug, randomPosts, articleJsonLd, cleanDate } = post;
+
   return (
     <>
       <script
@@ -136,7 +163,7 @@ async function WritingPostContent({ slug }: { slug: string }) {
           <div className="flex flex-col gap-6">
             <p className="text-tertiary">{cleanDate}</p>
             <PageTitle>{metadata.title}</PageTitle>
-            <BatchLikesProvider pageIds={[metadata.id]}>
+            <BatchLikesProvider pageIds={[metadata.id]} initialData={initialLikes}>
               <div className="w-fit">
                 <LikeButton
                   pageId={metadata.id}
@@ -161,9 +188,12 @@ async function WritingPostContent({ slug }: { slug: string }) {
               <div className="bg-brand h-1 w-5 rounded-full" />
               <h2 className="text-tertiary text-base">Read next</h2>
               <List>
-                {randomPosts.map((post) => (
-                  <ListItem key={post.id} href={`/writing/${buildSlug(post.title, post.shortId!)}`}>
-                    <ListItemLabel>{post.title}</ListItemLabel>
+                {randomPosts.map((nextPost) => (
+                  <ListItem
+                    key={nextPost.id}
+                    href={`/writing/${buildSlug(nextPost.title, nextPost.shortId!)}`}
+                  >
+                    <ListItemLabel>{nextPost.title}</ListItemLabel>
                   </ListItem>
                 ))}
               </List>

--- a/src/components/likes/BatchLikesProvider.tsx
+++ b/src/components/likes/BatchLikesProvider.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 
 import { BatchLikesContext, type LikeCount, type LikeData } from "@/lib/hooks/useLikes";
+import {
+  getServerViewerLikesSnapshot,
+  getStoredViewerLikesSnapshot,
+  storedViewerHints,
+  subscribeStoredViewerLikes,
+  writeStoredViewerLikes,
+} from "@/lib/likes-viewer-store";
 
 interface BatchLikesProviderProps {
   pageIds: string[];
@@ -12,20 +19,31 @@ interface BatchLikesProviderProps {
 
 export function BatchLikesProvider({ pageIds, initialData, children }: BatchLikesProviderProps) {
   const [viewer, setViewer] = useState<Record<string, LikeData> | null>(null);
+  const pageIdsKey = pageIds.join(",");
+  const stored = useSyncExternalStore(
+    subscribeStoredViewerLikes,
+    getStoredViewerLikesSnapshot,
+    getServerViewerLikesSnapshot,
+  );
+  const storedHint = useMemo(
+    () => storedViewerHints(stored, pageIdsKey ? pageIdsKey.split(",") : []),
+    [stored, pageIdsKey],
+  );
 
   // Always fetch viewer overlay client-side (SSR only provides counts)
   useEffect(() => {
-    if (pageIds.length === 0) return;
+    if (!pageIdsKey) return;
 
     const controller = new AbortController();
 
     const fetchBatchLikes = async () => {
       try {
-        const res = await fetch(`/api/likes/batch?ids=${pageIds.join(",")}`, {
+        const res = await fetch(`/api/likes/batch?ids=${pageIdsKey}`, {
           signal: controller.signal,
         });
         if (res.ok) {
           const data: Record<string, LikeData> = await res.json();
+          writeStoredViewerLikes(data);
           setViewer(data);
         }
       } catch (error) {
@@ -37,14 +55,14 @@ export function BatchLikesProvider({ pageIds, initialData, children }: BatchLike
     fetchBatchLikes();
 
     return () => controller.abort();
-  }, [pageIds]);
+  }, [pageIdsKey]);
 
   const contextValue = useMemo(
     () => ({
       counts: initialData ?? {},
-      viewer,
+      viewer: viewer ?? storedHint,
     }),
-    [initialData, viewer],
+    [initialData, viewer, storedHint],
   );
 
   return <BatchLikesContext.Provider value={contextValue}>{children}</BatchLikesContext.Provider>;

--- a/src/components/likes/LikeButton.test.tsx
+++ b/src/components/likes/LikeButton.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
+import { LikeButton } from "@/components/likes/LikeButton";
+import type { LikeCount } from "@/lib/hooks/useLikes";
+
+function markup(initialLikes?: Record<string, LikeCount>) {
+  return renderToStaticMarkup(
+    <BatchLikesProvider pageIds={["page-1"]} initialData={initialLikes}>
+      <LikeButton pageId="page-1" title="Cursor" href="/stack" contentType="stack" />
+    </BatchLikesProvider>,
+  );
+}
+
+describe("LikeButton first markup", () => {
+  test("renders a provided initial count of 506", () => {
+    expect(markup({ "page-1": { count: 506 } })).toContain("Current likes: 506");
+  });
+
+  test("does not render 0 when the count is unknown", () => {
+    const html = markup();
+    expect(html).not.toContain("Current likes: 0");
+    expect(html).toContain('aria-label="Like this."');
+  });
+
+  test("renders an actual cached count of 0", () => {
+    expect(markup({ "page-1": { count: 0 } })).toContain("Current likes: 0");
+  });
+});

--- a/src/components/likes/LikeButton.test.tsx
+++ b/src/components/likes/LikeButton.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { BatchLikesProvider } from "@/components/likes/BatchLikesProvider";
 import { LikeButton } from "@/components/likes/LikeButton";
-import type { LikeCount } from "@/lib/hooks/useLikes";
+import { BatchLikesContext, type LikeCount } from "@/lib/hooks/useLikes";
 
 function markup(initialLikes?: Record<string, LikeCount>) {
   return renderToStaticMarkup(
@@ -26,5 +26,37 @@ describe("LikeButton first markup", () => {
 
   test("renders an actual cached count of 0", () => {
     expect(markup({ "page-1": { count: 0 } })).toContain("Current likes: 0");
+  });
+
+  test("stored viewer state fills the heart and count before batch", () => {
+    const html = renderToStaticMarkup(
+      <BatchLikesContext.Provider
+        value={{
+          counts: { "page-1": { count: 506 } },
+          viewer: { "page-1": { count: 507, userLikes: 1 } },
+        }}
+      >
+        <LikeButton pageId="page-1" title="Cursor" href="/stack" contentType="stack" />
+      </BatchLikesContext.Provider>,
+    );
+    expect(html).toContain("Current likes: 507");
+    expect(html).toContain("liked 1 times");
+    expect(html).not.toContain("Current likes: 0");
+  });
+
+  test("live batch overlay wins over a stale stored viewer", () => {
+    const html = renderToStaticMarkup(
+      <BatchLikesContext.Provider
+        value={{
+          counts: { "page-1": { count: 506 } },
+          viewer: { "page-1": { count: 510, userLikes: 2 } },
+        }}
+      >
+        <LikeButton pageId="page-1" title="Cursor" href="/stack" contentType="stack" />
+      </BatchLikesContext.Provider>,
+    );
+    expect(html).toContain("Current likes: 510");
+    expect(html).toContain("liked 2 times");
+    expect(html).not.toContain("Current likes: 507");
   });
 });

--- a/src/components/likes/LikeButton.tsx
+++ b/src/components/likes/LikeButton.tsx
@@ -99,6 +99,7 @@ export function LikeButton({
     href,
     contentType,
   });
+  const countKnown = count !== undefined;
   const [isShaking, setIsShaking] = useState(false);
   const [particles, setParticles] = useState<ReturnType<typeof generateParticles>>([]);
   const [particleKey, setParticleKey] = useState(0);
@@ -112,8 +113,6 @@ export function LikeButton({
   const heartSpring = useSpring(heartScale, { stiffness: 500, damping: 15, mass: 0.5 });
 
   const handleClick = async () => {
-    if (isLoading) return;
-
     if (userLikes >= MAX_LIKES_PER_USER) {
       // At max likes - shake it!
       setIsShaking(true);
@@ -159,7 +158,7 @@ export function LikeButton({
 
   const handleContextMenu = async (e: React.MouseEvent) => {
     e.preventDefault();
-    if (isLoading || userLikes <= 0) return;
+    if (userLikes <= 0) return;
 
     // Subtle feedback for unlike
     buttonScale.set(0.98);
@@ -198,7 +197,6 @@ export function LikeButton({
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
         onPointerLeave={handlePointerUp}
-        disabled={isLoading}
         className={cn(
           "h-7 flex-row gap-1 rounded-full pr-2.5 pl-2 disabled:opacity-100",
           variant === "default" && [
@@ -216,9 +214,11 @@ export function LikeButton({
           className,
         )}
         aria-label={
-          isLoading
-            ? `Like this. Current likes: ${count}.`
-            : `Like this. Current likes: ${count}. You've liked ${userLikes} times.`
+          !countKnown
+            ? "Like this."
+            : isLoading
+              ? `Like this. Current likes: ${count}.`
+              : `Like this. Current likes: ${count}. You've liked ${userLikes} times.`
         }
         style={isFilled ? { color: heartColor } : undefined}
       >
@@ -260,7 +260,11 @@ export function LikeButton({
         </div>
 
         <span className="-translate-x-px translate-y-px leading-none">
-          <AnimatedNumber value={count} />
+          {count !== undefined ? (
+            <AnimatedNumber value={count} />
+          ) : (
+            <span aria-hidden="true">{"\u2013"}</span>
+          )}
         </span>
       </Button>
     </motion.div>

--- a/src/lib/hooks/useLikes.ts
+++ b/src/lib/hooks/useLikes.ts
@@ -1,11 +1,12 @@
 "use client";
 
-import { createContext, useContext } from "react";
+import { createContext, useContext, useSyncExternalStore } from "react";
 import useSWR, { mutate } from "swr";
 
 import { likeActivityPayload, type LikeActivityTarget } from "@/lib/activity-shared";
 import { fetcher } from "@/lib/fetcher";
 import {
+  isViewerLikeData,
   type LikeCount,
   type LikeData,
   MAX_LIKES_PER_USER,
@@ -13,17 +14,31 @@ import {
   optimisticRemoveLike,
   resolveLikeState,
 } from "@/lib/likes-constants";
+import {
+  getServerViewerLikesSnapshot,
+  getStoredViewerLikesSnapshot,
+  storedViewerHint,
+  subscribeStoredViewerLikes,
+  writeStoredViewerLike,
+} from "@/lib/likes-viewer-store";
 
 export type { LikeCount, LikeData };
 export type { LikeActivityTarget };
 
 type BatchLikesContextType = {
   counts: Record<string, LikeCount>;
-  /** null until the viewer batch returns. */
+  /** Stored hint or live batch overlay. null until either exists. */
   viewer: Record<string, LikeData> | null;
 };
 
 export const BatchLikesContext = createContext<BatchLikesContextType | null>(null);
+
+function persistViewerLike(pageId: string, data: LikeData) {
+  if (!isViewerLikeData(data) || !Number.isFinite(data.count) || !Number.isFinite(data.userLikes)) {
+    return;
+  }
+  writeStoredViewerLike(pageId, { count: data.count, userLikes: data.userLikes });
+}
 
 /**
  * Hook for individual like button.
@@ -34,6 +49,12 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
   const batchContext = useContext(BatchLikesContext);
   const inBatch = batchContext !== null;
   const countOnly = batchContext?.counts?.[pageId];
+  const stored = useSyncExternalStore(
+    subscribeStoredViewerLikes,
+    getStoredViewerLikesSnapshot,
+    getServerViewerLikesSnapshot,
+  );
+  const storedHint = storedViewerHint(stored, pageId);
 
   const { data, error } = useSWR<LikeData>(
     pageId ? `/api/likes/${pageId}` : null,
@@ -47,7 +68,7 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
 
   const { count, userLikes, viewerKnown } = resolveLikeState(
     countOnly,
-    batchContext?.viewer?.[pageId],
+    batchContext?.viewer?.[pageId] ?? storedHint,
     data,
   );
 
@@ -73,7 +94,9 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
         if (!res.ok) {
           throw new Error("Failed to like");
         }
-        return res.json();
+        const next = (await res.json()) as LikeData;
+        persistViewerLike(pageId, next);
+        return next;
       },
       {
         optimisticData,
@@ -95,7 +118,9 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
         if (!res.ok) {
           throw new Error("Failed to remove like");
         }
-        return res.json();
+        const next = (await res.json()) as LikeData;
+        persistViewerLike(pageId, next);
+        return next;
       },
       {
         optimisticData,

--- a/src/lib/hooks/useLikes.ts
+++ b/src/lib/hooks/useLikes.ts
@@ -9,6 +9,8 @@ import {
   type LikeCount,
   type LikeData,
   MAX_LIKES_PER_USER,
+  optimisticAddLike,
+  optimisticRemoveLike,
   resolveLikeState,
 } from "@/lib/likes-constants";
 
@@ -31,6 +33,7 @@ export const BatchLikesContext = createContext<BatchLikesContextType | null>(nul
 export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
   const batchContext = useContext(BatchLikesContext);
   const inBatch = batchContext !== null;
+  const countOnly = batchContext?.counts?.[pageId];
 
   const { data, error } = useSWR<LikeData>(
     pageId ? `/api/likes/${pageId}` : null,
@@ -43,13 +46,13 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
   );
 
   const { count, userLikes, viewerKnown } = resolveLikeState(
-    batchContext?.counts?.[pageId],
+    countOnly,
     batchContext?.viewer?.[pageId],
     data,
   );
 
   const addLike = async () => {
-    if (!viewerKnown || userLikes >= MAX_LIKES_PER_USER) return;
+    if (userLikes >= MAX_LIKES_PER_USER) return;
 
     const payload = likeActivityPayload(target, {
       title: document.title,
@@ -57,10 +60,7 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
     });
     if (!payload) return;
 
-    const optimisticData: LikeData = {
-      count: count + 1,
-      userLikes: userLikes + 1,
-    };
+    const optimisticData = optimisticAddLike(count, userLikes);
 
     await mutate(
       `/api/likes/${pageId}`,
@@ -84,12 +84,9 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
   };
 
   const removeLike = async () => {
-    if (!viewerKnown || userLikes <= 0) return;
+    if (userLikes <= 0) return;
 
-    const optimisticData: LikeData = {
-      count: Math.max(0, count - 1),
-      userLikes: userLikes - 1,
-    };
+    const optimisticData = optimisticRemoveLike(count, userLikes);
 
     await mutate(
       `/api/likes/${pageId}`,

--- a/src/lib/likes-constants.test.ts
+++ b/src/lib/likes-constants.test.ts
@@ -4,10 +4,17 @@ import {
   isViewerLikeData,
   type LikeCount,
   type LikeData,
+  LIKES_SERVER_CACHE_TAG,
   optimisticAddLike,
   optimisticRemoveLike,
   resolveLikeState,
 } from "@/lib/likes-constants";
+
+describe("LIKES_SERVER_CACHE_TAG", () => {
+  test("is the public count cache tag busted on write", () => {
+    expect(LIKES_SERVER_CACHE_TAG).toBe("likes:server");
+  });
+});
 
 describe("isViewerLikeData", () => {
   test("is false for count-only SSR payloads", () => {

--- a/src/lib/likes-constants.test.ts
+++ b/src/lib/likes-constants.test.ts
@@ -4,6 +4,8 @@ import {
   isViewerLikeData,
   type LikeCount,
   type LikeData,
+  optimisticAddLike,
+  optimisticRemoveLike,
   resolveLikeState,
 } from "@/lib/likes-constants";
 
@@ -30,6 +32,22 @@ describe("resolveLikeState", () => {
 
   test("does not invent a clickable empty viewer from missing data", () => {
     expect(resolveLikeState(undefined, undefined)).toEqual({
+      count: undefined,
+      userLikes: 0,
+      viewerKnown: false,
+    });
+  });
+
+  test("keeps a provided public count of 506 without treating it as unknown", () => {
+    expect(resolveLikeState({ count: 506 }, undefined)).toEqual({
+      count: 506,
+      userLikes: 0,
+      viewerKnown: false,
+    });
+  });
+
+  test("treats an actual cached count of 0 as known zero", () => {
+    expect(resolveLikeState({ count: 0 }, undefined)).toEqual({
       count: 0,
       userLikes: 0,
       viewerKnown: false,
@@ -60,5 +78,25 @@ describe("resolveLikeState", () => {
       userLikes: 0,
       viewerKnown: true,
     });
+  });
+});
+
+describe("optimistic like", () => {
+  test("increments the displayed count and viewer likes", () => {
+    expect(optimisticAddLike(506, 0)).toEqual({ count: 507, userLikes: 1 });
+    expect(resolveLikeState({ count: 506 }, undefined, optimisticAddLike(506, 0))).toEqual({
+      count: 507,
+      userLikes: 1,
+      viewerKnown: true,
+    });
+  });
+
+  test("increments from an unknown count without flashing 0 first", () => {
+    expect(optimisticAddLike(undefined, 0)).toEqual({ count: 1, userLikes: 1 });
+  });
+
+  test("decrements and floors at 0", () => {
+    expect(optimisticRemoveLike(1, 1)).toEqual({ count: 0, userLikes: 0 });
+    expect(optimisticRemoveLike(0, 1)).toEqual({ count: 0, userLikes: 0 });
   });
 });

--- a/src/lib/likes-constants.ts
+++ b/src/lib/likes-constants.ts
@@ -23,16 +23,33 @@ export function isViewerLikeData(data: LikeCount | LikeData): data is LikeData {
 /**
  * Merge SSR count, batch viewer overlay, and optional SWR/optimistic overlay.
  * `userLikes` is only meaningful when `viewerKnown` is true.
+ * `count` is undefined until a real count is known — unknown is not 0.
  */
 export function resolveLikeState(
   countOnly: LikeCount | undefined,
   viewer: LikeData | undefined,
   overlay?: LikeData,
-): { count: number; userLikes: number; viewerKnown: boolean } {
+): { count: number | undefined; userLikes: number; viewerKnown: boolean } {
   const likeData = overlay ?? viewer;
   return {
-    count: likeData?.count ?? countOnly?.count ?? 0,
+    count: likeData?.count ?? countOnly?.count,
     userLikes: likeData?.userLikes ?? 0,
     viewerKnown: likeData !== undefined,
+  };
+}
+
+/** Optimistic add from the count currently on screen (unknown starts at 0). */
+export function optimisticAddLike(count: number | undefined, userLikes: number): LikeData {
+  return {
+    count: (count ?? 0) + 1,
+    userLikes: userLikes + 1,
+  };
+}
+
+/** Optimistic remove from the count currently on screen. */
+export function optimisticRemoveLike(count: number | undefined, userLikes: number): LikeData {
+  return {
+    count: Math.max(0, (count ?? 0) - 1),
+    userLikes: Math.max(0, userLikes - 1),
   };
 }

--- a/src/lib/likes-constants.ts
+++ b/src/lib/likes-constants.ts
@@ -5,6 +5,9 @@
 
 export const MAX_LIKES_PER_USER = 16;
 
+/** `unstable_cache` tag for public like counts. Bust on POST/DELETE. */
+export const LIKES_SERVER_CACHE_TAG = "likes:server";
+
 /** SSR / cached count. Viewer state is unknown. */
 export interface LikeCount {
   count: number;

--- a/src/lib/likes-pages.test.ts
+++ b/src/lib/likes-pages.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const pagesDir = join(import.meta.dir, "../app");
+
+const likePages = [
+  "stack/page.tsx",
+  "sites/page.tsx",
+  "til/page.tsx",
+  "til/[slug]/page.tsx",
+  "writing/[slug]/page.tsx",
+  "ama/[id]/page.tsx",
+  "design-details/[id]/page.tsx",
+];
+
+describe("likes stay outside days-cached islands", () => {
+  test("list and detail pages fetch public counts after the Notion island", () => {
+    for (const relativePath of likePages) {
+      const source = readFileSync(join(pagesDir, relativePath), "utf8");
+      expect(source.includes("getServerLikes")).toBe(true);
+      expect(source.includes('"use cache"')).toBe(true);
+
+      const cachedFns = source
+        .split("async function")
+        .filter((block) => block.includes('"use cache"'));
+      expect(cachedFns.length).toBeGreaterThan(0);
+      for (const block of cachedFns) {
+        expect(block.includes("getServerLikes")).toBe(false);
+        expect(block.includes('cacheLife("days")')).toBe(true);
+      }
+    }
+  });
+});

--- a/src/lib/likes-server.ts
+++ b/src/lib/likes-server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { unstable_cache } from "next/cache";
 
-import { type LikeCount } from "./likes-constants";
+import { type LikeCount, LIKES_SERVER_CACHE_TAG } from "./likes-constants";
 import { getBatchLikeCounts } from "./likes-redis";
 
 export type { LikeCount, LikeData } from "./likes-constants";
@@ -38,6 +38,6 @@ export const getServerLikes = unstable_cache(
 
     return result;
   },
-  ["likes:server"],
-  { revalidate: LIKES_REVALIDATE, tags: ["likes:server"] },
+  [LIKES_SERVER_CACHE_TAG],
+  { revalidate: LIKES_REVALIDATE, tags: [LIKES_SERVER_CACHE_TAG] },
 );

--- a/src/lib/likes-viewer-store.test.ts
+++ b/src/lib/likes-viewer-store.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveLikeState } from "@/lib/likes-constants";
+import {
+  LIKES_VIEWER_STORAGE_KEY,
+  mergeStoredViewerLikes,
+  parseStoredViewerLikes,
+  readStoredViewerHint,
+  storedViewerHint,
+  storedViewerHints,
+  type ViewerLikeStore,
+  writeStoredViewerLike,
+  writeStoredViewerLikes,
+} from "@/lib/likes-viewer-store";
+
+function memoryStore(
+  initial: Record<string, string> = {},
+): ViewerLikeStore & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key: string) {
+      return data[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("parseStoredViewerLikes", () => {
+  test("keeps only pageId plus count and userLikes", () => {
+    expect(
+      parseStoredViewerLikes(
+        JSON.stringify({
+          "page-1": { count: 507, userLikes: 1, title: "secret", ip: "1.2.3.4" },
+        }),
+      ),
+    ).toEqual({ "page-1": { count: 507, userLikes: 1 } });
+  });
+
+  test("drops corrupt JSON and invalid entries", () => {
+    expect(parseStoredViewerLikes("{")).toEqual({});
+    expect(parseStoredViewerLikes(JSON.stringify(["nope"]))).toEqual({});
+    expect(
+      parseStoredViewerLikes(
+        JSON.stringify({
+          "page-1": { count: 507 },
+          "page-2": { count: -1, userLikes: 1 },
+          "page-3": { count: 1, userLikes: 99 },
+          "bad id": { count: 1, userLikes: 1 },
+        }),
+      ),
+    ).toEqual({});
+  });
+
+  test("does not invent a like when userLikes is 0 or missing", () => {
+    expect(storedViewerHint({}, "page-1")).toBeUndefined();
+    expect(storedViewerHint({ "page-1": { count: 506, userLikes: 0 } }, "page-1")).toEqual({
+      count: 506,
+      userLikes: 0,
+    });
+    expect(resolveLikeState({ count: 506 }, storedViewerHint({}, "page-1"))).toEqual({
+      count: 506,
+      userLikes: 0,
+      viewerKnown: false,
+    });
+    expect(
+      resolveLikeState(
+        { count: 506 },
+        storedViewerHint({ "page-1": { count: 506, userLikes: 0 } }, "page-1"),
+      ),
+    ).toEqual({
+      count: 506,
+      userLikes: 0,
+      viewerKnown: true,
+    });
+  });
+});
+
+describe("stored viewer overlay", () => {
+  test("fills heart and count from storage before the live batch", () => {
+    const stored = { "page-1": { count: 507, userLikes: 1 } };
+    expect(storedViewerHints(stored, ["page-1"])).toEqual(stored);
+    expect(resolveLikeState({ count: 506 }, stored["page-1"])).toEqual({
+      count: 507,
+      userLikes: 1,
+      viewerKnown: true,
+    });
+  });
+
+  test("lets the live batch override a stale store", () => {
+    const stored = { count: 507, userLikes: 1 };
+    const live = { count: 510, userLikes: 2 };
+    expect(resolveLikeState({ count: 506 }, stored, live)).toEqual({
+      count: 510,
+      userLikes: 2,
+      viewerKnown: true,
+    });
+  });
+});
+
+describe("writeStoredViewerLikes", () => {
+  test("writes and reads a successful like", () => {
+    const store = memoryStore();
+    writeStoredViewerLike("page-1", { count: 507, userLikes: 1 }, store);
+    expect(readStoredViewerHint("page-1", store)).toEqual({ count: 507, userLikes: 1 });
+    expect(store.data[LIKES_VIEWER_STORAGE_KEY]).not.toContain("ip");
+    expect(store.data[LIKES_VIEWER_STORAGE_KEY]).not.toContain("title");
+  });
+
+  test("ignores quota errors", () => {
+    const store: ViewerLikeStore = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+    };
+    expect(() =>
+      writeStoredViewerLikes({ "page-1": { count: 1, userLikes: 1 } }, store),
+    ).not.toThrow();
+  });
+
+  test("caps the map and keeps the newest pages", () => {
+    const existing = Object.fromEntries(
+      Array.from({ length: 2 }, (_, index) => [`old-${index}`, { count: index, userLikes: 0 }]),
+    );
+    const next = mergeStoredViewerLikes(existing, { fresh: { count: 9, userLikes: 1 } }, 2);
+    expect(next).toEqual({
+      "old-1": { count: 1, userLikes: 0 },
+      fresh: { count: 9, userLikes: 1 },
+    });
+  });
+});

--- a/src/lib/likes-viewer-store.ts
+++ b/src/lib/likes-viewer-store.ts
@@ -1,0 +1,181 @@
+import { type LikeData, MAX_LIKES_PER_USER } from "@/lib/likes-constants";
+
+export const LIKES_VIEWER_STORAGE_KEY = "brios-likes-viewer";
+export const LIKES_VIEWER_STORAGE_MAX_PAGES = 200;
+
+export type ViewerLikeStore = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+};
+
+function isStoredPageId(pageId: string): boolean {
+  return pageId.length > 0 && pageId.length <= 50 && !/\s/.test(pageId);
+}
+
+function isStoredLikeData(value: unknown): value is LikeData {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.count === "number" &&
+    Number.isFinite(record.count) &&
+    record.count >= 0 &&
+    typeof record.userLikes === "number" &&
+    Number.isFinite(record.userLikes) &&
+    record.userLikes >= 0 &&
+    record.userLikes <= MAX_LIKES_PER_USER
+  );
+}
+
+/** sessionStorage, or null when unavailable (SSR, privacy mode). */
+export function getSessionViewerStore(): ViewerLikeStore | null {
+  try {
+    if (typeof sessionStorage === "undefined") return null;
+    return sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+type ViewerStoreListener = () => void;
+const viewerStoreListeners = new Set<ViewerStoreListener>();
+const EMPTY_VIEWER_LIKES: Record<string, LikeData> = {};
+
+let snapshotRaw: string | null | undefined;
+let snapshotValue: Record<string, LikeData> = EMPTY_VIEWER_LIKES;
+
+function notifyStoredViewerLikes() {
+  snapshotRaw = undefined;
+  for (const listener of viewerStoreListeners) listener();
+}
+
+export function subscribeStoredViewerLikes(onStoreChange: () => void): () => void {
+  viewerStoreListeners.add(onStoreChange);
+  return () => {
+    viewerStoreListeners.delete(onStoreChange);
+  };
+}
+
+export function getStoredViewerLikesSnapshot(): Record<string, LikeData> {
+  const store = getSessionViewerStore();
+  let raw: string | null = null;
+  try {
+    raw = store?.getItem(LIKES_VIEWER_STORAGE_KEY) ?? null;
+  } catch {
+    raw = null;
+  }
+  if (raw === snapshotRaw) return snapshotValue;
+  snapshotRaw = raw;
+  snapshotValue = parseStoredViewerLikes(raw);
+  return snapshotValue;
+}
+
+export function getServerViewerLikesSnapshot(): Record<string, LikeData> {
+  return EMPTY_VIEWER_LIKES;
+}
+
+/** Parse a stored map. Corrupt JSON or entries are dropped. */
+export function parseStoredViewerLikes(raw: string | null): Record<string, LikeData> {
+  if (!raw) return EMPTY_VIEWER_LIKES;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return EMPTY_VIEWER_LIKES;
+
+    const result: Record<string, LikeData> = {};
+    for (const [pageId, value] of Object.entries(parsed)) {
+      if (!isStoredPageId(pageId) || !isStoredLikeData(value)) continue;
+      result[pageId] = { count: value.count, userLikes: value.userLikes };
+    }
+    return Object.keys(result).length === 0 ? EMPTY_VIEWER_LIKES : result;
+  } catch {
+    return EMPTY_VIEWER_LIKES;
+  }
+}
+
+/**
+ * Hint for one page. Missing / invalid entries are undefined.
+ * `userLikes: 0` is valid (empty heart) and does not invent a like.
+ */
+export function storedViewerHint(
+  stored: Record<string, LikeData>,
+  pageId: string,
+): LikeData | undefined {
+  return stored[pageId];
+}
+
+export function storedViewerHints(
+  stored: Record<string, LikeData>,
+  pageIds: string[],
+): Record<string, LikeData> | null {
+  const hint: Record<string, LikeData> = {};
+  let found = false;
+  for (const pageId of pageIds) {
+    const entry = storedViewerHint(stored, pageId);
+    if (!entry) continue;
+    hint[pageId] = entry;
+    found = true;
+  }
+  return found ? hint : null;
+}
+
+export function mergeStoredViewerLikes(
+  existing: Record<string, LikeData>,
+  updates: Record<string, LikeData>,
+  maxPages: number = LIKES_VIEWER_STORAGE_MAX_PAGES,
+): Record<string, LikeData> {
+  const next: Record<string, LikeData> = { ...existing };
+  for (const [pageId, value] of Object.entries(updates)) {
+    if (!isStoredPageId(pageId) || !isStoredLikeData(value)) continue;
+    delete next[pageId];
+    next[pageId] = { count: value.count, userLikes: value.userLikes };
+  }
+
+  const keys = Object.keys(next);
+  if (keys.length <= maxPages) return next;
+
+  const kept = keys.slice(-maxPages);
+  const trimmed: Record<string, LikeData> = {};
+  for (const key of kept) {
+    trimmed[key] = next[key]!;
+  }
+  return trimmed;
+}
+
+export function readStoredViewerLikes(
+  store: ViewerLikeStore | null = getSessionViewerStore(),
+): Record<string, LikeData> {
+  if (!store) return {};
+  try {
+    return parseStoredViewerLikes(store.getItem(LIKES_VIEWER_STORAGE_KEY));
+  } catch {
+    return {};
+  }
+}
+
+export function writeStoredViewerLikes(
+  updates: Record<string, LikeData>,
+  store: ViewerLikeStore | null = getSessionViewerStore(),
+): void {
+  if (!store || Object.keys(updates).length === 0) return;
+  try {
+    const next = mergeStoredViewerLikes(readStoredViewerLikes(store), updates);
+    store.setItem(LIKES_VIEWER_STORAGE_KEY, JSON.stringify(next));
+    notifyStoredViewerLikes();
+  } catch {
+    // Quota, private mode, or a thrown Storage setter — fall through.
+  }
+}
+
+export function writeStoredViewerLike(
+  pageId: string,
+  data: LikeData,
+  store: ViewerLikeStore | null = getSessionViewerStore(),
+): void {
+  writeStoredViewerLikes({ [pageId]: data }, store);
+}
+
+export function readStoredViewerHint(
+  pageId: string,
+  store: ViewerLikeStore | null = getSessionViewerStore(),
+): LikeData | undefined {
+  return storedViewerHint(readStoredViewerLikes(store), pageId);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After #2340, `/stack` and `/sites` (and the other Notion detail pages) painted like counts as **0**, then jumped to the real public count after the client batch overlay. That reads as “nobody liked this” even when the 1h snapshot already has 506.

A follow-up: after you like, a full refresh still first-painted the 1h snapshot (count missing your like, heart empty) until the batch overlay snapped to live Redis + IP hash.

## What changed

Public counts come back on first HTML, without putting likes inside the days-cached Notion island and without page-level Suspense skeletons.

- Days-cached islands still return Notion lists/posts only (`cacheLife("days")` + existing purge tags).
- After that island, `getServerLikes(ids)` (1h `unstable_cache`, `likes:server`) runs and `initialLikes` is passed into `StackPageClient` / `GoodWebsitesPageClient` / TIL feed / AMA / writing / TIL / design-details like buttons.
- Viewer heart state stays client-only. First paint: public count + unfilled heart (or a stored same-tab hint if this visitor just liked).
- Unknown count ≠ 0. The button renders an en-dash placeholder until a count is known. A cached 0 still renders 0.
- Heart stays clickable during the overlay. Optimistic toggle uses the displayed count and rolls back on error.

### Like-refresh tightening

- Successful `POST`/`DELETE` `/api/likes/[id]` calls `revalidateTag("likes:server", "max")` so the next SSR `getServerLikes` misses and reads Redis. Rejected writes do not bust the tag.
- Same-tab `sessionStorage` keeps `pageId → { count, userLikes }` after a successful write and after the batch overlay returns. On refresh, that hint fills the heart/count until `/api/likes/batch` arrives. Live batch/GET always wins. Corrupt, quota, or `userLikes: 0` / missing entries do not invent a like. No IP or title is stored.

Homepage and app-dissection detail have no like buttons, so they are unchanged.

## Tests

Behavior only:

- Unknown count does not render “0”
- A provided initial count of 506 renders 506 on first markup
- An actual cached 0 still renders 0
- Optimistic like increments from the displayed count
- List/detail pages call `getServerLikes` outside the `"use cache"` island
- POST/DELETE revalidate `likes:server`; GET and rejected writes do not
- Stored viewer state fills heart/count before batch; live batch overrides a stale store

Full suite: 561 pass.

## Live first HTML (curl, no JS)

Hard-refresh markup now includes the public counts instead of 0:

- `/stack`: 506, 164, 111, …
- `/sites`: 132, 88, 64, …
- `/writing/how-im-feeling-about-ai-in-august-2026-O7e1TFS`: 46
- `/til`: 280, 186, 174, …
- `/ama/359c711c-0ceb-81c7-be20-d82678c0ca5d`: 35

## Out of scope

`/stack` and `/sites` can still reorder after jotai hydrates a saved table sort from `localStorage`. Fixing that cheaply would either mismatch SSR or need a cookie. Did not block this likes fix on it.

Notion `/api/purge-cache` still does not bust likes (the write path now busts `likes:server` on its own).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec94ade2-d3fb-4fd3-bd29-24a65fb2f2df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec94ade2-d3fb-4fd3-bd29-24a65fb2f2df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

