### PR TITLE
Keep the activity HN icon official orange in both themes

### DIFF
--- a/src/components/icons/YCombinator.tsx
+++ b/src/components/icons/YCombinator.tsx
@@ -2,19 +2,19 @@ import { cn } from "@/lib/utils";
 
 import { IconProps } from "./types";
 
-/** Y Combinator square mark. Follows text color so it inverts in dark mode. */
+/** Y Combinator square mark. Official HN orange in both themes — not currentColor. */
 export function YCombinator({ size = 16, className, ...rest }: IconProps) {
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      className={cn("text-primary rounded-[3px]", className)}
+      className={cn("rounded-[3px]", className)}
       aria-hidden
       {...rest}
     >
       <path
-        fill="currentColor"
+        fill="#ff6600"
         fillRule="evenodd"
         d="m0 0h24v24h-24zm12.8 13.446 4.339-8.303h-1.871q-2.143 4.018-2.839 5.786l-.375.96-.32-.75c-.96-2.374-1.931-4.348-3.022-6.243l.129.243h-1.984l4.286 8.2v5.52h1.657z"
       />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The activity-feed Hacker News mark (`YCombinator`) used `currentColor` with `text-primary`, so it followed the theme: near-black in light mode and a washed-out gray/white in dark mode.

This pins the existing Y-in-square path to official Hacker News orange (`#ff6600`). It no longer inherits foreground color or inverts with the theme. Other activity source icons are unchanged.

No tests: visual/chrome restyle only.

[HN icon orange in light mode](https://cursor.com/agents/bc-66326758-63f9-4faf-9381-dcd171bd9f92/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhn_activity_feed_light.png)
[HN icon orange in dark mode](https://cursor.com/agents/bc-66326758-63f9-4faf-9381-dcd171bd9f92/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhn_activity_feed_dark.png)
[hn_icon_orange_light_and_dark.mp4](https://cursor.com/agents/bc-66326758-63f9-4faf-9381-dcd171bd9f92/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhn_icon_orange_light_and_dark.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66326758-63f9-4faf-9381-dcd171bd9f92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66326758-63f9-4faf-9381-dcd171bd9f92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

