### PR TITLE
Stop /sites from flashing a second shuffle on refresh

### DIFF
--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -1,17 +1,22 @@
 import { cachedResponse, errorResponse } from "@/lib/api-utils";
-import { filterGoodWebsites, getGoodWebsites, getGoodWebsitesSeed } from "@/lib/goodWebsites";
+import {
+  filterGoodWebsites,
+  getGoodWebsitesSource,
+  GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
+} from "@/lib/goodWebsites";
+import { getCachedShuffledGoodWebsites } from "@/lib/goodWebsites-cached";
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const tag = searchParams.get("tag") || "";
 
-    // Use the same function as the page to get randomized results
-    const items = await getGoodWebsites(getGoodWebsitesSeed());
+    // Same 5-minute shuffle cache as /sites so a client fetch cannot
+    // introduce a different permutation than first HTML.
+    const items = await getCachedShuffledGoodWebsites(await getGoodWebsitesSource());
     const filteredItems = filterGoodWebsites(items, { tag });
 
-    // Cache for 5 minutes to match ISR revalidation
-    return cachedResponse(filteredItems, 300);
+    return cachedResponse(filteredItems, GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS);
   } catch (error) {
     console.error("Error fetching good website items:", error);
     return errorResponse("Failed to fetch good website items");

--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -1,9 +1,5 @@
 import { cachedResponse, errorResponse } from "@/lib/api-utils";
-import {
-  filterGoodWebsites,
-  getGoodWebsitesSource,
-  GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
-} from "@/lib/goodWebsites";
+import { filterGoodWebsites, GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS } from "@/lib/goodWebsites";
 import { getCachedShuffledGoodWebsites } from "@/lib/goodWebsites-cached";
 
 export async function GET(request: Request) {
@@ -13,7 +9,7 @@ export async function GET(request: Request) {
 
     // Same 5-minute shuffle cache as /sites so a client fetch cannot
     // introduce a different permutation than first HTML.
-    const items = await getCachedShuffledGoodWebsites(await getGoodWebsitesSource());
+    const items = await getCachedShuffledGoodWebsites();
     const filteredItems = filterGoodWebsites(items, { tag });
 
     return cachedResponse(filteredItems, GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS);

--- a/src/app/sites/page.tsx
+++ b/src/app/sites/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { GoodWebsitesPageClient } from "@/components/good-websites/GoodWebsitesPageClient";
-import { getGoodWebsites, getGoodWebsitesSeed, type GoodWebsiteItem } from "@/lib/goodWebsites";
+import { getGoodWebsitesSource, type GoodWebsiteItem } from "@/lib/goodWebsites";
+import { getCachedShuffledGoodWebsites } from "@/lib/goodWebsites-cached";
 import { getServerLikes } from "@/lib/likes-server";
 import { createMetadata, SITE_CONFIG } from "@/lib/metadata";
 import { isPlaceholderNotionBuild } from "@/lib/notion";
@@ -21,7 +22,7 @@ export const metadata: Metadata = {
 };
 
 export default async function GoodWebsitesPage() {
-  const allWebsites = await getCachedGoodWebsites();
+  const allWebsites = await getCachedShuffledGoodWebsites(await getCachedGoodWebsites());
   const initialLikes = await getServerLikes(allWebsites.map((item) => item.id));
 
   return <GoodWebsitesPageClient initialData={allWebsites} initialLikes={initialLikes} />;
@@ -31,5 +32,5 @@ async function getCachedGoodWebsites(): Promise<GoodWebsiteItem[]> {
   "use cache";
   cacheLife("days");
   cacheTag("notion:good-websites");
-  return isPlaceholderNotionBuild() ? [] : await getGoodWebsites(getGoodWebsitesSeed());
+  return isPlaceholderNotionBuild() ? [] : await getGoodWebsitesSource();
 }

--- a/src/app/sites/page.tsx
+++ b/src/app/sites/page.tsx
@@ -22,7 +22,10 @@ export const metadata: Metadata = {
 };
 
 export default async function GoodWebsitesPage() {
-  const allWebsites = await getCachedShuffledGoodWebsites(await getCachedGoodWebsites());
+  // Keep the page-local days island live so /sites stays subscribed to the
+  // Notion purge tag. Visible order comes from the shared 5-minute shuffle.
+  await getCachedGoodWebsites();
+  const allWebsites = await getCachedShuffledGoodWebsites();
   const initialLikes = await getServerLikes(allWebsites.map((item) => item.id));
 
   return <GoodWebsitesPageClient initialData={allWebsites} initialLikes={initialLikes} />;

--- a/src/lib/goodWebsites-cached.ts
+++ b/src/lib/goodWebsites-cached.ts
@@ -4,19 +4,26 @@ import { cacheLife, cacheTag } from "next/cache";
 
 import {
   getGoodWebsitesSeed,
+  getGoodWebsitesSource,
   GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
-  type GoodWebsiteItem,
   shuffleGoodWebsites,
 } from "@/lib/goodWebsites";
+import { isPlaceholderNotionBuild } from "@/lib/notion";
+
+async function getCachedGoodWebsitesSource() {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:good-websites");
+  return isPlaceholderNotionBuild() ? [] : await getGoodWebsitesSource();
+}
 
 /**
- * Short-lived shuffle of a days-cached Notion list.
+ * Short-lived shuffle of the days-cached Notion list.
  * Seed is taken inside this island so cacheComponents can cache Date.now(),
  * and the life matches the existing 5-minute randomization window.
+ * No arguments — page and /api/sites must share one cached permutation.
  */
-export async function getCachedShuffledGoodWebsites(
-  items: GoodWebsiteItem[],
-): Promise<GoodWebsiteItem[]> {
+export async function getCachedShuffledGoodWebsites() {
   "use cache";
   cacheLife({
     stale: GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
@@ -24,5 +31,6 @@ export async function getCachedShuffledGoodWebsites(
     expire: GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS * 2,
   });
   cacheTag("notion:good-websites");
+  const items = await getCachedGoodWebsitesSource();
   return shuffleGoodWebsites(items, getGoodWebsitesSeed());
 }

--- a/src/lib/goodWebsites-cached.ts
+++ b/src/lib/goodWebsites-cached.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+
+import {
+  getGoodWebsitesSeed,
+  GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
+  type GoodWebsiteItem,
+  shuffleGoodWebsites,
+} from "@/lib/goodWebsites";
+
+/**
+ * Short-lived shuffle of a days-cached Notion list.
+ * Seed is taken inside this island so cacheComponents can cache Date.now(),
+ * and the life matches the existing 5-minute randomization window.
+ */
+export async function getCachedShuffledGoodWebsites(
+  items: GoodWebsiteItem[],
+): Promise<GoodWebsiteItem[]> {
+  "use cache";
+  cacheLife({
+    stale: GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
+    revalidate: GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
+    expire: GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS * 2,
+  });
+  cacheTag("notion:good-websites");
+  return shuffleGoodWebsites(items, getGoodWebsitesSeed());
+}

--- a/src/lib/goodWebsites.test.ts
+++ b/src/lib/goodWebsites.test.ts
@@ -155,11 +155,16 @@ describe("sites cache split", () => {
   });
 
   test("shuffle cache matches the 5-minute cadence and the sites purge tag", () => {
-    expect(cachedSource.includes('"use cache"')).toBe(true);
     expect(cachedSource.includes("GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS")).toBe(true);
     expect(cachedSource.includes('cacheTag("notion:good-websites")')).toBe(true);
     expect(cachedSource.includes("getGoodWebsitesSeed")).toBe(true);
-    expect(cachedSource.includes('cacheLife("days")')).toBe(false);
+    expect(cachedSource.includes('cacheLife("days")')).toBe(true);
+
+    const shuffleFn = cachedSource.split("export async function")[1] ?? "";
+    expect(shuffleFn.includes("getGoodWebsitesSeed")).toBe(true);
+    expect(shuffleFn.includes('cacheLife("days")')).toBe(false);
+    expect(pageSource.includes("getCachedShuffledGoodWebsites()")).toBe(true);
+    expect(apiSource.includes("getCachedShuffledGoodWebsites()")).toBe(true);
   });
 
   test("API serves the same shuffle cache and 5-minute HTTP lifetime", () => {

--- a/src/lib/goodWebsites.test.ts
+++ b/src/lib/goodWebsites.test.ts
@@ -1,6 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
-import { filterGoodWebsites, type GoodWebsiteItem, goodWebsiteLinks } from "@/lib/goodWebsites";
+import {
+  filterGoodWebsites,
+  getGoodWebsitesSeed,
+  GOOD_WEBSITES_SHUFFLE_INTERVAL_MS,
+  GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS,
+  type GoodWebsiteItem,
+  goodWebsiteLinks,
+  goodWebsitesClientKey,
+  resolveGoodWebsitesOrder,
+  shuffleGoodWebsites,
+} from "@/lib/goodWebsites";
 
 function site(
   overrides: Partial<GoodWebsiteItem> & Pick<GoodWebsiteItem, "id" | "name">,
@@ -10,30 +23,37 @@ function site(
   };
 }
 
-describe("filterGoodWebsites", () => {
-  const items = [
-    site({
-      id: "1",
-      name: "Paco Coursey",
-      url: "https://paco.me",
-      tags: ["Personal site"],
-    }),
-    site({
-      id: "2",
-      name: "Linear",
-      url: "https://linear.app",
-      tags: ["Company"],
-    }),
-    site({
-      id: "3",
-      name: "Untitled",
-    }),
-  ];
+const items = [
+  site({
+    id: "1",
+    name: "Paco Coursey",
+    url: "https://paco.me",
+    tags: ["Personal site"],
+  }),
+  site({
+    id: "2",
+    name: "Linear",
+    url: "https://linear.app",
+    tags: ["Company"],
+  }),
+  site({
+    id: "3",
+    name: "Untitled",
+  }),
+  site({
+    id: "4",
+    name: "Rauno Freiberg",
+    url: "https://rauno.me",
+    tags: ["Personal site"],
+  }),
+];
 
+describe("filterGoodWebsites", () => {
   test("lists every titled site href when no tag is set", () => {
     expect(goodWebsiteLinks(filterGoodWebsites(items))).toEqual([
       { id: "1", title: "Paco Coursey", href: "https://paco.me" },
       { id: "2", title: "Linear", href: "https://linear.app" },
+      { id: "4", title: "Rauno Freiberg", href: "https://rauno.me" },
     ]);
   });
 
@@ -41,5 +61,115 @@ describe("filterGoodWebsites", () => {
     expect(goodWebsiteLinks(filterGoodWebsites(items, { tag: "Company" }))).toEqual([
       { id: "2", title: "Linear", href: "https://linear.app" },
     ]);
+  });
+});
+
+describe("sites shuffle cadence", () => {
+  test("uses a 5-minute window", () => {
+    expect(GOOD_WEBSITES_SHUFFLE_INTERVAL_MS).toBe(5 * 60 * 1000);
+    expect(GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS).toBe(300);
+  });
+
+  test("keeps the same seed until the window rolls over", () => {
+    const windowStart = 12 * GOOD_WEBSITES_SHUFFLE_INTERVAL_MS;
+    expect(getGoodWebsitesSeed(windowStart)).toBe(12);
+    expect(getGoodWebsitesSeed(windowStart + GOOD_WEBSITES_SHUFFLE_INTERVAL_MS - 1)).toBe(12);
+    expect(getGoodWebsitesSeed(windowStart + GOOD_WEBSITES_SHUFFLE_INTERVAL_MS)).toBe(13);
+  });
+
+  test("same seed produces the same order and does not mutate the source", () => {
+    const original = items.map((item) => item.id);
+    const first = shuffleGoodWebsites(items, 12).map((item) => item.id);
+    const second = shuffleGoodWebsites(items, 12).map((item) => item.id);
+
+    expect(first).toEqual(second);
+    expect(items.map((item) => item.id)).toEqual(original);
+    expect(new Set(first)).toEqual(new Set(original));
+  });
+
+  test("later windows can produce a different permutation", () => {
+    const permutations = new Set(
+      [12, 13, 14, 15, 16].map((seed) =>
+        shuffleGoodWebsites(items, seed)
+          .map((item) => item.id)
+          .join(","),
+      ),
+    );
+
+    expect(permutations.size).toBeGreaterThan(1);
+  });
+});
+
+describe("first HTML order vs hydrate", () => {
+  const serverOrder = shuffleGoodWebsites(items, 12);
+  const fetchedOrder = shuffleGoodWebsites(items, 13);
+
+  test("keeps the server permutation when a client fetch returns another", () => {
+    expect(goodWebsiteLinks(resolveGoodWebsitesOrder(serverOrder, fetchedOrder))).toEqual(
+      goodWebsiteLinks(serverOrder),
+    );
+    expect(goodWebsiteLinks(resolveGoodWebsitesOrder(serverOrder, fetchedOrder))).not.toEqual(
+      goodWebsiteLinks(fetchedOrder),
+    );
+  });
+
+  test("filters the server order without reshuffling", () => {
+    expect(
+      goodWebsiteLinks(resolveGoodWebsitesOrder(serverOrder, fetchedOrder, "Personal site")),
+    ).toEqual(goodWebsiteLinks(filterGoodWebsites(serverOrder, { tag: "Personal site" })));
+  });
+
+  test("uses a fetched list only when the server did not provide one", () => {
+    expect(goodWebsiteLinks(resolveGoodWebsitesOrder(undefined, fetchedOrder))).toEqual(
+      goodWebsiteLinks(fetchedOrder),
+    );
+  });
+
+  test("does not subscribe SWR when the server already provided the list", () => {
+    expect(goodWebsitesClientKey(true)).toBeNull();
+    expect(goodWebsitesClientKey(true, "Company")).toBeNull();
+    expect(goodWebsitesClientKey(false)).toBe("/api/sites");
+    expect(goodWebsitesClientKey(false, "Company")).toBe("/api/sites?tag=Company");
+  });
+});
+
+describe("sites cache split", () => {
+  const pagesDir = join(import.meta.dir, "../app");
+  const pageSource = readFileSync(join(pagesDir, "sites/page.tsx"), "utf8");
+  const apiSource = readFileSync(join(pagesDir, "api/sites/route.ts"), "utf8");
+  const cachedSource = readFileSync(join(import.meta.dir, "goodWebsites-cached.ts"), "utf8");
+  const hookSource = readFileSync(join(import.meta.dir, "hooks/useGoodWebsites.ts"), "utf8");
+
+  test("days-cached Notion island does not bake in a shuffle", () => {
+    const daysIsland = pageSource
+      .split("async function")
+      .find((block) => block.includes('cacheLife("days")'));
+
+    expect(daysIsland).toBeDefined();
+    expect(daysIsland?.includes("getGoodWebsitesSeed")).toBe(false);
+    expect(daysIsland?.includes("shuffle")).toBe(false);
+    expect(daysIsland?.includes("getGoodWebsitesSource")).toBe(true);
+    expect(pageSource.includes('cacheTag("notion:good-websites")')).toBe(true);
+    expect(pageSource.includes("getCachedShuffledGoodWebsites")).toBe(true);
+    expect(pageSource.includes("getServerLikes")).toBe(true);
+  });
+
+  test("shuffle cache matches the 5-minute cadence and the sites purge tag", () => {
+    expect(cachedSource.includes('"use cache"')).toBe(true);
+    expect(cachedSource.includes("GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS")).toBe(true);
+    expect(cachedSource.includes('cacheTag("notion:good-websites")')).toBe(true);
+    expect(cachedSource.includes("getGoodWebsitesSeed")).toBe(true);
+    expect(cachedSource.includes('cacheLife("days")')).toBe(false);
+  });
+
+  test("API serves the same shuffle cache and 5-minute HTTP lifetime", () => {
+    expect(apiSource.includes("getCachedShuffledGoodWebsites")).toBe(true);
+    expect(apiSource.includes("GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS")).toBe(true);
+  });
+
+  test("client hook prefers the server list and skips a remount fetch", () => {
+    expect(hookSource.includes("resolveGoodWebsitesOrder")).toBe(true);
+    expect(hookSource.includes("goodWebsitesClientKey")).toBe(true);
+    expect(hookSource.includes("revalidateOnMount: false")).toBe(true);
   });
 });

--- a/src/lib/goodWebsites.ts
+++ b/src/lib/goodWebsites.ts
@@ -8,6 +8,10 @@ import {
 export type GoodWebsiteItem = NotionGoodWebsiteItem;
 export type GoodWebsiteItemWithDate = NotionGoodWebsiteItemWithDate;
 
+/** Sites re-randomize on this cadence. Keep shuffle caches aligned with it. */
+export const GOOD_WEBSITES_SHUFFLE_INTERVAL_MS = 5 * 60 * 1000;
+export const GOOD_WEBSITES_SHUFFLE_INTERVAL_SECONDS = GOOD_WEBSITES_SHUFFLE_INTERVAL_MS / 1000;
+
 // Seeded random number generator for consistent randomization within time windows
 function seededRandom(seed: number): () => number {
   let state = seed;
@@ -31,12 +35,39 @@ function shuffleWithSeed<T>(array: T[], seed: number): T[] {
 }
 
 export function getGoodWebsitesSeed(now: number = Date.now()): number {
-  return Math.floor(now / (5 * 60 * 1000));
+  return Math.floor(now / GOOD_WEBSITES_SHUFFLE_INTERVAL_MS);
+}
+
+export function shuffleGoodWebsites<T>(items: readonly T[], seed: number): T[] {
+  return shuffleWithSeed([...items], seed);
+}
+
+/** Prefer the server list so hydrate cannot replace first HTML with another permutation. */
+export function resolveGoodWebsitesOrder(
+  serverItems: GoodWebsiteItem[] | undefined,
+  fetchedItems: GoodWebsiteItem[] | undefined,
+  tag = "",
+): GoodWebsiteItem[] {
+  return filterGoodWebsites(serverItems ?? fetchedItems ?? [], { tag });
+}
+
+/** SWR must not revalidate a server-provided list; that is what flashed a second order. */
+export function goodWebsitesClientKey(hasServerList: boolean, tag = ""): string | null {
+  if (hasServerList) return null;
+
+  const params = new URLSearchParams();
+  if (tag) params.set("tag", tag);
+  const queryString = params.toString();
+  return `/api/sites${queryString ? `?${queryString}` : ""}`;
+}
+
+export async function getGoodWebsitesSource(): Promise<GoodWebsiteItem[]> {
+  return getGoodWebsitesDatabaseItems();
 }
 
 export async function getGoodWebsites(seed: number): Promise<GoodWebsiteItem[]> {
-  const items = await getGoodWebsitesDatabaseItems();
-  return shuffleWithSeed(items, seed);
+  const items = await getGoodWebsitesSource();
+  return shuffleGoodWebsites(items, seed);
 }
 
 export async function getGoodWebsitesForRss(): Promise<GoodWebsiteItemWithDate[]> {

--- a/src/lib/hooks/useGoodWebsites.ts
+++ b/src/lib/hooks/useGoodWebsites.ts
@@ -4,35 +4,35 @@ import { useMemo } from "react";
 import useSWR from "swr";
 
 import { fetcher } from "@/lib/fetcher";
-import { filterGoodWebsites, type GoodWebsiteItem } from "@/lib/goodWebsites";
+import {
+  type GoodWebsiteItem,
+  goodWebsitesClientKey,
+  resolveGoodWebsitesOrder,
+} from "@/lib/goodWebsites";
 
 export function useGoodWebsites(fallbackData?: GoodWebsiteItem[], tag = "") {
-  const filteredFallback = useMemo(
-    () => (fallbackData ? filterGoodWebsites(fallbackData, { tag }) : undefined),
-    [fallbackData, tag],
-  );
-
-  // Build query string for API
-  const params = new URLSearchParams();
-  if (tag) params.set("tag", tag);
-
-  const queryString = params.toString();
-  const url = `/api/sites${queryString ? `?${queryString}` : ""}`;
+  const url = goodWebsitesClientKey(fallbackData !== undefined, tag);
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<GoodWebsiteItem[]>(url, fetcher, {
-    // Keep previous data while revalidating to enable optimistic updates
     keepPreviousData: true,
-    // Use server-provided fallback data for instant initial render
-    fallbackData: filteredFallback,
+    fallbackData,
+    revalidateOnMount: false,
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
   });
 
+  const goodWebsites = useMemo(
+    () => resolveGoodWebsitesOrder(fallbackData, data, tag),
+    [data, fallbackData, tag],
+  );
+
   return {
-    goodWebsites: data || filteredFallback || [],
+    goodWebsites,
     isLoading,
     isValidating,
     isError: error,
     mutate,
-    // Helper to determine if this is initial loading vs filter change
-    isInitialLoading: isLoading && !data && !filteredFallback,
+    isInitialLoading: isLoading && !data && fallbackData === undefined,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The conflict

`/sites` randomizes every **5 minutes** (`getGoodWebsitesSeed` = `floor(now / 5min)`). After #2340 / #2341, that shuffle ran **inside** the days-cached Notion island (`use cache` + `cacheLife("days")` + `notion:good-websites`).

First HTML therefore kept whatever permutation was baked when the days cache filled. On hydrate, `useGoodWebsites` SWR-fetched `/api/sites`, which shuffled with the *current* 5-minute seed (and HTTP-cached that for 300s). Refresh: one order paints, then a different permutation replaces it.

Verified on production just now — first HTML and `/api/sites` are different permutations of the same 100 sites (0 of the first 20 names match).

Jotai `sites-table-sort` from localStorage can still reorder after first paint if the visitor saved an explicit column sort. That is unchanged. The default / randomized view no longer flashes.

`/stack` does not shuffle, so it is out of scope.

## The fix

1. **Days-cache the source list only** — `getGoodWebsitesSource()` inside `cacheLife("days")` + `cacheTag("notion:good-websites")`. No seed, no shuffle. Notion purge-cache still drops this island.
2. **Shuffle in a 5-minute cache** — `getCachedShuffledGoodWebsites` uses `cacheLife({ stale/revalidate: 300 })`, computes the seed inside the island (so `cacheComponents` can cache `Date.now()` without `connection()` / a Suspense skeleton), and is tagged `notion:good-websites` so purge busts the order too. No arguments, so `/sites` and `/api/sites` share one permutation.
3. **Client does not reshuffle on mount** — if the server already sent the list, SWR key is `null` and `resolveGoodWebsitesOrder` keeps that permutation (tag filters still apply).

Likes stay outside both cache islands (`getServerLikes` after shuffle), so the #2341 first-paint counts are unchanged.

## Tests

Behavior / correctness only:

- 5-minute seed windows
- Same seed → same order; later windows can permute
- Server order wins over a differently shuffled client fetch
- Days island does not shuffle; shuffle cache is 5 minutes + purge tag
- Hook skips remount fetch when SSR data exists

Full suite: 573 pass.

## Local check (this branch)

Hard-refresh of `/sites` and `/api/sites` return the same 100-name order, and a second refresh keeps it. Production still mismatches.

## Done when

- Hard refresh of `/sites` shows one stable order
- Later visits still re-randomize on the existing 5-minute cadence
- Notion purge-cache for `sites` still busts Redis + `notion:good-websites` + `/sites` + `/api/sites`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-573c4a60-4521-4b59-8af6-a8fbedbc6c6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-573c4a60-4521-4b59-8af6-a8fbedbc6c6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

