### PR TITLE
Redirect Overthought URLs and add a custom 404

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,11 +3,15 @@ import { withBotId } from "botid/next/config";
 import type { NextConfig } from "next";
 import path from "path";
 
+import { overthoughtRedirects } from "./src/lib/redirects";
+
 const nextConfig: NextConfig = {
   cacheComponents: true,
   partialPrefetching: true,
   async redirects() {
     return [
+      // Legacy Overthought blog URLs now land on the current writing index.
+      ...overthoughtRedirects,
       // Legacy brianlovin.ai (formerly the brios-api project) now redirects
       // to the main site. Both apex and www hosts, preserving the path.
       {

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import NotFound from "./not-found";
+
+describe("not-found", () => {
+  test("shows the 404 copy and links back home", () => {
+    const html = renderToStaticMarkup(<NotFound />);
+
+    expect(html).toContain("404");
+    expect(html).toContain("You have found yourself in quite a situation");
+    expect(html).toContain("Back home");
+    expect(html).toContain('href="/"');
+  });
+});

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+import { PageTitle } from "@/components/Typography";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-16 text-center">
+        <div className="flex max-w-xl flex-col items-center gap-4 leading-[1.6]">
+          <PageTitle>404</PageTitle>
+          <p className="text-secondary text-xl font-medium text-pretty">
+            You have found yourself in quite a situation
+          </p>
+          <Link href="/" className="link-body">
+            Back home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/redirects.test.ts
+++ b/src/lib/redirects.test.ts
@@ -33,4 +33,3 @@ describe("overthought redirects", () => {
     expect(match?.permanent).toBe(true);
   });
 });
-

--- a/src/lib/redirects.test.ts
+++ b/src/lib/redirects.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import nextConfig from "../../next.config";
+import { redirectDestination } from "./redirects";
+
+async function configuredRedirects() {
+  if (typeof nextConfig.redirects !== "function") {
+    throw new Error("next.config is missing redirects()");
+  }
+  return nextConfig.redirects();
+}
+
+describe("overthought redirects", () => {
+  test("/overthought permanently redirects to /writing", async () => {
+    expect(redirectDestination("/overthought")).toBe("/writing");
+
+    const match = (await configuredRedirects()).find(
+      (redirect) => redirect.source === "/overthought",
+    );
+    expect(match?.destination).toBe("/writing");
+    expect(match?.permanent).toBe(true);
+  });
+
+  test("a nested /overthought/slug permanently redirects to /writing", async () => {
+    expect(redirectDestination("/overthought/investing-for-designers-and-developers")).toBe(
+      "/writing",
+    );
+
+    const match = (await configuredRedirects()).find(
+      (redirect) => redirect.source === "/overthought/:path*",
+    );
+    expect(match?.destination).toBe("/writing");
+    expect(match?.permanent).toBe(true);
+  });
+});
+

--- a/src/lib/redirects.ts
+++ b/src/lib/redirects.ts
@@ -1,0 +1,38 @@
+export type AppRedirect = {
+  source: string;
+  destination: string;
+  permanent: boolean;
+};
+
+export const overthoughtRedirects: AppRedirect[] = [
+  {
+    source: "/overthought",
+    destination: "/writing",
+    permanent: true,
+  },
+  {
+    source: "/overthought/:path*",
+    destination: "/writing",
+    permanent: true,
+  },
+];
+
+function matchRedirectSource(source: string, pathname: string): boolean {
+  if (source === pathname) {
+    return true;
+  }
+
+  if (source.endsWith("/:path*")) {
+    const prefix = source.slice(0, -"/:path*".length);
+    return pathname.startsWith(`${prefix}/`);
+  }
+
+  return false;
+}
+
+export function redirectDestination(pathname: string): string | null {
+  const match = overthoughtRedirects.find((redirect) =>
+    matchRedirectSource(redirect.source, pathname),
+  );
+  return match?.destination ?? null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Old Overthought blog URLs like `/overthought/investing-for-designers-and-developers` currently 404. Unknown paths already reach the App Router (they render through the root layout), but there is no `not-found.tsx`, so visitors get the default Next/Vercel 404.

## Changes

- Permanent redirect `/overthought` and `/overthought/*` to `/writing` via the existing `next.config` `redirects()` list. Query strings can be dropped.
- Add `src/app/not-found.tsx` so unmatched routes show a quiet, on-brand page (site chrome from the root layout):
  - 404
  - You have found yourself in quite a situation
  - Back home → `/`

## Tests

- `/overthought` and a nested `/overthought/slug` redirect to `/writing`
- 404 page shows that exact copy and `Back home` links to `/`

## Verify

- `/overthought` and `/overthought/investing-for-designers-and-developers` land on `/writing`
- `/this-is-not-a-page` shows the custom 404 instead of the default Next/Vercel page

[Custom 404 page with required copy and Back home link](https://cursor.com/agents/bc-769c7011-0622-42d7-9182-5fedb40d4f1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcustom_404_page.webp)
[overthought_redirect_and_custom_404_demo.mp4](https://cursor.com/agents/bc-769c7011-0622-42d7-9182-5fedb40d4f1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverthought_redirect_and_custom_404_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-769c7011-0622-42d7-9182-5fedb40d4f1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-769c7011-0622-42d7-9182-5fedb40d4f1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

