### PR TITLE
Fix /computer list crash on AMA-style API envelope

### DIFF
--- a/src/app/api/computer/route.test.ts
+++ b/src/app/api/computer/route.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+import * as notion from "@/lib/notion";
+
+import { GET, POST } from "./route";
+
+describe("/api/computer", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("GET returns a Published list envelope", async () => {
+    spyOn(notion, "getComputerDatabaseItems").mockResolvedValue([
+      {
+        id: "tip-1",
+        title: "Raycast",
+        status: "Published",
+        createdTime: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      items: [
+        {
+          id: "tip-1",
+          title: "Raycast",
+          status: "Published",
+          createdTime: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  test("POST creates a tip from title and optional details", async () => {
+    const create = spyOn(notion, "createComputerTip").mockResolvedValue({ id: "new-tip" } as never);
+
+    const res = await POST(
+      new Request("http://localhost/api/computer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "A new shortcut", details: "Bind caps lock." }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "new-tip" });
+    expect(create).toHaveBeenCalledWith({
+      title: "A new shortcut",
+      body: "Bind caps lock.",
+    });
+  });
+});

--- a/src/lib/computer.test.ts
+++ b/src/lib/computer.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { HOME_PROJECTS } from "@/components/home/ProjectsList";
-import { COMPUTER_INTRO, COMPUTER_TITLE, type ComputerTip, computerTipLinks } from "@/lib/computer";
+import {
+  COMPUTER_INTRO,
+  COMPUTER_TITLE,
+  type ComputerTip,
+  computerTipLinks,
+  computerTipsFromApi,
+} from "@/lib/computer";
 import { INDEXABLE_SECTIONS } from "@/lib/site-copy";
 
 function tip(overrides: Partial<ComputerTip> & Pick<ComputerTip, "id" | "title">): ComputerTip {
@@ -18,6 +24,14 @@ describe("computer copy and links", () => {
     expect(COMPUTER_INTRO).toBe(
       "This is a living list of tips to use computers better: shortcuts, hotkeys, utility apps, helpful workflows, and so on.",
     );
+  });
+
+  test("reads tip lists from either API envelope", () => {
+    const published = [tip({ id: "raycast", title: "Raycast" })];
+    expect(computerTipsFromApi({ items: published })).toEqual(published);
+    expect(computerTipsFromApi(published)).toEqual(published);
+    expect(computerTipsFromApi({ items: "nope" })).toEqual([]);
+    expect(computerTipsFromApi(null)).toEqual([]);
   });
 
   test("lists published tip titles and hrefs", () => {

--- a/src/lib/computer.ts
+++ b/src/lib/computer.ts
@@ -23,6 +23,15 @@ export function computerTipLinks(items: ComputerTip[]) {
   }));
 }
 
+export function computerTipsFromApi(data: unknown): ComputerTip[] {
+  if (Array.isArray(data)) return data as ComputerTip[];
+  if (data && typeof data === "object" && "items" in data) {
+    const items = (data as { items: unknown }).items;
+    if (Array.isArray(items)) return items as ComputerTip[];
+  }
+  return [];
+}
+
 export async function submitComputerTip(title: string, details?: string) {
   await createComputerTip({ title, body: details });
 }

--- a/src/lib/hooks/useComputer.ts
+++ b/src/lib/hooks/useComputer.ts
@@ -2,6 +2,7 @@
 
 import useSWR, { preload } from "swr";
 
+import { computerTipsFromApi } from "@/lib/computer";
 import { fetcher } from "@/lib/fetcher";
 import type { NotionComputerItem, NotionComputerItemWithContent } from "@/lib/notion";
 
@@ -10,15 +11,17 @@ export function prefetchComputerTip(id: string) {
 }
 
 export function useComputerTips(fallbackData?: NotionComputerItem[]) {
-  const { data, error, isLoading } = useSWR<NotionComputerItem[]>("/api/computer", fetcher, {
+  const { data, error, isLoading } = useSWR<unknown>("/api/computer", fetcher, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     refreshInterval: 1000 * 60 * 5,
     fallbackData,
   });
 
+  const tips = data === undefined ? (fallbackData ?? []) : computerTipsFromApi(data);
+
   return {
-    tips: data || fallbackData || [],
+    tips,
     isLoading: isLoading && !fallbackData,
     isError: error,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #2349 (already merged).

`GET /api/computer` returns `{ items }` (same envelope as AMA). The client hook treated that object as the tip array, so `tips.findIndex` crashed on `/computer` after SWR revalidated.

## Fix
- `computerTipsFromApi()` accepts `{ items }` or a bare array
- `useComputerTips` uses that helper and keeps RSC fallback data until a response arrives
- Tests lock GET `{ items }`, POST create payload, and both envelope shapes

## Still needed on Vercel / Notion
- Set `NOTION_TIPS_DATABASE_ID=273c711c0ceb80c2af23ddac8ea9779e` on Production + Preview
- Share the Tips database with the `brios-api` Notion integration, or list/detail stay empty
- Add a Notion button hitting `/api/purge-cache?secret=<CACHE_PURGE_SECRET>&type=computer`

[Homepage project points at /computer](https://cursor.com/agents/bc-1b36ec19-d71d-4921-81cf-c405027bc95e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_computer_project.webp)
[/computer page with title, intro, and Suggest a tip](https://cursor.com/agents/bc-1b36ec19-d71d-4921-81cf-c405027bc95e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomputer_page.webp)
[Suggest a tip form](https://cursor.com/agents/bc-1b36ec19-d71d-4921-81cf-c405027bc95e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuggest_tip_form.webp)
[computer_section_walkthrough.mp4](https://cursor.com/agents/bc-1b36ec19-d71d-4921-81cf-c405027bc95e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomputer_section_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b36ec19-d71d-4921-81cf-c405027bc95e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b36ec19-d71d-4921-81cf-c405027bc95e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

