### PR TITLE
Capture light and dark site previews from the Notion webhook

### DIFF
--- a/src/app/api/webhooks/capture-site-preview/route.test.ts
+++ b/src/app/api/webhooks/capture-site-preview/route.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+import { POST } from "@/app/api/webhooks/capture-site-preview/route";
+import * as activitySchedule from "@/lib/activity-schedule";
+import * as optimize from "@/lib/image-processing/optimize";
+import { notion } from "@/lib/notion";
+import * as purge from "@/lib/notion/purge";
+import * as r2 from "@/lib/r2/storage";
+import * as screenshot from "@/lib/screenshot";
+
+const TEST_SECRET = "unit-test-webhook-secret";
+
+function webhookRequest(payload: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/webhooks/capture-site-preview", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-webhook-secret": TEST_SECRET,
+      ...headers,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+const notionPayload = {
+  data: {
+    id: "page-123",
+    properties: {
+      URL: { url: "https://example.com" },
+    },
+  },
+};
+
+function notionPage(status?: string) {
+  return {
+    properties: {
+      Name: { title: [{ plain_text: "Example" }] },
+      "Preview Status": status ? { select: { name: status } } : { select: null },
+    },
+  };
+}
+
+describe("POST /api/webhooks/capture-site-preview", () => {
+  const previousSecret = process.env.NOTION_WEBHOOK_VERIFICATION_SECRET;
+  let retrieve: ReturnType<typeof spyOn>;
+  let update: ReturnType<typeof spyOn>;
+  let capture: ReturnType<typeof spyOn>;
+  let upload: ReturnType<typeof spyOn>;
+  let purgeType: ReturnType<typeof spyOn>;
+  let scheduleActivity: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    process.env.NOTION_WEBHOOK_VERIFICATION_SECRET = TEST_SECRET;
+
+    retrieve = spyOn(notion.pages, "retrieve").mockResolvedValue(notionPage("Queued") as never);
+    update = spyOn(notion.pages, "update").mockResolvedValue({} as never);
+    capture = spyOn(screenshot, "captureLightAndDarkScreenshots").mockResolvedValue({
+      light: Buffer.from("light-png"),
+      dark: Buffer.from("dark-png"),
+    });
+    spyOn(optimize, "optimizeSitePreview").mockImplementation(async (buffer) => ({
+      buffer,
+      format: "webp",
+      contentType: "image/webp",
+      width: 1,
+      height: 1,
+      originalSize: buffer.length,
+      optimizedSize: buffer.length,
+      savings: 0,
+    }));
+
+    let uploads = 0;
+    upload = spyOn(r2, "uploadBufferToR2").mockImplementation(async () => {
+      uploads += 1;
+      return uploads === 1 ? "https://cdn.example/light" : "https://cdn.example/dark";
+    });
+    purgeType = spyOn(purge, "purgeContentType").mockResolvedValue(1);
+    scheduleActivity = spyOn(activitySchedule, "afterActivity").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mock.restore();
+    if (previousSecret === undefined) {
+      delete process.env.NOTION_WEBHOOK_VERIFICATION_SECRET;
+    } else {
+      process.env.NOTION_WEBHOOK_VERIFICATION_SECRET = previousSecret;
+    }
+  });
+
+  test("writes Preview Image and Preview Image Dark URLs on success", async () => {
+    const res = await POST(webhookRequest(notionPayload));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.previewUrl).toBe("https://cdn.example/light");
+    expect(body.previewUrlDark).toBe("https://cdn.example/dark");
+
+    expect(capture).toHaveBeenCalledWith("https://example.com");
+    expect(upload).toHaveBeenCalledTimes(2);
+
+    const doneUpdate = update.mock.calls.find(
+      (call) =>
+        (call[0] as { properties?: { "Preview Image"?: unknown } }).properties?.["Preview Image"],
+    );
+    expect(doneUpdate).toBeDefined();
+
+    const properties = (doneUpdate?.[0] as { properties: Record<string, unknown> }).properties;
+    expect(properties["Preview Image"]).toEqual({ url: "https://cdn.example/light" });
+    expect(properties["Preview Image Dark"]).toEqual({ url: "https://cdn.example/dark" });
+    expect(properties["Preview Status"]).toEqual({ select: { name: "Done" } });
+    expect(properties["Preview Updated"]).toEqual({
+      date: { start: expect.any(String) },
+    });
+
+    expect(purgeType).toHaveBeenCalledWith("sites");
+    expect(scheduleActivity).toHaveBeenCalledTimes(1);
+  });
+
+  test("still writes both preview URLs when URL is a plain string", async () => {
+    const res = await POST(
+      webhookRequest({
+        data: { id: "page-123", properties: { URL: "https://example.com" } },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const doneUpdate = update.mock.calls.find(
+      (call) =>
+        (call[0] as { properties?: { "Preview Image"?: unknown } }).properties?.["Preview Image"],
+    );
+    const properties = (doneUpdate?.[0] as { properties: Record<string, unknown> }).properties;
+    expect(properties["Preview Image"]).toEqual({ url: "https://cdn.example/light" });
+    expect(properties["Preview Image Dark"]).toEqual({ url: "https://cdn.example/dark" });
+  });
+
+  test("writes Preview Status Error when capture fails", async () => {
+    capture.mockRejectedValueOnce(new Error("tab crashed"));
+
+    const res = await POST(webhookRequest(notionPayload));
+    expect(res.status).toBe(500);
+
+    const errorUpdate = update.mock.calls.find(
+      (call) =>
+        (call[0] as { properties?: { "Preview Status"?: { select?: { name?: string } } } })
+          .properties?.["Preview Status"]?.select?.name === "Error",
+    );
+    expect(errorUpdate).toBeDefined();
+
+    const properties = (errorUpdate?.[0] as { properties: Record<string, unknown> }).properties;
+    expect(properties["Preview Status"]).toEqual({ select: { name: "Error" } });
+    expect(properties["Preview Error"]).toEqual({
+      rich_text: [{ text: { content: "tab crashed" } }],
+    });
+    expect(properties["Preview Image"]).toBeUndefined();
+    expect(properties["Preview Image Dark"]).toBeUndefined();
+    expect(purgeType).toHaveBeenCalledWith("sites");
+    expect(scheduleActivity).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when the webhook secret does not match", async () => {
+    const res = await POST(webhookRequest(notionPayload, { "x-webhook-secret": "wrong" }));
+    expect(res.status).toBe(401);
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/webhooks/capture-site-preview/route.test.ts
+++ b/src/app/api/webhooks/capture-site-preview/route.test.ts
@@ -10,6 +10,25 @@ import * as screenshot from "@/lib/screenshot";
 
 const TEST_SECRET = "unit-test-webhook-secret";
 
+type NotionUpdateArg = {
+  page_id?: string;
+  properties?: {
+    "Preview Image"?: { url?: string };
+    "Preview Image Dark"?: { url?: string };
+    "Preview Status"?: { select?: { name?: string } };
+    "Preview Error"?: { rich_text?: { text?: { content?: string } }[] };
+    "Preview Updated"?: { date?: { start?: string } };
+  };
+};
+
+function updateArg(call: unknown[]): NotionUpdateArg {
+  return (call[0] ?? {}) as NotionUpdateArg;
+}
+
+function notionUpdates(update: ReturnType<typeof spyOn>): NotionUpdateArg[] {
+  return (update.mock.calls as unknown[][]).map(updateArg);
+}
+
 function webhookRequest(payload: unknown, headers: Record<string, string> = {}): Request {
   return new Request("http://localhost/api/webhooks/capture-site-preview", {
     method: "POST",
@@ -99,13 +118,10 @@ describe("POST /api/webhooks/capture-site-preview", () => {
     expect(capture).toHaveBeenCalledWith("https://example.com");
     expect(upload).toHaveBeenCalledTimes(2);
 
-    const doneUpdate = update.mock.calls.find(
-      (call) =>
-        (call[0] as { properties?: { "Preview Image"?: unknown } }).properties?.["Preview Image"],
-    );
+    const doneUpdate = notionUpdates(update).find((arg) => arg.properties?.["Preview Image"]);
     expect(doneUpdate).toBeDefined();
 
-    const properties = (doneUpdate?.[0] as { properties: Record<string, unknown> }).properties;
+    const properties = doneUpdate?.properties ?? {};
     expect(properties["Preview Image"]).toEqual({ url: "https://cdn.example/light" });
     expect(properties["Preview Image Dark"]).toEqual({ url: "https://cdn.example/dark" });
     expect(properties["Preview Status"]).toEqual({ select: { name: "Done" } });
@@ -125,11 +141,8 @@ describe("POST /api/webhooks/capture-site-preview", () => {
     );
     expect(res.status).toBe(200);
 
-    const doneUpdate = update.mock.calls.find(
-      (call) =>
-        (call[0] as { properties?: { "Preview Image"?: unknown } }).properties?.["Preview Image"],
-    );
-    const properties = (doneUpdate?.[0] as { properties: Record<string, unknown> }).properties;
+    const doneUpdate = notionUpdates(update).find((arg) => arg.properties?.["Preview Image"]);
+    const properties = doneUpdate?.properties ?? {};
     expect(properties["Preview Image"]).toEqual({ url: "https://cdn.example/light" });
     expect(properties["Preview Image Dark"]).toEqual({ url: "https://cdn.example/dark" });
   });
@@ -140,14 +153,12 @@ describe("POST /api/webhooks/capture-site-preview", () => {
     const res = await POST(webhookRequest(notionPayload));
     expect(res.status).toBe(500);
 
-    const errorUpdate = update.mock.calls.find(
-      (call) =>
-        (call[0] as { properties?: { "Preview Status"?: { select?: { name?: string } } } })
-          .properties?.["Preview Status"]?.select?.name === "Error",
+    const errorUpdate = notionUpdates(update).find(
+      (arg) => arg.properties?.["Preview Status"]?.select?.name === "Error",
     );
     expect(errorUpdate).toBeDefined();
 
-    const properties = (errorUpdate?.[0] as { properties: Record<string, unknown> }).properties;
+    const properties = errorUpdate?.properties ?? {};
     expect(properties["Preview Status"]).toEqual({ select: { name: "Error" } });
     expect(properties["Preview Error"]).toEqual({
       rich_text: [{ text: { content: "tab crashed" } }],

--- a/src/app/api/webhooks/capture-site-preview/route.ts
+++ b/src/app/api/webhooks/capture-site-preview/route.ts
@@ -8,10 +8,13 @@ import { optimizeSitePreview } from "@/lib/image-processing/optimize";
 import { notion } from "@/lib/notion";
 import { purgeContentType } from "@/lib/notion/purge";
 import { uploadBufferToR2 } from "@/lib/r2/storage";
-import { captureScreenshot } from "@/lib/screenshot";
+import { captureLightAndDarkScreenshots } from "@/lib/screenshot";
+
+// Two navigations can each take ~30s + settle. One browser, sequential captures.
+export const maxDuration = 120;
 
 /**
- * Webhook endpoint to capture a website screenshot and store it in R2
+ * Webhook endpoint to capture website screenshots and store them in R2
  *
  * POST /api/webhooks/capture-site-preview
  * Notion automation payload: { data: { id, properties: { URL } } }
@@ -19,10 +22,10 @@ import { captureScreenshot } from "@/lib/screenshot";
  * Flow:
  * 1. Extract page ID and URL from Notion webhook
  * 2. Set status to "Processing"
- * 3. Capture screenshot using Puppeteer
- * 4. Optimize image (resize, compress to WebP)
- * 5. Upload to R2 storage
- * 6. Update Notion page with preview URL and status
+ * 3. Capture light and dark viewport screenshots (one browser, two navigations)
+ * 4. Optimize both images (resize, compress to WebP)
+ * 5. Upload both to R2 storage
+ * 6. Update Notion page with preview URLs and status
  */
 export async function POST(request: Request) {
   try {
@@ -90,27 +93,24 @@ export async function POST(request: Request) {
     });
 
     try {
-      // Step 2: Capture screenshot
-      console.log(`Capturing screenshot for: ${url}`);
-      const screenshot = await captureScreenshot(url);
-      console.log(`Screenshot captured: ${(screenshot.length / 1024).toFixed(0)}KB`);
-
-      // Step 3: Optimize the screenshot
-      const optimized = await optimizeSitePreview(screenshot);
+      // Step 2: Capture light and dark screenshots
+      console.log(`Capturing light and dark screenshots for: ${url}`);
+      const screenshots = await captureLightAndDarkScreenshots(url);
       console.log(
-        `Optimized preview: ${optimized.width}x${optimized.height}, ${(optimized.optimizedSize / 1024).toFixed(2)}KB (saved ${optimized.savings.toFixed(1)}%)`,
+        `Screenshots captured: light ${(screenshots.light.length / 1024).toFixed(0)}KB, dark ${(screenshots.dark.length / 1024).toFixed(0)}KB`,
       );
 
-      // Step 4: Upload to R2
-      const r2Url = await uploadBufferToR2(optimized.buffer, optimized.contentType);
-      console.log(`Uploaded to R2: ${r2Url}`);
+      // Step 3–4: Optimize and upload both
+      const previewUrl = await optimizeAndUploadPreview(screenshots.light, "light");
+      const previewUrlDark = await optimizeAndUploadPreview(screenshots.dark, "dark");
 
       // Step 5: Update Notion page with success
       await notion.pages.update({
         page_id: pageId,
         properties: {
           "Preview Status": { select: { name: "Done" } },
-          "Preview Image": { url: r2Url },
+          "Preview Image": { url: previewUrl },
+          "Preview Image Dark": { url: previewUrlDark },
           "Preview Updated": { date: { start: new Date().toISOString() } },
         },
       });
@@ -125,7 +125,8 @@ export async function POST(request: Request) {
         {
           success: true,
           message: "Site preview captured and uploaded successfully",
-          previewUrl: r2Url,
+          previewUrl,
+          previewUrlDark,
         },
         { status: 200 },
       );
@@ -153,4 +154,18 @@ export async function POST(request: Request) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
     return errorResponse(`Failed to capture site preview: ${errorMessage}`, 500, error);
   }
+}
+
+async function optimizeAndUploadPreview(
+  screenshot: Buffer,
+  scheme: "light" | "dark",
+): Promise<string> {
+  const optimized = await optimizeSitePreview(screenshot);
+  console.log(
+    `Optimized ${scheme} preview: ${optimized.width}x${optimized.height}, ${(optimized.optimizedSize / 1024).toFixed(2)}KB (saved ${optimized.savings.toFixed(1)}%)`,
+  );
+
+  const r2Url = await uploadBufferToR2(optimized.buffer, optimized.contentType);
+  console.log(`Uploaded ${scheme} preview to R2: ${r2Url}`);
+  return r2Url;
 }

--- a/src/lib/screenshot/index.test.ts
+++ b/src/lib/screenshot/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { capturePageScreenshot, colorSchemeMediaFeatures } from "@/lib/screenshot";
+
+describe("colorSchemeMediaFeatures", () => {
+  test("requests prefers-color-scheme dark", () => {
+    expect(colorSchemeMediaFeatures("dark")).toEqual([
+      { name: "prefers-color-scheme", value: "dark" },
+    ]);
+  });
+
+  test("requests prefers-color-scheme light", () => {
+    expect(colorSchemeMediaFeatures("light")).toEqual([
+      { name: "prefers-color-scheme", value: "light" },
+    ]);
+  });
+});
+
+describe("capturePageScreenshot", () => {
+  test("emulates dark before navigating", async () => {
+    const order: string[] = [];
+    const emulateMediaFeatures = mock(async () => {
+      order.push("emulate");
+    });
+    const goto = mock(async () => {
+      order.push("goto");
+    });
+    const screenshot = mock(async () => Buffer.from("png"));
+
+    await capturePageScreenshot({ emulateMediaFeatures, goto, screenshot }, "https://example.com", {
+      colorScheme: "dark",
+      settleDelayMs: 0,
+    });
+
+    expect(emulateMediaFeatures).toHaveBeenCalledWith([
+      { name: "prefers-color-scheme", value: "dark" },
+    ]);
+    expect(goto).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({ waitUntil: "networkidle2" }),
+    );
+    expect(order).toEqual(["emulate", "goto"]);
+  });
+});

--- a/src/lib/screenshot/index.ts
+++ b/src/lib/screenshot/index.ts
@@ -1,5 +1,5 @@
 import chromium from "@sparticuz/chromium";
-import puppeteer from "puppeteer-core";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
 
 const VIEWPORT = {
   width: 1280,
@@ -12,8 +12,32 @@ const TIMEOUT = 30000; // 30 seconds
 // the screenshot is of the settled page rather than a splash or fade-in.
 const SETTLE_DELAY = 2500;
 
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
 // Check if running in serverless environment
 const IS_SERVERLESS = !!process.env.AWS_LAMBDA_FUNCTION_NAME || !!process.env.VERCEL;
+
+export type ColorScheme = "light" | "dark";
+
+export type MediaFeature = {
+  name: string;
+  value: string;
+};
+
+/**
+ * Media features that make `prefers-color-scheme` resolve to the given scheme.
+ * Sites that only read the preference at first paint need this set before navigation.
+ */
+export function colorSchemeMediaFeatures(colorScheme: ColorScheme): MediaFeature[] {
+  return [{ name: "prefers-color-scheme", value: colorScheme }];
+}
+
+export type PageLike = {
+  emulateMediaFeatures(features?: MediaFeature[]): Promise<void>;
+  goto(url: string, options?: Record<string, unknown>): Promise<unknown>;
+  screenshot(options?: Record<string, unknown>): Promise<Uint8Array | Buffer | string>;
+};
 
 /**
  * Get the Chrome executable path based on environment
@@ -45,14 +69,10 @@ async function getExecutablePath(): Promise<string> {
   );
 }
 
-/**
- * Capture a screenshot of a website using Puppeteer
- * Works in both local development (uses system Chrome) and serverless (uses @sparticuz/chromium)
- */
-export async function captureScreenshot(url: string): Promise<Buffer> {
+async function launchBrowser(): Promise<Browser> {
   const executablePath = process.env.CHROME_PATH || (await getExecutablePath());
 
-  const browser = await puppeteer.launch({
+  return puppeteer.launch({
     args: IS_SERVERLESS
       ? chromium.args
       : ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
@@ -60,31 +80,80 @@ export async function captureScreenshot(url: string): Promise<Buffer> {
     executablePath,
     headless: true,
   });
+}
+
+async function preparePage(browser: Browser): Promise<Page> {
+  const page = await browser.newPage();
+  await page.setUserAgent(USER_AGENT);
+  return page;
+}
+
+/**
+ * Capture a viewport screenshot after emulating the given color scheme and navigating.
+ *
+ * A second navigation (not a same-page media swap) is the reliable path: many sites
+ * only apply `prefers-color-scheme` on first paint. Emulation is set before `goto`.
+ */
+export async function capturePageScreenshot(
+  page: PageLike,
+  url: string,
+  options: { colorScheme?: ColorScheme; settleDelayMs?: number } = {},
+): Promise<Buffer> {
+  const colorScheme = options.colorScheme ?? "light";
+  const settleDelayMs = options.settleDelayMs ?? SETTLE_DELAY;
+
+  await page.emulateMediaFeatures(colorSchemeMediaFeatures(colorScheme));
+
+  await page.goto(url, {
+    waitUntil: "networkidle2",
+    timeout: TIMEOUT,
+  });
+
+  // Wait in Node (not page JS) so a site that overrides timers still settles
+  await new Promise((resolve) => setTimeout(resolve, settleDelayMs));
+
+  const screenshot = await page.screenshot({
+    type: "png",
+    fullPage: false,
+  });
+
+  return Buffer.from(screenshot);
+}
+
+/**
+ * Capture a screenshot of a website using Puppeteer.
+ * Works in both local development (uses system Chrome) and serverless (uses @sparticuz/chromium).
+ * Defaults to light; pass `{ colorScheme: "dark" }` for a dark capture.
+ */
+export async function captureScreenshot(
+  url: string,
+  options: { colorScheme?: ColorScheme } = {},
+): Promise<Buffer> {
+  const browser = await launchBrowser();
 
   try {
-    const page = await browser.newPage();
+    const page = await preparePage(browser);
+    return await capturePageScreenshot(page, url, options);
+  } finally {
+    await browser.close();
+  }
+}
 
-    // Set a realistic user agent
-    await page.setUserAgent(
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-    );
+/**
+ * Capture light and dark viewport screenshots in one browser session.
+ * Dark is a second navigation with `prefers-color-scheme: dark` already emulated.
+ */
+export async function captureLightAndDarkScreenshots(url: string): Promise<{
+  light: Buffer;
+  dark: Buffer;
+}> {
+  const browser = await launchBrowser();
 
-    // Navigate to the page
-    await page.goto(url, {
-      waitUntil: "networkidle2",
-      timeout: TIMEOUT,
-    });
-
-    // Wait in Node (not page JS) so a site that overrides timers still settles
-    await new Promise((resolve) => setTimeout(resolve, SETTLE_DELAY));
-
-    // Take screenshot of the viewport (not full page)
-    const screenshot = await page.screenshot({
-      type: "png",
-      fullPage: false,
-    });
-
-    return Buffer.from(screenshot);
+  try {
+    const page = await preparePage(browser);
+    const light = await capturePageScreenshot(page, url, { colorScheme: "light" });
+    const dark = await capturePageScreenshot(page, url, { colorScheme: "dark" });
+    return { light, dark };
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Gap

The Good websites gallery already switches on `prefers-color-scheme: dark` via `Preview Image Dark`, and existing rows have both URLs. The Notion **Capture Screenshot** button (`POST /api/webhooks/capture-site-preview`) only captured a default (light) viewport and wrote `Preview Image`. Nothing in code wrote the dark field.

## Fix

Same webhook, same `x-webhook-secret` / `NOTION_WEBHOOK_VERIFICATION_SECRET` auth, same Notion payload shape.

One browser session now:

1. Emulates `prefers-color-scheme: light`, navigates, settles, captures
2. Emulates `prefers-color-scheme: dark`, navigates again, settles, captures

Second navigation (not a same-page media swap) is the reliable path: many sites only apply the preference on first paint. Sites with no dark styles still get a dark capture written — it may look the same; the field is never skipped.

Both images are optimized and uploaded to R2 the same way light worked before. Success writes `Preview Image`, `Preview Image Dark`, `Preview Status: Done`, and `Preview Updated`. Failure still writes `Preview Status: Error` + `Preview Error`. `type=sites` purge and the existing activity emit are unchanged.

`maxDuration` is 120s so two ~32s captures can finish. `previewUrl` stays in the JSON response; `previewUrlDark` is added. Favicon / `update-site-icon` is untouched. No new public API.

## Tests

- Success writes both preview URL properties
- Dark emulation is requested before navigation
- Failed capture still writes Error
- String URL payloads still write both fields (existing callers)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cd392b4-0cac-4806-9707-5a3d3e7b0a12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cd392b4-0cac-4806-9707-5a3d3e7b0a12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

