### PR TITLE
Fix /activity globe jitter and idle-frame cost

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -252,46 +252,6 @@
     }
   }
 
-  /* Official COBE bindable-marker fade: --cobe-visible-{id} is `N` or unset. */
-  .activity-globe-dot {
-    position: absolute;
-    z-index: 1;
-    pointer-events: none;
-    transform: translate(-50%, -50%);
-  }
-  .activity-globe-dot-core {
-    display: block;
-    border-radius: 9999px;
-    transition:
-      width 300ms ease,
-      height 300ms ease,
-      box-shadow 300ms ease;
-    box-shadow: 0 0 calc(var(--activity-globe-dot-px, 12px) * 1.15) rgb(252 83 42 / 0.95);
-  }
-  .activity-globe-dot-core.is-focused {
-    background-color: rgb(255 196 92);
-    box-shadow: 0 0 calc(var(--activity-globe-dot-px, 12px) * 2.2) rgb(255 150 60 / 1);
-    animation: activity-globe-focus var(--activity-globe-focus-ms, 1.4s) ease-out;
-  }
-  @keyframes activity-globe-focus {
-    0% {
-      transform: scale(1);
-      filter: brightness(1);
-    }
-    28% {
-      transform: scale(var(--activity-globe-focus-scale, 1.75));
-      filter: brightness(1.55);
-    }
-    100% {
-      transform: scale(1);
-      filter: brightness(1);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .activity-globe-dot-core.is-focused {
-      animation: none;
-    }
-  }
   @keyframes zoom-in {
     from {
       transform: scale(0.95);

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -54,16 +54,20 @@ type AimState = {
   duration: number;
 };
 
+type GlobePerfSnapshot = {
+  frames: number;
+  markerUpdates: number;
+  meanDt: number;
+  p95Dt: number;
+  dropped: number;
+  meanWork: number;
+  p95Work: number;
+};
+
 type GlobePerfTracker = {
-  frame: () => void;
+  frame: (workMs?: number) => void;
   markMarkers: () => void;
-  snapshot: () => {
-    frames: number;
-    markerUpdates: number;
-    meanDt: number;
-    p95Dt: number;
-    dropped: number;
-  };
+  snapshot: () => GlobePerfSnapshot;
 };
 
 function subscribeDark(onChange: () => void): () => void {
@@ -110,30 +114,43 @@ function scrollFeedFromOverlay(overlay: HTMLElement, deltaY: number): void {
   }
 }
 
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1));
+  return sorted[index] ?? 0;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
 function createGlobePerfTracker(): GlobePerfTracker {
   const dts: number[] = [];
+  const works: number[] = [];
   let last = 0;
   let markerUpdates = 0;
   return {
-    frame() {
+    frame(workMs = 0) {
       const now = performance.now();
       if (last) dts.push(now - last);
       last = now;
+      works.push(workMs);
     },
     markMarkers() {
       markerUpdates += 1;
     },
     snapshot() {
-      const sorted = [...dts].sort((a, b) => a - b);
-      const mean = dts.length === 0 ? 0 : dts.reduce((sum, dt) => sum + dt, 0) / dts.length;
-      const p95 =
-        sorted[Math.max(0, Math.floor(sorted.length * 0.95) - (sorted.length > 0 ? 1 : 0))] ?? 0;
+      const sortedDt = [...dts].sort((a, b) => a - b);
+      const sortedWork = [...works].sort((a, b) => a - b);
       return {
         frames: dts.length,
         markerUpdates,
-        meanDt: mean,
-        p95Dt: p95,
+        meanDt: mean(dts),
+        p95Dt: percentile(sortedDt, 0.95),
         dropped: dts.filter((dt) => dt > DROPPED_FRAME_MS).length,
+        meanWork: mean(works),
+        p95Work: percentile(sortedWork, 0.95),
       };
     },
   };
@@ -318,17 +335,23 @@ export function ActivityGlobe({
     themeDirtyRef.current = false;
 
     const perf = isGlobePerfQuery(window.location.search) ? createGlobePerfTracker() : null;
-    let loggedPerf = false;
+    type GlobePerfWindow = Window & {
+      __ACTIVITY_GLOBE_PERF?: ReturnType<GlobePerfTracker["snapshot"]>;
+      __ACTIVITY_GLOBE_PERF_LIVE?: GlobePerfTracker;
+    };
     if (perf) {
-      window.setTimeout(() => {
-        if (loggedPerf) return;
-        loggedPerf = true;
-        const snapshot = perf.snapshot();
-        console.info("[activity-globe]", snapshot);
-        (window as Window & { __ACTIVITY_GLOBE_PERF?: typeof snapshot }).__ACTIVITY_GLOBE_PERF =
-          snapshot;
-      }, 8000);
+      (window as GlobePerfWindow).__ACTIVITY_GLOBE_PERF_LIVE = perf;
     }
+    let loggedPerf = false;
+    const perfTimer = perf
+      ? window.setTimeout(() => {
+          if (loggedPerf) return;
+          loggedPerf = true;
+          const snapshot = perf.snapshot();
+          console.info("[activity-globe]", snapshot);
+          (window as GlobePerfWindow).__ACTIVITY_GLOBE_PERF = snapshot;
+        }, 8000)
+      : 0;
 
     let frame = 0;
     const intersectingRef = { current: true };
@@ -402,8 +425,9 @@ export function ActivityGlobe({
         themeDirtyRef.current = false;
       }
 
+      const workStart = performance.now();
       globe.update(update);
-      perf?.frame();
+      perf?.frame(performance.now() - workStart);
       frame = window.requestAnimationFrame(onRender);
     };
 
@@ -438,6 +462,7 @@ export function ActivityGlobe({
 
     return () => {
       stop();
+      if (perfTimer) window.clearTimeout(perfTimer);
       document.removeEventListener("visibilitychange", onVisibility);
       io.disconnect();
       globeRef.current = null;

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -23,6 +23,7 @@ import {
   globeDevicePixelRatio,
   globeDiameterFromHeight,
   globeMarkersChanged,
+  globeMarkerSizingForMesh,
   type GlobeMarkerSnapshot,
   isGlobePerfQuery,
   latLngToVisibleGlobePose,
@@ -211,9 +212,14 @@ export function ActivityGlobe({
   const [grabbing, setGrabbing] = useState(false);
   const [focusId, setFocusId] = useState<string | null>(null);
 
+  // Sandbox keeps the slider. Live path matches production's 12px + glow at this mesh.
+  const markerSizing = useMemo(
+    () => (configProp ? config : globeMarkerSizingForMesh(layout.size, config)),
+    [config, configProp, layout.size],
+  );
   const markers = useMemo(
-    () => activityRecentGlobeMarkers(events, config.markerRecentCount, config),
-    [events, config],
+    () => activityRecentGlobeMarkers(events, config.markerRecentCount, markerSizing),
+    [events, config.markerRecentCount, markerSizing],
   );
   const newestId = markers[0]?.eventId ?? null;
   const [seenNewestId, setSeenNewestId] = useState(newestId);
@@ -354,7 +360,11 @@ export function ActivityGlobe({
       theta: thetaRef.current,
       markers: cobeGpuMarkers(initialMarkers),
       // DPR 2 already supplies the samples; MSAA on a ~0.72×vh mesh is the idle-frame tax.
-      context: { antialias: false, powerPreference: "high-performance" },
+      context: {
+        antialias: false,
+        powerPreference: "high-performance",
+        desynchronized: true,
+      },
       ...globeCobeOptions(themeRef.current.isDark, configRef.current),
     });
     const cobeStyle = takeNewHeadStyle(stylesBefore);

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -73,6 +73,7 @@ type GlobePerfTracker = {
   frame: (workMs?: number, cheap?: boolean) => void;
   markMarkers: () => void;
   markOptions: () => void;
+  reset: () => void;
   snapshot: () => GlobePerfSnapshot;
 };
 
@@ -151,6 +152,14 @@ function createGlobePerfTracker(): GlobePerfTracker {
     },
     markOptions() {
       optionUpdates += 1;
+    },
+    reset() {
+      dts.length = 0;
+      works.length = 0;
+      last = 0;
+      markerUpdates = 0;
+      optionUpdates = 0;
+      cheapFrames = 0;
     },
     snapshot() {
       const sortedDt = [...dts].sort((a, b) => a - b);

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -17,9 +17,10 @@ import { type ActivityLatLng, activityRecentGlobeMarkers } from "@/lib/activity-
 import {
   cobeGpuMarkers,
   cobeWebGLMarkers,
-  GLOBE_DEVICE_PIXEL_RATIO,
+  GLOBE_DEVICE_PIXEL_RATIO_CAP,
   GLOBE_HANG,
   GLOBE_MESH_MIN,
+  globeDevicePixelRatio,
   globeDiameterFromHeight,
   globeMarkersChanged,
   type GlobeMarkerSnapshot,
@@ -315,6 +316,7 @@ export function ActivityGlobe({
     if (!canvas) return;
 
     const size = sizeRef.current;
+    const dpr = globeDevicePixelRatio();
     const initialMarkers = cobeWebGLMarkers(
       markersRef.current,
       configRef.current,
@@ -322,7 +324,7 @@ export function ActivityGlobe({
     );
     let sentMarkers: GlobeMarkerSnapshot[] = initialMarkers;
     const globe = createGlobe(canvas, {
-      devicePixelRatio: GLOBE_DEVICE_PIXEL_RATIO,
+      devicePixelRatio: dpr,
       width: size,
       height: size,
       phi: phiRef.current,
@@ -355,6 +357,8 @@ export function ActivityGlobe({
 
     let frame = 0;
     const intersectingRef = { current: true };
+    // Reused on the cheap path so idle spin / drag never allocates a new update object.
+    const poseState = { phi: 0, theta: 0 };
 
     const isActive = () =>
       shouldRunGlobeLoop({
@@ -401,28 +405,31 @@ export function ActivityGlobe({
         }
       }
 
-      const update: { phi: number; theta: number } & Record<string, unknown> = {
-        phi: phiRef.current,
-        theta: thetaRef.current,
-      };
+      const markersDirty = markersDirtyRef.current;
+      const themeDirty = themeDirtyRef.current;
+      let update: { phi: number; theta: number } & Record<string, unknown> = poseState;
+      poseState.phi = phiRef.current;
+      poseState.theta = thetaRef.current;
 
-      if (markersDirtyRef.current) {
-        const nextMarkers = cobeWebGLMarkers(
-          markersRef.current,
-          configRef.current,
-          focusIdRef.current,
-        );
-        if (globeMarkersChanged(sentMarkers, nextMarkers)) {
-          update.markers = cobeGpuMarkers(nextMarkers);
-          sentMarkers = nextMarkers;
-          perf?.markMarkers();
+      if (markersDirty || themeDirty) {
+        update = { phi: poseState.phi, theta: poseState.theta };
+        if (markersDirty) {
+          const nextMarkers = cobeWebGLMarkers(
+            markersRef.current,
+            configRef.current,
+            focusIdRef.current,
+          );
+          if (globeMarkersChanged(sentMarkers, nextMarkers)) {
+            update.markers = cobeGpuMarkers(nextMarkers);
+            sentMarkers = nextMarkers;
+            perf?.markMarkers();
+          }
+          markersDirtyRef.current = false;
         }
-        markersDirtyRef.current = false;
-      }
-
-      if (themeDirtyRef.current) {
-        Object.assign(update, globeCobeOptions(themeRef.current.isDark, configRef.current));
-        themeDirtyRef.current = false;
+        if (themeDirty) {
+          Object.assign(update, globeCobeOptions(themeRef.current.isDark, configRef.current));
+          themeDirtyRef.current = false;
+        }
       }
 
       const workStart = performance.now();
@@ -492,6 +499,7 @@ export function ActivityGlobe({
     setGrabbing(true);
   }
 
+  // Pointer-move writes refs only. rAF applies the cheap { phi, theta } update.
   function applyDrag(clientX: number, clientY: number): void {
     const now = performance.now();
     const dx = clientX - lastXRef.current;
@@ -551,8 +559,8 @@ export function ActivityGlobe({
       >
         <canvas
           ref={canvasRef}
-          width={layout.size * GLOBE_DEVICE_PIXEL_RATIO}
-          height={layout.size * GLOBE_DEVICE_PIXEL_RATIO}
+          width={layout.size * GLOBE_DEVICE_PIXEL_RATIO_CAP}
+          height={layout.size * GLOBE_DEVICE_PIXEL_RATIO_CAP}
           className={cn(
             "pointer-events-auto size-full touch-none select-none",
             grabbing ? "cursor-grabbing" : "cursor-grab",

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -17,19 +17,19 @@ import { type ActivityLatLng, activityRecentGlobeMarkers } from "@/lib/activity-
 import {
   cobeGpuMarkers,
   cobeWebGLMarkers,
-  GLOBE_DEVICE_PIXEL_RATIO_CAP,
   GLOBE_HANG,
   GLOBE_MESH_MIN,
   globeDevicePixelRatio,
   globeDiameterFromHeight,
-  globeMarkerFacing,
+  globeMarkerFacingFromUnit,
   globeMarkersChanged,
-  globeMarkerSizingForMesh,
   type GlobeMarkerSnapshot,
   isGlobePerfQuery,
+  latLngToGlobePoint,
   latLngToVisibleGlobePose,
   type MarkerHorizonState,
   muteCobeEmptyRootStyle,
+  selectGlobeMarkerSizing,
   shortestAngleDelta,
   shouldRunGlobeLoop,
   stepMarkerHorizon,
@@ -52,6 +52,7 @@ const MIN_FEED_WIDTH = 720;
 const AIM_MS_MIN = 600;
 const AIM_MS_MAX = 850;
 const DROPPED_FRAME_MS = 20;
+const GLOBE_PERF_SAMPLE_CAP = 600;
 
 type AimState = {
   fromPhi: number;
@@ -150,6 +151,9 @@ function createGlobePerfTracker(): GlobePerfTracker {
       if (last) dts.push(now - last);
       last = now;
       works.push(workMs);
+      if (dts.length > GLOBE_PERF_SAMPLE_CAP) dts.splice(0, dts.length - GLOBE_PERF_SAMPLE_CAP);
+      if (works.length > GLOBE_PERF_SAMPLE_CAP)
+        works.splice(0, works.length - GLOBE_PERF_SAMPLE_CAP);
       if (cheap) cheapFrames += 1;
     },
     markMarkers() {
@@ -218,7 +222,7 @@ export function ActivityGlobe({
 
   // Sandbox keeps the slider. Live path matches production's 12px + glow at this mesh.
   const markerSizing = useMemo(
-    () => (configProp ? config : globeMarkerSizingForMesh(layout.size, config)),
+    () => selectGlobeMarkerSizing(config, layout.size, Boolean(configProp)),
     [config, configProp, layout.size],
   );
   const markers = useMemo(
@@ -350,25 +354,23 @@ export function ActivityGlobe({
     const size = sizeRef.current;
     const dpr = globeDevicePixelRatio();
     const horizon = new Map<string, MarkerHorizonState>();
-    const initialAppear: Record<string, number> = {};
+    const points = new Map<string, [number, number, number]>();
+    const appearById: Record<string, number> = {};
     const primedAt = performance.now();
     for (const marker of markersRef.current) {
-      const facing = globeMarkerFacing(
-        marker.location[0],
-        marker.location[1],
-        phiRef.current,
-        thetaRef.current,
-      );
+      const point = latLngToGlobePoint(marker.location[0], marker.location[1]);
+      points.set(marker.id, point);
+      const facing = globeMarkerFacingFromUnit(point, phiRef.current, thetaRef.current);
       const state = stepMarkerHorizon(undefined, facing, primedAt, 0);
       horizon.set(marker.id, state);
-      initialAppear[marker.id] = state.value;
+      appearById[marker.id] = state.value;
     }
     const initialTheme = globeThemeColors(themeRef.current.isDark, configRef.current);
     const initialMarkers = cobeWebGLMarkers(
       markersRef.current,
       configRef.current,
       focusIdRef.current,
-      initialAppear,
+      appearById,
       initialTheme.baseColor,
     );
     let sentMarkers: GlobeMarkerSnapshot[] = initialMarkers;
@@ -472,27 +474,35 @@ export function ActivityGlobe({
       const liveMarkers = markersRef.current;
       const fadeMs = themeRef.current.prefersReducedMotion ? 0 : configRef.current.markerFadeMs;
       const now = performance.now();
-      const appearById: Record<string, number> = {};
       let horizonDirty = false;
-      const seen = new Set<string>();
+
+      if (markersDirty) {
+        const liveIds = new Set<string>();
+        for (const marker of liveMarkers) liveIds.add(marker.id);
+        for (const id of horizon.keys()) {
+          if (!liveIds.has(id)) horizon.delete(id);
+        }
+        for (const id of points.keys()) {
+          if (!liveIds.has(id)) points.delete(id);
+        }
+        for (const id of Object.keys(appearById)) {
+          if (!liveIds.has(id)) delete appearById[id];
+        }
+      }
+
       for (const marker of liveMarkers) {
-        seen.add(marker.id);
-        const facing = globeMarkerFacing(
-          marker.location[0],
-          marker.location[1],
-          poseState.phi,
-          poseState.theta,
-        );
+        let point = points.get(marker.id);
+        if (!point) {
+          point = latLngToGlobePoint(marker.location[0], marker.location[1]);
+          points.set(marker.id, point);
+        }
+        const facing = globeMarkerFacingFromUnit(point, poseState.phi, poseState.theta);
         const next = stepMarkerHorizon(horizon.get(marker.id), facing, now, fadeMs);
         const prev = horizon.get(marker.id);
         if (next !== prev) {
           horizon.set(marker.id, next);
           if (next.value !== prev?.value) horizonDirty = true;
         }
-        appearById[marker.id] = next.value;
-      }
-      for (const id of horizon.keys()) {
-        if (!seen.has(id)) horizon.delete(id);
       }
 
       let cheap = true;
@@ -500,6 +510,9 @@ export function ActivityGlobe({
         cheap = false;
         update = { phi: poseState.phi, theta: poseState.theta };
         if (markersDirty || horizonDirty) {
+          for (const marker of liveMarkers) {
+            appearById[marker.id] = horizon.get(marker.id)?.value ?? 1;
+          }
           const theme = globeThemeColors(themeRef.current.isDark, configRef.current);
           const nextMarkers = cobeWebGLMarkers(
             liveMarkers,
@@ -560,6 +573,11 @@ export function ActivityGlobe({
     return () => {
       stop();
       if (perfTimer) window.clearTimeout(perfTimer);
+      if (perf) {
+        const win = window as GlobePerfWindow;
+        delete win.__ACTIVITY_GLOBE_PERF;
+        delete win.__ACTIVITY_GLOBE_PERF_LIVE;
+      }
       document.removeEventListener("visibilitychange", onVisibility);
       io.disconnect();
       globeRef.current = null;
@@ -649,8 +667,6 @@ export function ActivityGlobe({
       >
         <canvas
           ref={canvasRef}
-          width={layout.size * GLOBE_DEVICE_PIXEL_RATIO_CAP}
-          height={layout.size * GLOBE_DEVICE_PIXEL_RATIO_CAP}
           className={cn(
             "pointer-events-auto size-full touch-none select-none",
             grabbing ? "cursor-grabbing" : "cursor-grab",

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -3,7 +3,6 @@
 import createGlobe from "cobe";
 import { useReducedMotion } from "motion/react";
 import {
-  type CSSProperties,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -16,22 +15,23 @@ import {
 import type { ActivityEvent } from "@/lib/activity";
 import { type ActivityLatLng, activityRecentGlobeMarkers } from "@/lib/activity-geo";
 import {
-  bindableGlobeMarkers,
+  cobeGpuMarkers,
+  cobeWebGLMarkers,
+  GLOBE_DEVICE_PIXEL_RATIO,
   GLOBE_HANG,
   GLOBE_MESH_MIN,
   globeDiameterFromHeight,
-  globeMapDotPx,
+  globeMarkersChanged,
+  type GlobeMarkerSnapshot,
+  isGlobePerfQuery,
   latLngToVisibleGlobePose,
   shortestAngleDelta,
+  shouldRunGlobeLoop,
 } from "@/lib/activity-globe";
 import {
   type ActivityGlobeConfig,
-  cobeMarkerStyle,
-  cssPx,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
-  markerDotPxForAge,
-  rgbCss,
 } from "@/lib/activity-globe-config";
 import { cn } from "@/lib/utils";
 
@@ -43,6 +43,7 @@ const THETA_LIMIT = Math.PI / 2 - 0.08;
 const MIN_FEED_WIDTH = 720;
 const AIM_MS_MIN = 600;
 const AIM_MS_MAX = 850;
+const DROPPED_FRAME_MS = 20;
 
 type AimState = {
   fromPhi: number;
@@ -53,6 +54,18 @@ type AimState = {
   duration: number;
 };
 
+type GlobePerfTracker = {
+  frame: () => void;
+  markMarkers: () => void;
+  snapshot: () => {
+    frames: number;
+    markerUpdates: number;
+    meanDt: number;
+    p95Dt: number;
+    dropped: number;
+  };
+};
+
 function subscribeDark(onChange: () => void): () => void {
   const observer = new MutationObserver(onChange);
   observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
@@ -61,25 +74,6 @@ function subscribeDark(onChange: () => void): () => void {
 
 function isDarkClass(): boolean {
   return document.documentElement.classList.contains("dark");
-}
-
-function subscribeNoop(): () => void {
-  return () => {};
-}
-
-/**
- * The CSS dots are inert until COBE exists: they sit at `opacity: 0` and anchor
- * to `--cobe-*` positions that only the client creates. Rendering them on the
- * server buys nothing and costs two hydration mismatches — `useReducedMotion()`
- * reads the media query during render, and dot sizes come out of `**`, which is
- * not correctly rounded and so differs in the last bit between Bun and Chrome.
- */
-function useHydrated(): boolean {
-  return useSyncExternalStore(
-    subscribeNoop,
-    () => true,
-    () => false,
-  );
 }
 
 function useIsDark(): boolean {
@@ -116,6 +110,35 @@ function scrollFeedFromOverlay(overlay: HTMLElement, deltaY: number): void {
   }
 }
 
+function createGlobePerfTracker(): GlobePerfTracker {
+  const dts: number[] = [];
+  let last = 0;
+  let markerUpdates = 0;
+  return {
+    frame() {
+      const now = performance.now();
+      if (last) dts.push(now - last);
+      last = now;
+    },
+    markMarkers() {
+      markerUpdates += 1;
+    },
+    snapshot() {
+      const sorted = [...dts].sort((a, b) => a - b);
+      const mean = dts.length === 0 ? 0 : dts.reduce((sum, dt) => sum + dt, 0) / dts.length;
+      const p95 =
+        sorted[Math.max(0, Math.floor(sorted.length * 0.95) - (sorted.length > 0 ? 1 : 0))] ?? 0;
+      return {
+        frames: dts.length,
+        markerUpdates,
+        meanDt: mean,
+        p95Dt: p95,
+        dropped: dts.filter((dt) => dt > DROPPED_FRAME_MS).length,
+      };
+    },
+  };
+}
+
 export function ActivityGlobe({
   events,
   config: configProp,
@@ -142,7 +165,6 @@ export function ActivityGlobe({
   const lastXRef = useRef(0);
   const lastYRef = useRef(0);
   const lastTRef = useRef(0);
-  const hydrated = useHydrated();
   const isDark = useIsDark();
   const prefersReducedMotion = useReducedMotion() === true;
   const [layout, setLayout] = useState({ hasRoom: true, size: GLOBE_MESH_MIN });
@@ -150,8 +172,8 @@ export function ActivityGlobe({
   const [focusId, setFocusId] = useState<string | null>(null);
 
   const markers = useMemo(
-    () => activityRecentGlobeMarkers(events, config.markerRecentCount),
-    [events, config.markerRecentCount],
+    () => activityRecentGlobeMarkers(events, config.markerRecentCount, config),
+    [events, config],
   );
   const newestId = markers[0]?.eventId ?? null;
   const [seenNewestId, setSeenNewestId] = useState(newestId);
@@ -160,16 +182,27 @@ export function ActivityGlobe({
     setFocusId(newestId);
   }
   const markersRef = useRef(markers);
+  const focusIdRef = useRef(focusId);
   const themeRef = useRef({ isDark, prefersReducedMotion });
   const sizeRef = useRef(layout.size);
+  const markersDirtyRef = useRef(false);
+  const themeDirtyRef = useRef(false);
 
   useEffect(() => {
     configRef.current = config;
+    markersDirtyRef.current = true;
+    themeDirtyRef.current = true;
   }, [config]);
 
   useEffect(() => {
     markersRef.current = markers;
+    markersDirtyRef.current = true;
   }, [markers]);
+
+  useEffect(() => {
+    focusIdRef.current = focusId;
+    markersDirtyRef.current = true;
+  }, [focusId]);
 
   useEffect(() => {
     sizeRef.current = layout.size;
@@ -177,6 +210,7 @@ export function ActivityGlobe({
 
   useEffect(() => {
     themeRef.current = { isDark, prefersReducedMotion };
+    themeDirtyRef.current = true;
   }, [isDark, prefersReducedMotion]);
 
   useLayoutEffect(() => {
@@ -263,22 +297,55 @@ export function ActivityGlobe({
     const wrap = wrapRef.current;
     if (!canvas) return;
 
-    const dpr = Math.min(2, window.devicePixelRatio || 1);
     const size = sizeRef.current;
+    const initialMarkers = cobeWebGLMarkers(
+      markersRef.current,
+      configRef.current,
+      focusIdRef.current,
+    );
+    let sentMarkers: GlobeMarkerSnapshot[] = initialMarkers;
     const globe = createGlobe(canvas, {
-      devicePixelRatio: dpr,
+      devicePixelRatio: GLOBE_DEVICE_PIXEL_RATIO,
       width: size,
       height: size,
       phi: phiRef.current,
       theta: thetaRef.current,
-      markers: bindableGlobeMarkers(markersRef.current),
+      markers: cobeGpuMarkers(initialMarkers),
       ...globeCobeOptions(themeRef.current.isDark, configRef.current),
     });
     globeRef.current = globe;
+    markersDirtyRef.current = false;
+    themeDirtyRef.current = false;
+
+    const perf = isGlobePerfQuery(window.location.search) ? createGlobePerfTracker() : null;
+    let loggedPerf = false;
+    if (perf) {
+      window.setTimeout(() => {
+        if (loggedPerf) return;
+        loggedPerf = true;
+        const snapshot = perf.snapshot();
+        console.info("[activity-globe]", snapshot);
+        (window as Window & { __ACTIVITY_GLOBE_PERF?: typeof snapshot }).__ACTIVITY_GLOBE_PERF =
+          snapshot;
+      }, 8000);
+    }
 
     let frame = 0;
+    const intersectingRef = { current: true };
+
+    const isActive = () =>
+      shouldRunGlobeLoop({
+        visibilityState: document.visibilityState,
+        isIntersecting: intersectingRef.current,
+      });
+
     const onRender = () => {
-      const { isDark: nextDark, prefersReducedMotion: reduced } = themeRef.current;
+      if (!isActive()) {
+        frame = 0;
+        return;
+      }
+
+      const { prefersReducedMotion: reduced } = themeRef.current;
       const aimState = aimingRef.current;
 
       if (draggingRef.current) {
@@ -311,18 +378,68 @@ export function ActivityGlobe({
         }
       }
 
-      globe.update({
+      const update: { phi: number; theta: number } & Record<string, unknown> = {
         phi: phiRef.current,
         theta: thetaRef.current,
-        markers: bindableGlobeMarkers(markersRef.current),
-        ...globeCobeOptions(nextDark, configRef.current),
-      });
+      };
+
+      if (markersDirtyRef.current) {
+        const nextMarkers = cobeWebGLMarkers(
+          markersRef.current,
+          configRef.current,
+          focusIdRef.current,
+        );
+        if (globeMarkersChanged(sentMarkers, nextMarkers)) {
+          update.markers = cobeGpuMarkers(nextMarkers);
+          sentMarkers = nextMarkers;
+          perf?.markMarkers();
+        }
+        markersDirtyRef.current = false;
+      }
+
+      if (themeDirtyRef.current) {
+        Object.assign(update, globeCobeOptions(themeRef.current.isDark, configRef.current));
+        themeDirtyRef.current = false;
+      }
+
+      globe.update(update);
+      perf?.frame();
       frame = window.requestAnimationFrame(onRender);
     };
-    frame = window.requestAnimationFrame(onRender);
+
+    const start = () => {
+      if (frame) return;
+      if (!isActive()) return;
+      frame = window.requestAnimationFrame(onRender);
+    };
+
+    const stop = () => {
+      if (!frame) return;
+      window.cancelAnimationFrame(frame);
+      frame = 0;
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") stop();
+      else start();
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+
+    const io = new IntersectionObserver((entries) => {
+      intersectingRef.current = entries.some((entry) => entry.isIntersecting);
+      if (intersectingRef.current) start();
+      else stop();
+    });
+    const overlay = overlayRef.current;
+    if (overlay) io.observe(overlay);
+
+    start();
 
     return () => {
-      window.cancelAnimationFrame(frame);
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+      io.disconnect();
       globeRef.current = null;
       globe.destroy();
       if (wrap && canvas.parentElement && canvas.parentElement !== wrap) {
@@ -409,8 +526,8 @@ export function ActivityGlobe({
       >
         <canvas
           ref={canvasRef}
-          width={layout.size * 2}
-          height={layout.size * 2}
+          width={layout.size * GLOBE_DEVICE_PIXEL_RATIO}
+          height={layout.size * GLOBE_DEVICE_PIXEL_RATIO}
           className={cn(
             "pointer-events-auto size-full touch-none select-none",
             grabbing ? "cursor-grabbing" : "cursor-grab",
@@ -418,8 +535,7 @@ export function ActivityGlobe({
           onWheel={(event) => {
             if (draggingRef.current) return;
             const overlay = overlayRef.current;
-            if (!overlay) return;
-            scrollFeedFromOverlay(overlay, event.deltaY);
+            if (overlay) scrollFeedFromOverlay(overlay, event.deltaY);
           }}
           onPointerDown={(event) => {
             lastXRef.current = event.clientX;
@@ -449,45 +565,6 @@ export function ActivityGlobe({
           onPointerCancel={endDrag}
         />
       </div>
-      {hydrated
-        ? markers.map((marker) => {
-            const px = cssPx(
-              markerDotPxForAge(marker.age, config, globeMapDotPx(layout.size, config.scale)),
-            );
-            return (
-              <span
-                key={marker.id}
-                className="activity-globe-dot"
-                style={
-                  {
-                    ...cobeMarkerStyle(marker.id, {
-                      markerBlurPx: config.markerBlurPx,
-                      markerFadeMs: prefersReducedMotion ? 0 : config.markerFadeMs,
-                    }),
-                    "--activity-globe-focus-scale": 1 + config.focusPulseScale,
-                    "--activity-globe-focus-ms": `${config.focusMs}ms`,
-                  } as CSSProperties
-                }
-              >
-                <span
-                  key={focusId === marker.eventId ? focusId : "idle"}
-                  className={cn(
-                    "activity-globe-dot-core",
-                    focusId === marker.eventId && "is-focused",
-                  )}
-                  style={
-                    {
-                      width: px,
-                      height: px,
-                      backgroundColor: rgbCss(config.markerColor),
-                      "--activity-globe-dot-px": px,
-                    } as CSSProperties
-                  }
-                />
-              </span>
-            );
-          })
-        : null}
     </div>
   );
 }

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -26,8 +26,10 @@ import {
   type GlobeMarkerSnapshot,
   isGlobePerfQuery,
   latLngToVisibleGlobePose,
+  muteCobeEmptyRootStyle,
   shortestAngleDelta,
   shouldRunGlobeLoop,
+  takeNewHeadStyle,
 } from "@/lib/activity-globe";
 import {
   type ActivityGlobeConfig,
@@ -58,6 +60,8 @@ type AimState = {
 type GlobePerfSnapshot = {
   frames: number;
   markerUpdates: number;
+  optionUpdates: number;
+  cheapFrames: number;
   meanDt: number;
   p95Dt: number;
   dropped: number;
@@ -66,8 +70,9 @@ type GlobePerfSnapshot = {
 };
 
 type GlobePerfTracker = {
-  frame: (workMs?: number) => void;
+  frame: (workMs?: number, cheap?: boolean) => void;
   markMarkers: () => void;
+  markOptions: () => void;
   snapshot: () => GlobePerfSnapshot;
 };
 
@@ -131,15 +136,21 @@ function createGlobePerfTracker(): GlobePerfTracker {
   const works: number[] = [];
   let last = 0;
   let markerUpdates = 0;
+  let optionUpdates = 0;
+  let cheapFrames = 0;
   return {
-    frame(workMs = 0) {
+    frame(workMs = 0, cheap = true) {
       const now = performance.now();
       if (last) dts.push(now - last);
       last = now;
       works.push(workMs);
+      if (cheap) cheapFrames += 1;
     },
     markMarkers() {
       markerUpdates += 1;
+    },
+    markOptions() {
+      optionUpdates += 1;
     },
     snapshot() {
       const sortedDt = [...dts].sort((a, b) => a - b);
@@ -147,6 +158,8 @@ function createGlobePerfTracker(): GlobePerfTracker {
       return {
         frames: dts.length,
         markerUpdates,
+        optionUpdates,
+        cheapFrames,
         meanDt: mean(dts),
         p95Dt: percentile(sortedDt, 0.95),
         dropped: dts.filter((dt) => dt > DROPPED_FRAME_MS).length,
@@ -323,6 +336,7 @@ export function ActivityGlobe({
       focusIdRef.current,
     );
     let sentMarkers: GlobeMarkerSnapshot[] = initialMarkers;
+    const stylesBefore = new Set(document.head.querySelectorAll("style"));
     const globe = createGlobe(canvas, {
       devicePixelRatio: dpr,
       width: size,
@@ -330,8 +344,12 @@ export function ActivityGlobe({
       phi: phiRef.current,
       theta: thetaRef.current,
       markers: cobeGpuMarkers(initialMarkers),
+      // DPR 2 already supplies the samples; MSAA on a ~0.72×vh mesh is the idle-frame tax.
+      context: { antialias: false, powerPreference: "high-performance" },
       ...globeCobeOptions(themeRef.current.isDark, configRef.current),
     });
+    const cobeStyle = takeNewHeadStyle(stylesBefore);
+    if (cobeStyle) muteCobeEmptyRootStyle(cobeStyle);
     globeRef.current = globe;
     markersDirtyRef.current = false;
     themeDirtyRef.current = false;
@@ -411,7 +429,9 @@ export function ActivityGlobe({
       poseState.phi = phiRef.current;
       poseState.theta = thetaRef.current;
 
+      let cheap = true;
       if (markersDirty || themeDirty) {
+        cheap = false;
         update = { phi: poseState.phi, theta: poseState.theta };
         if (markersDirty) {
           const nextMarkers = cobeWebGLMarkers(
@@ -429,12 +449,13 @@ export function ActivityGlobe({
         if (themeDirty) {
           Object.assign(update, globeCobeOptions(themeRef.current.isDark, configRef.current));
           themeDirtyRef.current = false;
+          perf?.markOptions();
         }
       }
 
       const workStart = performance.now();
       globe.update(update);
-      perf?.frame(performance.now() - workStart);
+      perf?.frame(performance.now() - workStart, cheap);
       frame = window.requestAnimationFrame(onRender);
     };
 

--- a/src/components/ActivityGlobe.tsx
+++ b/src/components/ActivityGlobe.tsx
@@ -22,20 +22,24 @@ import {
   GLOBE_MESH_MIN,
   globeDevicePixelRatio,
   globeDiameterFromHeight,
+  globeMarkerFacing,
   globeMarkersChanged,
   globeMarkerSizingForMesh,
   type GlobeMarkerSnapshot,
   isGlobePerfQuery,
   latLngToVisibleGlobePose,
+  type MarkerHorizonState,
   muteCobeEmptyRootStyle,
   shortestAngleDelta,
   shouldRunGlobeLoop,
+  stepMarkerHorizon,
   takeNewHeadStyle,
 } from "@/lib/activity-globe";
 import {
   type ActivityGlobeConfig,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
   globeCobeOptions,
+  globeThemeColors,
 } from "@/lib/activity-globe-config";
 import { cn } from "@/lib/utils";
 
@@ -345,10 +349,27 @@ export function ActivityGlobe({
 
     const size = sizeRef.current;
     const dpr = globeDevicePixelRatio();
+    const horizon = new Map<string, MarkerHorizonState>();
+    const initialAppear: Record<string, number> = {};
+    const primedAt = performance.now();
+    for (const marker of markersRef.current) {
+      const facing = globeMarkerFacing(
+        marker.location[0],
+        marker.location[1],
+        phiRef.current,
+        thetaRef.current,
+      );
+      const state = stepMarkerHorizon(undefined, facing, primedAt, 0);
+      horizon.set(marker.id, state);
+      initialAppear[marker.id] = state.value;
+    }
+    const initialTheme = globeThemeColors(themeRef.current.isDark, configRef.current);
     const initialMarkers = cobeWebGLMarkers(
       markersRef.current,
       configRef.current,
       focusIdRef.current,
+      initialAppear,
+      initialTheme.baseColor,
     );
     let sentMarkers: GlobeMarkerSnapshot[] = initialMarkers;
     const stylesBefore = new Set(document.head.querySelectorAll("style"));
@@ -448,15 +469,44 @@ export function ActivityGlobe({
       poseState.phi = phiRef.current;
       poseState.theta = thetaRef.current;
 
+      const liveMarkers = markersRef.current;
+      const fadeMs = themeRef.current.prefersReducedMotion ? 0 : configRef.current.markerFadeMs;
+      const now = performance.now();
+      const appearById: Record<string, number> = {};
+      let horizonDirty = false;
+      const seen = new Set<string>();
+      for (const marker of liveMarkers) {
+        seen.add(marker.id);
+        const facing = globeMarkerFacing(
+          marker.location[0],
+          marker.location[1],
+          poseState.phi,
+          poseState.theta,
+        );
+        const next = stepMarkerHorizon(horizon.get(marker.id), facing, now, fadeMs);
+        const prev = horizon.get(marker.id);
+        if (next !== prev) {
+          horizon.set(marker.id, next);
+          if (next.value !== prev?.value) horizonDirty = true;
+        }
+        appearById[marker.id] = next.value;
+      }
+      for (const id of horizon.keys()) {
+        if (!seen.has(id)) horizon.delete(id);
+      }
+
       let cheap = true;
-      if (markersDirty || themeDirty) {
+      if (markersDirty || themeDirty || horizonDirty) {
         cheap = false;
         update = { phi: poseState.phi, theta: poseState.theta };
-        if (markersDirty) {
+        if (markersDirty || horizonDirty) {
+          const theme = globeThemeColors(themeRef.current.isDark, configRef.current);
           const nextMarkers = cobeWebGLMarkers(
-            markersRef.current,
+            liveMarkers,
             configRef.current,
             focusIdRef.current,
+            appearById,
+            theme.baseColor,
           );
           if (globeMarkersChanged(sentMarkers, nextMarkers)) {
             update.markers = cobeGpuMarkers(nextMarkers);

--- a/src/components/ActivityGlobeSandboxPanel.test.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.test.tsx
@@ -11,6 +11,7 @@ describe("ActivityGlobeSandboxPanel", () => {
     );
 
     expect(markup).toContain("Diffuse");
+    expect(markup).toContain("Horizon fade");
     expect(markup).toContain('role="slider"');
     expect(markup).toContain("0.60");
     expect(markup).not.toContain('type="range"');

--- a/src/components/ActivityGlobeSandboxPanel.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.tsx
@@ -40,7 +40,7 @@ const COBE_SLIDERS: SliderDef[] = [
 ];
 
 const MARKER_SLIDERS: SliderDef[] = [
-  { key: "markerBaseSize", label: "Dot size", min: 0.008, max: 0.08, step: 0.002 },
+  { key: "markerBaseSize", label: "Dot size", min: 0.008, max: 0.12, step: 0.002 },
   { key: "markerRecentCount", label: "Recent markers", min: 1, max: 16, step: 1 },
   { key: "markerAgeShrink", label: "Age size shrink", min: 0.04, max: 0.25, step: 0.01 },
   { key: "focusPulseScale", label: "Focus size pulse", min: 0, max: 1.5, step: 0.05 },

--- a/src/components/ActivityGlobeSandboxPanel.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.tsx
@@ -41,6 +41,7 @@ const COBE_SLIDERS: SliderDef[] = [
 
 const MARKER_SLIDERS: SliderDef[] = [
   { key: "markerBaseSize", label: "Dot size", min: 0.008, max: 0.12, step: 0.002 },
+  { key: "markerFadeMs", label: "Horizon fade (ms)", min: 0, max: 800, step: 25 },
   { key: "markerRecentCount", label: "Recent markers", min: 1, max: 16, step: 1 },
   { key: "markerAgeShrink", label: "Age size shrink", min: 0.04, max: 0.25, step: 0.01 },
   { key: "focusPulseScale", label: "Focus size pulse", min: 0, max: 1.5, step: 0.05 },

--- a/src/components/ActivityGlobeSandboxPanel.tsx
+++ b/src/components/ActivityGlobeSandboxPanel.tsx
@@ -40,9 +40,7 @@ const COBE_SLIDERS: SliderDef[] = [
 ];
 
 const MARKER_SLIDERS: SliderDef[] = [
-  { key: "markerDotPx", label: "Dot size (px)", min: 3, max: 16, step: 1 },
-  { key: "markerBlurPx", label: "Horizon blur (px)", min: 0, max: 20, step: 1 },
-  { key: "markerFadeMs", label: "Horizon fade (ms)", min: 0, max: 800, step: 25 },
+  { key: "markerBaseSize", label: "Dot size", min: 0.008, max: 0.08, step: 0.002 },
   { key: "markerRecentCount", label: "Recent markers", min: 1, max: 16, step: 1 },
   { key: "markerAgeShrink", label: "Age size shrink", min: 0.04, max: 0.25, step: 0.01 },
   { key: "focusPulseScale", label: "Focus size pulse", min: 0, max: 1.5, step: 0.05 },
@@ -173,7 +171,7 @@ export function ActivityGlobeSandboxPanel({
         </div>
 
         <GlobeSliderSection
-          title="Markers (CSS fade)"
+          title="Markers"
           sliders={MARKER_SLIDERS}
           config={config}
           onPatch={patch}

--- a/src/lib/activity-geo.ts
+++ b/src/lib/activity-geo.ts
@@ -2,6 +2,7 @@ import { COUNTRY_CENTROIDS } from "./activity-geo-centroids";
 import {
   type ActivityGlobeConfig,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
+  markerSizeForAge,
   markerSizeFromCount,
 } from "./activity-globe-config";
 
@@ -62,7 +63,7 @@ export function activityGlobeLocationKey(lat: number, lng: number): string {
   return `${lat.toFixed(1)},${lng.toFixed(1)}`;
 }
 
-/** Stable CSS-safe id for COBE bindable markers (`--cobe-{id}`). */
+/** Stable id for a location bucket (used for marker identity, not CSS anchors). */
 export function activityGlobeMarkerId(lat: number, lng: number): string {
   const encode = (value: number): string =>
     value.toFixed(1).replaceAll("-", "n").replaceAll(".", "d");
@@ -717,8 +718,10 @@ export function activityGlobeMarkers(
 export function activityRecentGlobeMarkers(
   events: Array<{ id?: string; type?: string; source?: string; meta?: Record<string, unknown> }>,
   limit: number,
+  sizeConfig?: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerAgeShrink">,
 ): ActivityRecentGlobeMarker[] {
   const cap = Math.max(0, Math.floor(limit));
+  const sizing = sizeConfig ?? DEFAULT_ACTIVITY_GLOBE_CONFIG;
   const seen = new Set<string>();
   const markers: ActivityRecentGlobeMarker[] = [];
   for (const event of events) {
@@ -728,12 +731,13 @@ export function activityRecentGlobeMarkers(
     const key = activityGlobeLocationKey(loc.lat, loc.lng);
     if (seen.has(key)) continue;
     seen.add(key);
+    const age = markers.length;
     markers.push({
       id: activityGlobeMarkerId(loc.lat, loc.lng),
       eventId: typeof event.id === "string" && event.id ? event.id : key,
       location: [loc.lat, loc.lng],
-      size: 0,
-      age: markers.length,
+      size: markerSizeForAge(age, sizing),
+      age,
     });
   }
   return markers;

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  cobeMarkerStyle,
-  cssPx,
   DEFAULT_ACTIVITY_GLOBE_CONFIG,
+  focusMarkerColor,
   globeCobeOptions,
   globeThemeColors,
   markerAgeScale,
-  markerDotPxForAge,
-  markerDotPxForSize,
+  markerSizeForAge,
   markerSizeFromCount,
-  rgbCss,
 } from "./activity-globe-config";
 
 describe("activity-globe-config", () => {
@@ -19,12 +16,6 @@ describe("activity-globe-config", () => {
     expect(markerSizeFromCount(1, cfg)).toBeCloseTo(cfg.markerBaseSize);
     expect(markerSizeFromCount(4, cfg)).toBeGreaterThan(markerSizeFromCount(1, cfg));
     expect(markerSizeFromCount(10_000, cfg)).toBeCloseTo(cfg.markerMaxSize);
-  });
-
-  test("markerDotPxForSize scales the CSS dot with visit count", () => {
-    const cfg = DEFAULT_ACTIVITY_GLOBE_CONFIG;
-    expect(markerDotPxForSize(cfg.markerBaseSize, cfg)).toBeCloseTo(cfg.markerDotPx);
-    expect(markerDotPxForSize(cfg.markerBaseSize * 2, cfg)).toBeCloseTo(cfg.markerDotPx * 2);
   });
 
   test("globeThemeColors and globeCobeOptions switch light and dark palettes", () => {
@@ -39,16 +30,6 @@ describe("activity-globe-config", () => {
     );
   });
 
-  test("cobeMarkerStyle matches the official visibility recipe", () => {
-    const style = cobeMarkerStyle("sf", DEFAULT_ACTIVITY_GLOBE_CONFIG);
-    expect(style.positionAnchor).toBe("--cobe-sf");
-    expect(style.left).toBe("anchor(center)");
-    expect(style.top).toBe("anchor(center)");
-    expect(style.opacity).toBe("var(--cobe-visible-sf, 0)");
-    expect(style.filter).toBe("blur(calc((1 - var(--cobe-visible-sf, 0)) * 8px))");
-    expect(String(style.transition)).toContain("opacity 300ms");
-  });
-
   test("markerAgeScale shrinks ~10% per older marker", () => {
     expect(markerAgeScale(0, 0.1)).toBe(1);
     expect(markerAgeScale(1, 0.1)).toBeCloseTo(0.9);
@@ -57,21 +38,16 @@ describe("activity-globe-config", () => {
     expect(markerAgeScale(1, DEFAULT_ACTIVITY_GLOBE_CONFIG.markerAgeShrink)).toBeCloseTo(0.9);
   });
 
-  test("markerDotPxForAge never shrinks below the land-dot floor", () => {
+  test("markerSizeForAge shrinks from markerBaseSize", () => {
     const cfg = DEFAULT_ACTIVITY_GLOBE_CONFIG;
-    expect(markerDotPxForAge(0, cfg, 5)).toBeCloseTo(cfg.markerDotPx);
-    expect(markerDotPxForAge(9, cfg, 5)).toBe(5);
-    expect(markerDotPxForAge(9, cfg, 0)).toBeCloseTo(cfg.markerDotPx * 0.9 ** 9);
+    expect(markerSizeForAge(0, cfg)).toBeCloseTo(cfg.markerBaseSize);
+    expect(markerSizeForAge(1, cfg)).toBeCloseTo(cfg.markerBaseSize * 0.9);
+    expect(markerSizeForAge(2, cfg)).toBeGreaterThan(0);
   });
 
-  test("cssPx rounds floats so SSR and client serialize the same", () => {
-    expect(cssPx(7.8732000000000015)).toBe("7.87px");
-    expect(cssPx(7.873200000000001)).toBe("7.87px");
-    expect(cssPx(12)).toBe("12px");
-    expect(cssPx(Number.NaN)).toBe("0px");
-  });
-
-  test("rgbCss emits a hex color", () => {
-    expect(rgbCss(DEFAULT_ACTIVITY_GLOBE_CONFIG.markerColor)).toBe("#fc532a");
+  test("focusMarkerColor stays in 0–1 and is brighter than the base orange", () => {
+    const focused = focusMarkerColor(DEFAULT_ACTIVITY_GLOBE_CONFIG.markerColor);
+    expect(focused.every((channel) => channel >= 0 && channel <= 1)).toBe(true);
+    expect(focused[0]).toBeGreaterThan(DEFAULT_ACTIVITY_GLOBE_CONFIG.markerColor[0]);
   });
 });

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -43,8 +43,6 @@ describe("activity-globe-config", () => {
     expect(markerSizeForAge(0, cfg)).toBeCloseTo(cfg.markerBaseSize);
     expect(markerSizeForAge(1, cfg)).toBeCloseTo(cfg.markerBaseSize * 0.9);
     expect(markerSizeForAge(2, cfg)).toBeGreaterThan(0);
-    // Newest discs must match the old ~12px CSS + glow weight.
-    expect(markerSizeForAge(0, cfg)).toBeGreaterThanOrEqual(0.06);
     expect(markerSizeForAge(9, cfg)).toBeGreaterThanOrEqual(cfg.markerBaseSize * 0.5);
   });
 

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -38,13 +38,19 @@ describe("activity-globe-config", () => {
     expect(markerAgeScale(1, DEFAULT_ACTIVITY_GLOBE_CONFIG.markerAgeShrink)).toBeCloseTo(0.9);
   });
 
-  test("markerSizeForAge shrinks from markerBaseSize", () => {
+  test("markerSizeForAge shrinks from markerBaseSize and floors the trail", () => {
     const cfg = DEFAULT_ACTIVITY_GLOBE_CONFIG;
     expect(markerSizeForAge(0, cfg)).toBeCloseTo(cfg.markerBaseSize);
     expect(markerSizeForAge(1, cfg)).toBeCloseTo(cfg.markerBaseSize * 0.9);
     expect(markerSizeForAge(2, cfg)).toBeGreaterThan(0);
-    // Newest discs must stay near the old 12px CSS weight, not the 0.018 pinprick.
-    expect(markerSizeForAge(0, cfg)).toBeGreaterThanOrEqual(0.04);
+    // Newest discs must match the old ~12px CSS + glow weight.
+    expect(markerSizeForAge(0, cfg)).toBeGreaterThanOrEqual(0.06);
+    expect(markerSizeForAge(9, cfg)).toBeGreaterThanOrEqual(cfg.markerBaseSize * 0.5);
+  });
+
+  test("default mapSamples stays in the 12k–14k band", () => {
+    expect(DEFAULT_ACTIVITY_GLOBE_CONFIG.mapSamples).toBeGreaterThanOrEqual(12000);
+    expect(DEFAULT_ACTIVITY_GLOBE_CONFIG.mapSamples).toBeLessThanOrEqual(14000);
   });
 
   test("focusMarkerColor stays in 0–1 and is brighter than the base orange", () => {

--- a/src/lib/activity-globe-config.test.ts
+++ b/src/lib/activity-globe-config.test.ts
@@ -43,6 +43,8 @@ describe("activity-globe-config", () => {
     expect(markerSizeForAge(0, cfg)).toBeCloseTo(cfg.markerBaseSize);
     expect(markerSizeForAge(1, cfg)).toBeCloseTo(cfg.markerBaseSize * 0.9);
     expect(markerSizeForAge(2, cfg)).toBeGreaterThan(0);
+    // Newest discs must stay near the old 12px CSS weight, not the 0.018 pinprick.
+    expect(markerSizeForAge(0, cfg)).toBeGreaterThanOrEqual(0.04);
   });
 
   test("focusMarkerColor stays in 0–1 and is brighter than the base orange", () => {

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -70,9 +70,10 @@ export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
   darkGlowColor: [0.12, 0.12, 0.12],
   markerColor: [252 / 255, 83 / 255, 42 / 255],
 
-  markerBaseSize: 0.018,
-  markerSizePerLog: 0.007,
-  markerMaxSize: 0.05,
+  // ~12px CSS disc + glow on a 512–900px mesh. 0.018 read as a pinprick.
+  markerBaseSize: 0.045,
+  markerSizePerLog: 0.01,
+  markerMaxSize: 0.09,
 
   markerDotPx: 12,
   markerBlurPx: 8,

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -1,4 +1,4 @@
-/** Tunable COBE + CSS bindable-marker settings for the activity globe. */
+/** Tunable COBE settings for the activity globe. */
 
 export type RgbTriplet = [number, number, number];
 
@@ -20,12 +20,12 @@ export type ActivityGlobeConfig = {
   darkGlowColor: RgbTriplet;
   markerColor: RgbTriplet;
 
-  /** CSS dot scale from visit-count buckets. */
+  /** WebGL disc scale from visit-count buckets / age trail. */
   markerBaseSize: number;
   markerSizePerLog: number;
   markerMaxSize: number;
 
-  /** Bindable CSS dots — same recipe as https://cobe.vercel.app */
+  /** Unused by the live WebGL path; kept so sandbox JSON stays stable. */
   markerDotPx: number;
   markerBlurPx: number;
   markerFadeMs: number;
@@ -44,23 +44,12 @@ export function markerAgeScale(age: number, shrink: number): number {
   return (1 - shrink) ** age;
 }
 
-/** Newest is `markerDotPx`; each older step shrinks, never below the land-dot floor. */
-export function markerDotPxForAge(
+/** Newest is `markerBaseSize`; each older step shrinks by `markerAgeShrink`. */
+export function markerSizeForAge(
   age: number,
-  config: Pick<ActivityGlobeConfig, "markerDotPx" | "markerAgeShrink">,
-  minPx: number,
+  config: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerAgeShrink">,
 ): number {
-  const scaled = config.markerDotPx * markerAgeScale(age, config.markerAgeShrink);
-  const floor = Number.isFinite(minPx) ? Math.max(0, minPx) : 0;
-  return Math.max(floor, scaled);
-}
-
-export function markerDotPxForSize(
-  size: number,
-  config: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerDotPx">,
-): number {
-  if (config.markerBaseSize <= 0) return config.markerDotPx;
-  return config.markerDotPx * (size / config.markerBaseSize);
+  return config.markerBaseSize * markerAgeScale(age, config.markerAgeShrink);
 }
 
 export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
@@ -135,40 +124,11 @@ export function globeCobeOptions(isDark: boolean, config: ActivityGlobeConfig) {
   };
 }
 
-/**
- * Rounded `Npx` string for inline styles.
- *
- * `**` is not correctly rounded, so the SSR runtime and the browser can disagree
- * in the last bit: `12 * 0.9 ** 4` is `7.8732000000000015` in Bun/Node and
- * `7.873200000000001` in Chrome. React hydration compares the raw `style`
- * attribute string, so that one bit is a mismatch. Rounding kills it.
- */
-export function cssPx(value: number): string {
-  if (!Number.isFinite(value)) return "0px";
-  return `${Number(value.toFixed(2))}px`;
-}
-
-/** Hex keeps the marker color one stable token in the serialized style attribute. */
-export function rgbCss(color: RgbTriplet): string {
-  const channel = (value: number) =>
-    Math.round(Math.min(1, Math.max(0, value)) * 255)
-      .toString(16)
-      .padStart(2, "0");
-  return `#${channel(color[0])}${channel(color[1])}${channel(color[2])}`;
-}
-
-/** Official COBE bindable-marker visibility: `--cobe-visible-{id}` is `N` or unset. */
-export function cobeMarkerStyle(
-  markerId: string,
-  config: Pick<ActivityGlobeConfig, "markerBlurPx" | "markerFadeMs">,
-): Record<string, string | number> {
-  const visible = `--cobe-visible-${markerId}`;
-  return {
-    positionAnchor: `--cobe-${markerId}`,
-    left: "anchor(center)",
-    top: "anchor(center)",
-    opacity: `var(${visible}, 0)`,
-    filter: `blur(calc((1 - var(${visible}, 0)) * ${config.markerBlurPx}px))`,
-    transition: `opacity ${config.markerFadeMs}ms ease, filter ${config.markerFadeMs}ms ease`,
-  };
+/** Brighter orange for the briefly focused newest pin — no CSS animation. */
+export function focusMarkerColor(color: RgbTriplet): RgbTriplet {
+  return [
+    Math.min(1, color[0] * 0.25 + 0.75),
+    Math.min(1, color[1] * 0.35 + 0.55),
+    Math.min(1, color[2] * 0.35 + 0.18),
+  ];
 }

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -55,8 +55,8 @@ export function markerSizeForAge(
 
 export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
   diffuse: 0.6,
-  // 19000 at DPR 2 on a ~0.72×vh mesh dropped frames on retina. 13000 keeps land readable.
-  mapSamples: 13000,
+  // 19000 at DPR 2 on a ~0.72×vh mesh dropped frames. 12000 is the low end that still reads.
+  mapSamples: 12000,
   mapBrightness: 3.1,
   mapBaseBrightness: 0,
   mapBrightnessDark: 6,
@@ -72,7 +72,7 @@ export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
   darkGlowColor: [0.12, 0.12, 0.12],
   markerColor: [252 / 255, 83 / 255, 42 / 255],
 
-  // Cobe clip radius ≈ size * mesh/4. 0.08 ≈ 12px disc + the old 1.15× glow.
+  // Fallback / sandbox. Live path converts 12px+glow → Cobe units at the mesh size.
   markerBaseSize: 0.08,
   markerSizePerLog: 0.014,
   markerMaxSize: 0.14,

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -44,17 +44,19 @@ export function markerAgeScale(age: number, shrink: number): number {
   return (1 - shrink) ** age;
 }
 
-/** Newest is `markerBaseSize`; each older step shrinks by `markerAgeShrink`. */
+/** Newest is `markerBaseSize`; each older step shrinks, never below half that. */
 export function markerSizeForAge(
   age: number,
   config: Pick<ActivityGlobeConfig, "markerBaseSize" | "markerAgeShrink">,
 ): number {
-  return config.markerBaseSize * markerAgeScale(age, config.markerAgeShrink);
+  const scaled = config.markerBaseSize * markerAgeScale(age, config.markerAgeShrink);
+  return Math.max(config.markerBaseSize * 0.5, scaled);
 }
 
 export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
   diffuse: 0.6,
-  mapSamples: 19000,
+  // 19000 at DPR 2 on a ~0.72×vh mesh dropped frames on retina. 13000 keeps land readable.
+  mapSamples: 13000,
   mapBrightness: 3.1,
   mapBaseBrightness: 0,
   mapBrightnessDark: 6,
@@ -70,10 +72,10 @@ export const DEFAULT_ACTIVITY_GLOBE_CONFIG: ActivityGlobeConfig = {
   darkGlowColor: [0.12, 0.12, 0.12],
   markerColor: [252 / 255, 83 / 255, 42 / 255],
 
-  // ~12px CSS disc + glow on a 512–900px mesh. 0.018 read as a pinprick.
-  markerBaseSize: 0.045,
-  markerSizePerLog: 0.01,
-  markerMaxSize: 0.09,
+  // Cobe clip radius ≈ size * mesh/4. 0.08 ≈ 12px disc + the old 1.15× glow.
+  markerBaseSize: 0.08,
+  markerSizePerLog: 0.014,
+  markerMaxSize: 0.14,
 
   markerDotPx: 12,
   markerBlurPx: 8,

--- a/src/lib/activity-globe-config.ts
+++ b/src/lib/activity-globe-config.ts
@@ -25,9 +25,11 @@ export type ActivityGlobeConfig = {
   markerSizePerLog: number;
   markerMaxSize: number;
 
-  /** Unused by the live WebGL path; kept so sandbox JSON stays stable. */
+  /** Unused leftover from the CSS-dot era. Live dots use Cobe `size`. */
   markerDotPx: number;
+  /** Unused leftover from the CSS-dot era. Live dots use Cobe `size`. */
   markerBlurPx: number;
+  /** Appear ease on the front of the globe. Hide snaps because Cobe culls the back. */
   markerFadeMs: number;
   /** How many recent unique locations stay on the globe. */
   markerRecentCount: number;

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -18,6 +18,7 @@ import {
   latLngToVisibleGlobePose,
   projectGlobeMarker,
   shortestAngleDelta,
+  shouldCommitCobeRootStyle,
   shouldRunGlobeLoop,
 } from "./activity-globe";
 import { DEFAULT_ACTIVITY_GLOBE_CONFIG } from "./activity-globe-config";
@@ -178,6 +179,17 @@ describe("isGlobePerfQuery", () => {
     expect(isGlobePerfQuery("?globePerf=1")).toBe(true);
     expect(isGlobePerfQuery("?globePerf=0")).toBe(false);
     expect(isGlobePerfQuery("")).toBe(false);
+  });
+});
+
+describe("shouldCommitCobeRootStyle", () => {
+  test("skips identical and empty :root writes", () => {
+    expect(shouldCommitCobeRootStyle(":root{}", "")).toBe(false);
+    expect(shouldCommitCobeRootStyle("", "")).toBe(false);
+    expect(shouldCommitCobeRootStyle(":root{--cobe-visible-a:N;}", "")).toBe(true);
+    expect(
+      shouldCommitCobeRootStyle(":root{--cobe-visible-a:N;}", ":root{--cobe-visible-a:N;}"),
+    ).toBe(false);
   });
 });
 

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -2,17 +2,22 @@ import { describe, expect, test } from "bun:test";
 
 import { activityGlobeMarkerIdForLocation, activityRecentGlobeMarkers } from "./activity-geo";
 import {
+  cobeCssPxForSize,
   cobeGpuMarkers,
+  cobeSizeForCssPx,
   cobeWebGLMarkers,
   GLOBE_DEVICE_PIXEL_RATIO_CAP,
   GLOBE_HANG,
   GLOBE_MAP_DOT_CHORD,
+  GLOBE_MARKER_TARGET_CSS_PX,
+  GLOBE_MESH_MIN,
   GLOBE_MESH_RADIUS,
   globeAimVisibleBias,
   globeDevicePixelRatio,
   globeMapDotPx,
   globeMarkerFacing,
   globeMarkersChanged,
+  globeMarkerSizingForMesh,
   isGlobePerfQuery,
   latLngToGlobePose,
   latLngToVisibleGlobePose,
@@ -21,7 +26,7 @@ import {
   shouldCommitCobeRootStyle,
   shouldRunGlobeLoop,
 } from "./activity-globe";
-import { DEFAULT_ACTIVITY_GLOBE_CONFIG } from "./activity-globe-config";
+import { DEFAULT_ACTIVITY_GLOBE_CONFIG, markerSizeForAge } from "./activity-globe-config";
 
 describe("latLngToGlobePose", () => {
   test("uses the COBE phi/theta convention", () => {
@@ -102,6 +107,24 @@ describe("globeDevicePixelRatio", () => {
     expect(globeDevicePixelRatio(2)).toBe(2);
     expect(globeDevicePixelRatio(3)).toBe(2);
     expect(globeDevicePixelRatio(0)).toBe(1);
+  });
+});
+
+describe("cobeSizeForCssPx", () => {
+  test("converts the old 12px + glow target through Cobe's mesh-relative size", () => {
+    expect(cobeCssPxForSize(cobeSizeForCssPx(22, 692), 692)).toBeCloseTo(22);
+    expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 692)).toBeGreaterThan(0.05);
+    expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 692)).toBeLessThan(0.08);
+    expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 900)).toBeLessThan(
+      cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, GLOBE_MESH_MIN),
+    );
+  });
+
+  test("globeMarkerSizingForMesh keeps newest at the CSS target and floors the trail", () => {
+    const sizing = globeMarkerSizingForMesh(692, DEFAULT_ACTIVITY_GLOBE_CONFIG);
+    expect(cobeCssPxForSize(sizing.markerBaseSize, 692)).toBeCloseTo(GLOBE_MARKER_TARGET_CSS_PX);
+    expect(markerSizeForAge(0, sizing)).toBeCloseTo(sizing.markerBaseSize);
+    expect(markerSizeForAge(9, sizing)).toBeGreaterThanOrEqual(sizing.markerBaseSize * 0.5);
   });
 });
 

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -2,18 +2,23 @@ import { describe, expect, test } from "bun:test";
 
 import { activityGlobeMarkerIdForLocation, activityRecentGlobeMarkers } from "./activity-geo";
 import {
-  bindableGlobeMarkers,
+  cobeGpuMarkers,
+  cobeWebGLMarkers,
   GLOBE_HANG,
   GLOBE_MAP_DOT_CHORD,
   GLOBE_MESH_RADIUS,
   globeAimVisibleBias,
   globeMapDotPx,
   globeMarkerFacing,
+  globeMarkersChanged,
+  isGlobePerfQuery,
   latLngToGlobePose,
   latLngToVisibleGlobePose,
   projectGlobeMarker,
   shortestAngleDelta,
+  shouldRunGlobeLoop,
 } from "./activity-globe";
+import { DEFAULT_ACTIVITY_GLOBE_CONFIG } from "./activity-globe-config";
 
 describe("latLngToGlobePose", () => {
   test("uses the COBE phi/theta convention", () => {
@@ -96,10 +101,71 @@ describe("globeMapDotPx", () => {
   });
 });
 
-describe("bindableGlobeMarkers", () => {
-  test("keeps ids and locations so COBE can bind CSS anchors", () => {
-    const markers = bindableGlobeMarkers([{ id: "sf", location: [37.77, -122.42], size: 0.02 }]);
-    expect(markers).toEqual([{ id: "sf", location: [37.77, -122.42], size: 0 }]);
+describe("globeMarkersChanged", () => {
+  const sf = { id: "sf", location: [37.77, -122.42] as [number, number], size: 0.02 };
+  const ldn = { id: "ldn", location: [51.51, -0.13] as [number, number], size: 0.018 };
+
+  test("is a no-op for the same ref or identical id/location/size", () => {
+    const markers = [sf];
+    expect(globeMarkersChanged(markers, markers)).toBe(false);
+    expect(globeMarkersChanged([sf], [{ ...sf, location: [37.77, -122.42] }])).toBe(false);
+  });
+
+  test("detects identity, location, size, and color changes", () => {
+    expect(globeMarkersChanged(null, [sf])).toBe(true);
+    expect(globeMarkersChanged([sf], [ldn])).toBe(true);
+    expect(globeMarkersChanged([sf], [{ ...sf, size: 0.04 }])).toBe(true);
+    expect(globeMarkersChanged([sf], [{ ...sf, location: [37.8, -122.42] }])).toBe(true);
+    expect(globeMarkersChanged([sf], [{ ...sf, color: [1, 0, 0] }])).toBe(true);
+  });
+});
+
+describe("shouldRunGlobeLoop", () => {
+  test("pauses when the document is hidden or the globe is off-screen", () => {
+    expect(shouldRunGlobeLoop({ visibilityState: "visible", isIntersecting: true })).toBe(true);
+    expect(shouldRunGlobeLoop({ visibilityState: "hidden", isIntersecting: true })).toBe(false);
+    expect(shouldRunGlobeLoop({ visibilityState: "visible", isIntersecting: false })).toBe(false);
+  });
+});
+
+describe("cobeWebGLMarkers", () => {
+  test("keeps ids and WebGL sizes greater than zero", () => {
+    const recent = activityRecentGlobeMarkers(
+      [
+        { id: "tokyo", meta: { latitude: 35.68, longitude: 139.69 } },
+        { id: "london", meta: { latitude: 51.51, longitude: -0.13 } },
+      ],
+      5,
+    );
+    const markers = cobeWebGLMarkers(recent, DEFAULT_ACTIVITY_GLOBE_CONFIG, null);
+    expect(markers.length).toBe(2);
+    expect(markers.every((marker) => marker.id && marker.size > 0)).toBe(true);
+    expect(cobeGpuMarkers(markers).every((marker) => !("id" in marker) && marker.size > 0)).toBe(
+      true,
+    );
+  });
+
+  test("enlarges the focused event without changing other sizes", () => {
+    const recent = activityRecentGlobeMarkers(
+      [
+        { id: "tokyo", meta: { latitude: 35.68, longitude: 139.69 } },
+        { id: "london", meta: { latitude: 51.51, longitude: -0.13 } },
+      ],
+      5,
+    );
+    const idle = cobeWebGLMarkers(recent, DEFAULT_ACTIVITY_GLOBE_CONFIG, null);
+    const focused = cobeWebGLMarkers(recent, DEFAULT_ACTIVITY_GLOBE_CONFIG, "tokyo");
+    expect(focused[0]?.size).toBeGreaterThan(idle[0]?.size ?? 0);
+    expect(focused[1]?.size).toBe(idle[1]?.size);
+    expect(focused[0]?.color).toBeDefined();
+  });
+});
+
+describe("isGlobePerfQuery", () => {
+  test("is only on when globePerf=1", () => {
+    expect(isGlobePerfQuery("?globePerf=1")).toBe(true);
+    expect(isGlobePerfQuery("?globePerf=0")).toBe(false);
+    expect(isGlobePerfQuery("")).toBe(false);
   });
 });
 
@@ -133,6 +199,8 @@ describe("activityRecentGlobeMarkers", () => {
     );
     expect(markers.map((marker) => marker.eventId)).toEqual(["tokyo", "london", "sf"]);
     expect(markers.map((marker) => marker.age)).toEqual([0, 1, 2]);
+    expect(markers.every((marker) => marker.size > 0)).toBe(true);
+    expect(markers[0]?.size).toBeGreaterThan(markers[1]?.size ?? 0);
   });
 
   test("places GitHub and Notion publish events in San Francisco", () => {

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -4,10 +4,12 @@ import { activityGlobeMarkerIdForLocation, activityRecentGlobeMarkers } from "./
 import {
   cobeGpuMarkers,
   cobeWebGLMarkers,
+  GLOBE_DEVICE_PIXEL_RATIO_CAP,
   GLOBE_HANG,
   GLOBE_MAP_DOT_CHORD,
   GLOBE_MESH_RADIUS,
   globeAimVisibleBias,
+  globeDevicePixelRatio,
   globeMapDotPx,
   globeMarkerFacing,
   globeMarkersChanged,
@@ -89,6 +91,16 @@ describe("shortestAngleDelta", () => {
     const target = latLngToGlobePose(0, 0).phi;
     const spun = target + Math.PI * 2 * 3 + 0.4;
     expect(shortestAngleDelta(spun, target)).toBeCloseTo(-0.4);
+  });
+});
+
+describe("globeDevicePixelRatio", () => {
+  test("matches production: cap at 2, pass through 1x and 2x", () => {
+    expect(GLOBE_DEVICE_PIXEL_RATIO_CAP).toBe(2);
+    expect(globeDevicePixelRatio(1)).toBe(1);
+    expect(globeDevicePixelRatio(2)).toBe(2);
+    expect(globeDevicePixelRatio(3)).toBe(2);
+    expect(globeDevicePixelRatio(0)).toBe(1);
   });
 });
 

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -21,10 +21,12 @@ import {
   isGlobePerfQuery,
   latLngToGlobePose,
   latLngToVisibleGlobePose,
+  mixRgb,
   projectGlobeMarker,
   shortestAngleDelta,
   shouldCommitCobeRootStyle,
   shouldRunGlobeLoop,
+  stepMarkerHorizon,
 } from "./activity-globe";
 import { DEFAULT_ACTIVITY_GLOBE_CONFIG, markerSizeForAge } from "./activity-globe-config";
 
@@ -194,6 +196,49 @@ describe("cobeWebGLMarkers", () => {
     expect(focused[0]?.size).toBeGreaterThan(idle[0]?.size ?? 0);
     expect(focused[1]?.size).toBe(idle[1]?.size);
     expect(focused[0]?.color).toBeDefined();
+  });
+
+  test("scales by horizon appear and keeps the recency size trail", () => {
+    const recent = activityRecentGlobeMarkers(
+      [
+        { id: "tokyo", meta: { latitude: 35.68, longitude: 139.69 } },
+        { id: "london", meta: { latitude: 51.51, longitude: -0.13 } },
+      ],
+      5,
+    );
+    const appear = { [recent[0]!.id]: 0.5, [recent[1]!.id]: 0.5 };
+    const faded = cobeWebGLMarkers(recent, DEFAULT_ACTIVITY_GLOBE_CONFIG, null, appear, [1, 1, 1]);
+    const full = cobeWebGLMarkers(recent, DEFAULT_ACTIVITY_GLOBE_CONFIG, null);
+    expect(faded[0]?.size).toBeCloseTo((full[0]?.size ?? 0) * 0.5);
+    expect(faded[1]?.size).toBeCloseTo((full[1]?.size ?? 0) * 0.5);
+    expect(faded[0]?.size ?? 0).toBeGreaterThan(faded[1]?.size ?? 0);
+    expect(faded[0]?.color).toBeDefined();
+  });
+});
+
+describe("stepMarkerHorizon", () => {
+  test("snaps on first sample and eases after a visibility flip", () => {
+    const first = stepMarkerHorizon(undefined, 0.8, 0, 300);
+    expect(first.visible).toBe(true);
+    expect(first.value).toBe(1);
+
+    const hidden = stepMarkerHorizon(first, 0, 10, 300);
+    expect(hidden.visible).toBe(false);
+    expect(hidden.value).toBe(1);
+
+    const mid = stepMarkerHorizon(hidden, 0, 160, 300);
+    expect(mid.value).toBeGreaterThan(0);
+    expect(mid.value).toBeLessThan(1);
+
+    const done = stepMarkerHorizon(mid, 0, 400, 300);
+    expect(done.value).toBe(0);
+
+    const reduced = stepMarkerHorizon(first, 0, 10, 0);
+    expect(reduced.value).toBe(0);
+  });
+
+  test("mixRgb interpolates toward the fade target", () => {
+    expect(mixRgb([0, 0, 0], [1, 1, 1], 0.5)).toEqual([0.5, 0.5, 0.5]);
   });
 });
 

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -112,9 +112,9 @@ describe("globeDevicePixelRatio", () => {
 
 describe("cobeSizeForCssPx", () => {
   test("converts the old 12px + glow target through Cobe's mesh-relative size", () => {
-    expect(cobeCssPxForSize(cobeSizeForCssPx(22, 692), 692)).toBeCloseTo(22);
-    expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 692)).toBeGreaterThan(0.05);
-    expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 692)).toBeLessThan(0.08);
+    expect(cobeCssPxForSize(cobeSizeForCssPx(18, 692), 692)).toBeCloseTo(18);
+    expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 692)).toBeGreaterThan(0.045);
+    expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 692)).toBeLessThan(0.07);
     expect(cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, 900)).toBeLessThan(
       cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, GLOBE_MESH_MIN),
     );

--- a/src/lib/activity-globe.test.ts
+++ b/src/lib/activity-globe.test.ts
@@ -8,13 +8,10 @@ import {
   cobeWebGLMarkers,
   GLOBE_DEVICE_PIXEL_RATIO_CAP,
   GLOBE_HANG,
-  GLOBE_MAP_DOT_CHORD,
   GLOBE_MARKER_TARGET_CSS_PX,
   GLOBE_MESH_MIN,
-  GLOBE_MESH_RADIUS,
   globeAimVisibleBias,
   globeDevicePixelRatio,
-  globeMapDotPx,
   globeMarkerFacing,
   globeMarkersChanged,
   globeMarkerSizingForMesh,
@@ -23,6 +20,7 @@ import {
   latLngToVisibleGlobePose,
   mixRgb,
   projectGlobeMarker,
+  selectGlobeMarkerSizing,
   shortestAngleDelta,
   shouldCommitCobeRootStyle,
   shouldRunGlobeLoop,
@@ -128,14 +126,12 @@ describe("cobeSizeForCssPx", () => {
     expect(markerSizeForAge(0, sizing)).toBeCloseTo(sizing.markerBaseSize);
     expect(markerSizeForAge(9, sizing)).toBeGreaterThanOrEqual(sizing.markerBaseSize * 0.5);
   });
-});
 
-describe("globeMapDotPx", () => {
-  test("matches a facing-center COBE land dot on the mesh", () => {
-    expect(globeMapDotPx(512)).toBeCloseTo(GLOBE_MAP_DOT_CHORD * GLOBE_MESH_RADIUS * 512);
-    expect(globeMapDotPx(1000)).toBeGreaterThan(globeMapDotPx(512));
-    expect(globeMapDotPx(512, 1.2)).toBeCloseTo(globeMapDotPx(512) * 1.2);
-    expect(globeMapDotPx(0)).toBe(2);
+  test("selectGlobeMarkerSizing uses the mesh target live and the slider in sandbox", () => {
+    const live = selectGlobeMarkerSizing(DEFAULT_ACTIVITY_GLOBE_CONFIG, 692, false);
+    expect(cobeCssPxForSize(live.markerBaseSize, 692)).toBeCloseTo(GLOBE_MARKER_TARGET_CSS_PX);
+    const sandbox = selectGlobeMarkerSizing(DEFAULT_ACTIVITY_GLOBE_CONFIG, 692, true);
+    expect(sandbox.markerBaseSize).toBe(DEFAULT_ACTIVITY_GLOBE_CONFIG.markerBaseSize);
   });
 });
 
@@ -183,6 +179,25 @@ describe("cobeWebGLMarkers", () => {
     );
   });
 
+  test("omits id from the GPU payload even when focus or appear sets color", () => {
+    const recent = activityRecentGlobeMarkers(
+      [{ id: "tokyo", meta: { latitude: 35.68, longitude: 139.69 } }],
+      5,
+    );
+    const focused = cobeWebGLMarkers(recent, DEFAULT_ACTIVITY_GLOBE_CONFIG, "tokyo");
+    const faded = cobeWebGLMarkers(
+      recent,
+      DEFAULT_ACTIVITY_GLOBE_CONFIG,
+      null,
+      { [recent[0]!.id]: 0.4 },
+      [1, 1, 1],
+    );
+    expect(focused[0]?.color).toBeDefined();
+    expect(faded[0]?.color).toBeDefined();
+    expect(cobeGpuMarkers(focused).every((marker) => !("id" in marker))).toBe(true);
+    expect(cobeGpuMarkers(faded).every((marker) => !("id" in marker))).toBe(true);
+  });
+
   test("enlarges the focused event without changing other sizes", () => {
     const recent = activityRecentGlobeMarkers(
       [
@@ -217,24 +232,37 @@ describe("cobeWebGLMarkers", () => {
 });
 
 describe("stepMarkerHorizon", () => {
-  test("snaps on first sample and eases after a visibility flip", () => {
+  test("snaps hide immediately; appear still eases", () => {
     const first = stepMarkerHorizon(undefined, 0.8, 0, 300);
     expect(first.visible).toBe(true);
     expect(first.value).toBe(1);
 
     const hidden = stepMarkerHorizon(first, 0, 10, 300);
     expect(hidden.visible).toBe(false);
-    expect(hidden.value).toBe(1);
+    expect(hidden.value).toBe(0);
 
-    const mid = stepMarkerHorizon(hidden, 0, 160, 300);
+    const stillHidden = stepMarkerHorizon(hidden, 0, 160, 300);
+    expect(stillHidden.value).toBe(0);
+
+    const appear = stepMarkerHorizon(hidden, 0.8, 10, 300);
+    expect(appear.visible).toBe(true);
+    expect(appear.value).toBe(0);
+
+    const mid = stepMarkerHorizon(appear, 0.8, 160, 300);
     expect(mid.value).toBeGreaterThan(0);
     expect(mid.value).toBeLessThan(1);
 
-    const done = stepMarkerHorizon(mid, 0, 400, 300);
-    expect(done.value).toBe(0);
+    const done = stepMarkerHorizon(mid, 0.8, 400, 300);
+    expect(done.value).toBe(1);
 
     const reduced = stepMarkerHorizon(first, 0, 10, 0);
     expect(reduced.value).toBe(0);
+  });
+
+  test("first sample facing 0 snaps to 0", () => {
+    const first = stepMarkerHorizon(undefined, 0, 0, 300);
+    expect(first.visible).toBe(false);
+    expect(first.value).toBe(0);
   });
 
   test("mixRgb interpolates toward the fade target", () => {

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -124,10 +124,16 @@ export function globeDiameterFromHeight(height: number): number {
 }
 
 /**
- * Cap globe backing-store density. A 512–~1400px mesh at devicePixelRatio 2 is a
- * large fragment workload for a decorative hang; 1x keeps land readable at 60fps.
+ * Same cap as production: retina land dots stay sharp. Do not drop this to 1 —
+ * a 1x backing store is what made the preview look soft.
  */
-export const GLOBE_DEVICE_PIXEL_RATIO = 1;
+export const GLOBE_DEVICE_PIXEL_RATIO_CAP = 2;
+
+export function globeDevicePixelRatio(
+  dpr: number = typeof window === "undefined" ? 1 : window.devicePixelRatio || 1,
+): number {
+  return Math.min(GLOBE_DEVICE_PIXEL_RATIO_CAP, dpr || 1);
+}
 
 export type GlobeMarkerSnapshot = {
   id: string;
@@ -203,7 +209,11 @@ export function cobeGpuMarkers(
   }));
 }
 
-/** WebGL discs from the recent-location trail. Ids are kept for change detection. */
+/**
+ * WebGL discs from the recent-location trail. Ids are kept for change detection.
+ * Focus is a one-shot size/color bump (dirty once on, once off) — not a
+ * per-frame pulse, so panning never re-uploads the marker buffer.
+ */
 export function cobeWebGLMarkers(
   markers: ReadonlyArray<{
     id: string;

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -57,19 +57,22 @@ export function rotateGlobePoint(
  * 0 behind the limb, 1 at the camera-facing apex.
  * COBE v2 `--cobe-visible-{id}` is only a boolean (`N` / unset); use this for depth.
  */
-export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: number): number {
-  const [, , rz] = rotateGlobePoint(latLngToGlobePoint(lat, lng), phi, theta);
+export function globeMarkerFacingFromUnit(
+  point: readonly [number, number, number],
+  phi: number,
+  theta: number,
+): number {
+  const [, , rz] = rotateGlobePoint([point[0], point[1], point[2]], phi, theta);
   return Math.min(1, Math.max(0, rz));
+}
+
+export function globeMarkerFacing(lat: number, lng: number, phi: number, theta: number): number {
+  return globeMarkerFacingFromUnit(latLngToGlobePoint(lat, lng), phi, theta);
 }
 
 /** Same mesh radius as cobe@2 (`GLOBE_R`). */
 export const GLOBE_MESH_RADIUS = 0.8;
 export const GLOBE_MARKER_ELEVATION = 0;
-/**
- * COBE land-dot radius in unit-sphere chord length.
- * Fragment shader: `smoothstep(8e-3, 0., distanceToLattice)`.
- */
-export const GLOBE_MAP_DOT_CHORD = 0.008;
 
 /** Fraction of the mesh that hangs past the right and bottom edges. */
 export const GLOBE_HANG = 0.4;
@@ -176,6 +179,29 @@ export function globeMarkerSizingForMesh(
   };
 }
 
+/**
+ * Live path converts 12px+glow at the mesh. Sandbox keeps the raw slider
+ * (`configProp` is set) so DialKit still tunes Cobe units.
+ */
+export function selectGlobeMarkerSizing(
+  config: ActivityGlobeConfig,
+  meshSize: number,
+  sandbox: boolean,
+): Pick<
+  ActivityGlobeConfig,
+  "markerBaseSize" | "markerSizePerLog" | "markerMaxSize" | "markerAgeShrink"
+> {
+  if (sandbox) {
+    return {
+      markerBaseSize: config.markerBaseSize,
+      markerSizePerLog: config.markerSizePerLog,
+      markerMaxSize: config.markerMaxSize,
+      markerAgeShrink: config.markerAgeShrink,
+    };
+  }
+  return globeMarkerSizingForMesh(meshSize, config);
+}
+
 export function globeDevicePixelRatio(
   dpr: number = typeof window === "undefined" ? 1 : window.devicePixelRatio || 1,
 ): number {
@@ -270,13 +296,6 @@ export function muteCobeEmptyRootStyle(style: HTMLStyleElement): void {
   });
 }
 
-/** CSS px of one COBE country-shape dot at the facing center of the mesh. */
-export function globeMapDotPx(meshSize: number, scale = 1): number {
-  if (!Number.isFinite(meshSize) || meshSize <= 0) return 2;
-  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
-  return Math.max(2, GLOBE_MAP_DOT_CHORD * GLOBE_MESH_RADIUS * meshSize * safeScale);
-}
-
 /**
  * GPU payload for Cobe. Ids stay on {@link GlobeMarkerSnapshot} for identity
  * compares, but are omitted here so Cobe never creates CSS-anchor nodes or
@@ -304,8 +323,8 @@ export type MarkerHorizonState = {
 
 /**
  * Old CSS used `--cobe-visible-{id}` (boolean) + a 300ms opacity/blur ease.
- * First sample snaps so front markers do not grow on load. Later flips ease
- * from the current value so dots fade and size up as they come over the limb.
+ * First sample snaps. Appear eases over `fadeMs`. Hide snaps — Cobe already
+ * culls `z < 0`, so a fade-out would only re-upload an invisible buffer.
  */
 export function stepMarkerHorizon(
   prev: MarkerHorizonState | undefined,
@@ -319,7 +338,7 @@ export function stepMarkerHorizon(
     return { visible, value: to, from: to, to, start: now };
   }
   if (prev.visible !== visible) {
-    if (fadeMs <= 0) return { visible, value: to, from: to, to, start: now };
+    if (fadeMs <= 0 || !visible) return { visible, value: to, from: to, to, start: now };
     return { visible, value: prev.value, from: prev.value, to, start: now };
   }
   if (prev.value === prev.to) return prev;

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -129,6 +129,49 @@ export function globeDiameterFromHeight(height: number): number {
  */
 export const GLOBE_DEVICE_PIXEL_RATIO_CAP = 2;
 
+/**
+ * Production CSS was a 12px disc + ~1.15× / 8px glow. Cobe `size` is mesh-relative
+ * (CSS diameter ≈ size × mesh / 2), so a fixed 0.08 overshoots on a ~0.72×vh
+ * canvas. Target the old CSS weight in pixels, then convert at the live mesh.
+ */
+export const GLOBE_MARKER_CSS_PX = 12;
+export const GLOBE_MARKER_GLOW_CSS_PX = 10;
+export const GLOBE_MARKER_TARGET_CSS_PX = GLOBE_MARKER_CSS_PX + GLOBE_MARKER_GLOW_CSS_PX;
+
+/** Inverse of Cobe's marker vertex scale: diameter_css ≈ size × mesh / 2. */
+export function cobeSizeForCssPx(cssDiameter: number, meshSize: number): number {
+  const mesh = Number.isFinite(meshSize) && meshSize > 0 ? meshSize : GLOBE_MESH_MIN;
+  const px =
+    Number.isFinite(cssDiameter) && cssDiameter > 0 ? cssDiameter : GLOBE_MARKER_TARGET_CSS_PX;
+  return (2 * px) / mesh;
+}
+
+export function cobeCssPxForSize(size: number, meshSize: number): number {
+  const mesh = Number.isFinite(meshSize) && meshSize > 0 ? meshSize : GLOBE_MESH_MIN;
+  return (size * mesh) / 2;
+}
+
+/** Live-path sizing: newest disc matches {@link GLOBE_MARKER_TARGET_CSS_PX} at `meshSize`. */
+export function globeMarkerSizingForMesh(
+  meshSize: number,
+  config: Pick<
+    ActivityGlobeConfig,
+    "markerBaseSize" | "markerSizePerLog" | "markerMaxSize" | "markerAgeShrink"
+  >,
+): Pick<
+  ActivityGlobeConfig,
+  "markerBaseSize" | "markerSizePerLog" | "markerMaxSize" | "markerAgeShrink"
+> {
+  const markerBaseSize = cobeSizeForCssPx(GLOBE_MARKER_TARGET_CSS_PX, meshSize);
+  const ratio = markerBaseSize / config.markerBaseSize;
+  return {
+    markerBaseSize,
+    markerSizePerLog: config.markerSizePerLog * ratio,
+    markerMaxSize: config.markerMaxSize * ratio,
+    markerAgeShrink: config.markerAgeShrink,
+  };
+}
+
 export function globeDevicePixelRatio(
   dpr: number = typeof window === "undefined" ? 1 : window.devicePixelRatio || 1,
 ): number {

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -1,5 +1,7 @@
 /** COBE camera pose and marker depth. Safe for client components. */
 
+import { type ActivityGlobeConfig, focusMarkerColor } from "./activity-globe-config";
+
 export type GlobePose = {
   phi: number;
   theta: number;
@@ -121,6 +123,62 @@ export function globeDiameterFromHeight(height: number): number {
   return Math.round(Math.max(GLOBE_MESH_MIN, height * GLOBE_MESH_HEIGHT_RATIO));
 }
 
+/**
+ * Cap globe backing-store density. A 512–~1400px mesh at devicePixelRatio 2 is a
+ * large fragment workload for a decorative hang; 1x keeps land readable at 60fps.
+ */
+export const GLOBE_DEVICE_PIXEL_RATIO = 1;
+
+export type GlobeMarkerSnapshot = {
+  id: string;
+  location: readonly [number, number];
+  size: number;
+  color?: readonly [number, number, number];
+};
+
+function rgbEqual(
+  a: readonly [number, number, number] | undefined,
+  b: readonly [number, number, number] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+/** True when Cobe must re-upload the marker GPU buffer. Same ref is a no-op. */
+export function globeMarkersChanged(
+  prev: readonly GlobeMarkerSnapshot[] | null | undefined,
+  next: readonly GlobeMarkerSnapshot[],
+): boolean {
+  if (prev === next) return false;
+  if (!prev || prev.length !== next.length) return true;
+  for (let i = 0; i < next.length; i++) {
+    const a = prev[i];
+    const b = next[i];
+    if (!a || !b) return true;
+    if (a.id !== b.id || a.size !== b.size) return true;
+    if (a.location[0] !== b.location[0] || a.location[1] !== b.location[1]) return true;
+    if (!rgbEqual(a.color, b.color)) return true;
+  }
+  return false;
+}
+
+/** Run the rAF loop only when the tab is visible and the globe is on screen. */
+export function shouldRunGlobeLoop(input: {
+  visibilityState: DocumentVisibilityState | string;
+  isIntersecting: boolean;
+}): boolean {
+  return input.visibilityState === "visible" && input.isIntersecting;
+}
+
+export function isGlobePerfQuery(search: string): boolean {
+  try {
+    return new URLSearchParams(search).get("globePerf") === "1";
+  } catch {
+    return false;
+  }
+}
+
 /** CSS px of one COBE country-shape dot at the facing center of the mesh. */
 export function globeMapDotPx(meshSize: number, scale = 1): number {
   if (!Number.isFinite(meshSize) || meshSize <= 0) return 2;
@@ -129,15 +187,41 @@ export function globeMapDotPx(meshSize: number, scale = 1): number {
 }
 
 /**
- * Keep marker ids so COBE creates `--cobe-{id}` anchors and `--cobe-visible-{id}`,
- * but hide the WebGL discs — those do not fade. The CSS dots do.
+ * GPU payload for Cobe. Ids stay on {@link GlobeMarkerSnapshot} for identity
+ * compares, but are omitted here so Cobe never creates CSS-anchor nodes or
+ * rewrites `--cobe-visible-*` on every `update()`.
  */
-export function bindableGlobeMarkers(
-  markers: ReadonlyArray<{ id: string; location: [number, number]; size?: number }>,
-): Array<{ id: string; location: [number, number]; size: number }> {
+export function cobeGpuMarkers(
+  markers: readonly GlobeMarkerSnapshot[],
+): Array<{ location: [number, number]; size: number; color?: [number, number, number] }> {
   return markers.map((marker) => ({
-    id: marker.id,
-    location: marker.location,
-    size: 0,
+    location: [marker.location[0], marker.location[1]],
+    size: marker.size,
+    ...(marker.color
+      ? { color: [marker.color[0], marker.color[1], marker.color[2]] as [number, number, number] }
+      : {}),
   }));
+}
+
+/** WebGL discs from the recent-location trail. Ids are kept for change detection. */
+export function cobeWebGLMarkers(
+  markers: ReadonlyArray<{
+    id: string;
+    eventId: string;
+    location: [number, number];
+    size: number;
+  }>,
+  config: Pick<ActivityGlobeConfig, "markerColor" | "focusPulseScale">,
+  focusEventId: string | null,
+): GlobeMarkerSnapshot[] {
+  return markers.map((marker) => {
+    const focused = focusEventId !== null && marker.eventId === focusEventId;
+    const size = focused ? marker.size * (1 + config.focusPulseScale) : marker.size;
+    return {
+      id: marker.id,
+      location: marker.location,
+      size,
+      ...(focused ? { color: focusMarkerColor(config.markerColor) } : {}),
+    };
+  });
 }

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -1,6 +1,10 @@
 /** COBE camera pose and marker depth. Safe for client components. */
 
-import { type ActivityGlobeConfig, focusMarkerColor } from "./activity-globe-config";
+import {
+  type ActivityGlobeConfig,
+  focusMarkerColor,
+  type RgbTriplet,
+} from "./activity-globe-config";
 
 export type GlobePose = {
   phi: number;
@@ -290,10 +294,56 @@ export function cobeGpuMarkers(
   }));
 }
 
+export type MarkerHorizonState = {
+  visible: boolean;
+  value: number;
+  from: number;
+  to: number;
+  start: number;
+};
+
+/**
+ * Old CSS used `--cobe-visible-{id}` (boolean) + a 300ms opacity/blur ease.
+ * First sample snaps so front markers do not grow on load. Later flips ease
+ * from the current value so dots fade and size up as they come over the limb.
+ */
+export function stepMarkerHorizon(
+  prev: MarkerHorizonState | undefined,
+  facing: number,
+  now: number,
+  fadeMs: number,
+): MarkerHorizonState {
+  const visible = facing > 0;
+  const to = visible ? 1 : 0;
+  if (!prev) {
+    return { visible, value: to, from: to, to, start: now };
+  }
+  if (prev.visible !== visible) {
+    if (fadeMs <= 0) return { visible, value: to, from: to, to, start: now };
+    return { visible, value: prev.value, from: prev.value, to, start: now };
+  }
+  if (prev.value === prev.to) return prev;
+  const t = fadeMs <= 0 ? 1 : Math.min(1, (now - prev.start) / fadeMs);
+  const eased = t >= 1 ? 1 : t * t * (3 - 2 * t);
+  const value = prev.from + (prev.to - prev.from) * eased;
+  if (t >= 1) return { visible, value: to, from: to, to, start: prev.start };
+  return { visible, value, from: prev.from, to, start: prev.start };
+}
+
+export function mixRgb(from: RgbTriplet, to: RgbTriplet, t: number): RgbTriplet {
+  const u = Math.min(1, Math.max(0, t));
+  return [
+    from[0] + (to[0] - from[0]) * u,
+    from[1] + (to[1] - from[1]) * u,
+    from[2] + (to[2] - from[2]) * u,
+  ];
+}
+
 /**
  * WebGL discs from the recent-location trail. Ids are kept for change detection.
- * Focus is a one-shot size/color bump (dirty once on, once off) — not a
- * per-frame pulse, so panning never re-uploads the marker buffer.
+ * Focus is a one-shot size/color bump (dirty once on, once off). Horizon appear
+ * (0–1) scales size and mixes color so dots fade in / size up without CSS anchors.
+ * Recency still owns the base size (newest larger than older).
  */
 export function cobeWebGLMarkers(
   markers: ReadonlyArray<{
@@ -304,15 +354,21 @@ export function cobeWebGLMarkers(
   }>,
   config: Pick<ActivityGlobeConfig, "markerColor" | "focusPulseScale">,
   focusEventId: string | null,
+  appearById?: Readonly<Record<string, number>>,
+  fadeInto?: RgbTriplet,
 ): GlobeMarkerSnapshot[] {
   return markers.map((marker) => {
     const focused = focusEventId !== null && marker.eventId === focusEventId;
-    const size = focused ? marker.size * (1 + config.focusPulseScale) : marker.size;
+    const appear = appearById?.[marker.id] ?? 1;
+    const base = focused ? marker.size * (1 + config.focusPulseScale) : marker.size;
+    const size = base * appear;
+    const fullColor = focused ? focusMarkerColor(config.markerColor) : config.markerColor;
+    const color = appear < 1 && fadeInto ? mixRgb(fadeInto, fullColor, appear) : fullColor;
     return {
       id: marker.id,
       location: marker.location,
       size,
-      ...(focused ? { color: focusMarkerColor(config.markerColor) } : {}),
+      ...(focused || appear < 1 ? { color } : {}),
     };
   });
 }

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -130,12 +130,12 @@ export function globeDiameterFromHeight(height: number): number {
 export const GLOBE_DEVICE_PIXEL_RATIO_CAP = 2;
 
 /**
- * Production CSS was a 12px disc + ~1.15× / 8px glow. Cobe `size` is mesh-relative
+ * Production CSS was a 12px disc + glow. Cobe `size` is mesh-relative
  * (CSS diameter ≈ size × mesh / 2), so a fixed 0.08 overshoots on a ~0.72×vh
- * canvas. Target the old CSS weight in pixels, then convert at the live mesh.
+ * canvas. Target ~18px (12px core + visible bloom) at the live mesh.
  */
 export const GLOBE_MARKER_CSS_PX = 12;
-export const GLOBE_MARKER_GLOW_CSS_PX = 10;
+export const GLOBE_MARKER_GLOW_CSS_PX = 6;
 export const GLOBE_MARKER_TARGET_CSS_PX = GLOBE_MARKER_CSS_PX + GLOBE_MARKER_GLOW_CSS_PX;
 
 /** Inverse of Cobe's marker vertex scale: diameter_css ≈ size × mesh / 2. */

--- a/src/lib/activity-globe.ts
+++ b/src/lib/activity-globe.ts
@@ -185,6 +185,44 @@ export function isGlobePerfQuery(search: string): boolean {
   }
 }
 
+/**
+ * Cobe's `update()` always does `style.textContent = ":root{...}"`.
+ * With no CSS-anchor ids that string is `:root{}` every frame, which still
+ * invalidates document styles. Skip identical and empty writes.
+ */
+export function shouldCommitCobeRootStyle(next: string, prev: string): boolean {
+  if (next === prev) return false;
+  return next !== ":root{}" && next !== "";
+}
+
+/** First `<style>` Cobe appended to `document.head` during `createGlobe`. */
+export function takeNewHeadStyle(before: ReadonlySet<Element>): HTMLStyleElement | null {
+  if (typeof document === "undefined") return null;
+  for (const node of document.head.querySelectorAll("style")) {
+    if (!before.has(node)) return node;
+  }
+  return null;
+}
+
+/** Neutralize Cobe's empty `:root{}` write so idle spin does not restyle `:root`. */
+export function muteCobeEmptyRootStyle(style: HTMLStyleElement): void {
+  const nativeSet = Object.getOwnPropertyDescriptor(Node.prototype, "textContent")?.set;
+  if (!nativeSet) return;
+  let applied = style.textContent ?? "";
+  Object.defineProperty(style, "textContent", {
+    configurable: true,
+    get() {
+      return applied;
+    },
+    set(value: string) {
+      const next = value ?? "";
+      if (!shouldCommitCobeRootStyle(next, applied)) return;
+      applied = next;
+      nativeSet.call(style, next);
+    },
+  });
+}
+
 /** CSS px of one COBE country-shape dot at the facing center of the mesh. */
 export function globeMapDotPx(meshSize: number, scale = 1): number {
   if (!Number.isFinite(meshSize) || meshSize <= 0) return 2;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Keep

DPR cap **2**. Cheap `{ phi, theta }` rAF path. No CSS-anchor markers.

## Review fixes (`3755a806`)

Addresses the code-review nits on the horizon-fade revision:

- **Hide snaps.** Cobe already culls `z < 0`, so fade-out was uploading an invisible buffer for ~300ms. Appear still eases size + color over `markerFadeMs`.
- **Canvas backing store.** React no longer sets `width`/`height` to `size * 2`. Cobe owns the buffer via the same `globeDevicePixelRatio()` passed to `createGlobe`.
- **`markerFadeMs` is live.** Config comments no longer call it unused. Sandbox “Horizon fade (ms)” slider is back.
- **Cheaper idle loop.** Marker unit vectors are cached; appear payload is built only on upload; horizon/point maps prune only when markers change.
- **`?globePerf=1`.** Sample arrays cap at 600; window keys are deleted on destroy.
- **Live vs sandbox sizing** is `selectGlobeMarkerSizing` and unit-tested. Dead `globeMapDotPx` helper is gone.

## Horizon fade

The old CSS dots used `--cobe-visible-{id}` (boolean) plus a **300ms** `opacity` / `filter` / size ease. WebGL now replays appear on the GPU path:

- First sample **snaps** (front markers do not grow on load)
- When a marker comes around the limb, size eases 0→full and color mixes from the globe base
- Hide is immediate
- No `--cobe-*` anchors, no DOM dots

## Recency sizes stay intentional

Newest is still the largest. Each older unique location shrinks ~10%, floored at 50%. Horizon appear only *scales* that trail.

## Also in this branch

- Live markers target the old **12px + glow** in CSS pixels at the current mesh (~18px)
- `mapSamples: 12000`, MSAA off, empty `:root{}` write muted
- Focus is still a one-shot bump

## Preview

Refresh **`3755a806`** when Vercel is Ready. Do not use older 0.045 / DPR=1 / no-fade deploys.

## Out of scope

No react-globe.gl. No CSS-anchor markers. Do not merge until Brian signs off.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba789239-e0e1-4d5f-9b46-9b18f401f4a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba789239-e0e1-4d5f-9b46-9b18f401f4a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

