### PR TITLE
Fix /computer crash when SWR returns `{ items }`

### DIFF
--- a/src/lib/computer.test.ts
+++ b/src/lib/computer.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { HOME_PROJECTS } from "@/components/home/ProjectsList";
-import { COMPUTER_INTRO, COMPUTER_TITLE, type ComputerTip, computerTipLinks } from "@/lib/computer";
+import {
+  COMPUTER_INTRO,
+  COMPUTER_TITLE,
+  type ComputerTip,
+  computerTipLinks,
+  unwrapComputerTips,
+} from "@/lib/computer";
 import { INDEXABLE_SECTIONS } from "@/lib/site-copy";
 
 function tip(overrides: Partial<ComputerTip> & Pick<ComputerTip, "id" | "title">): ComputerTip {
@@ -30,6 +36,31 @@ describe("computer copy and links", () => {
       { id: "raycast", title: "Raycast", href: "/computer/raycast" },
       { id: "hyperkeys", title: "Hyperkeys", href: "/computer/hyperkeys" },
     ]);
+  });
+});
+
+describe("unwrapComputerTips", () => {
+  const items = [tip({ id: "raycast", title: "Raycast" })];
+  const fallback = [tip({ id: "hyperkeys", title: "Hyperkeys" })];
+
+  test("reads items from the { items } API payload", () => {
+    expect(unwrapComputerTips({ items })).toEqual(items);
+  });
+
+  test("prefers payload items over fallback", () => {
+    expect(unwrapComputerTips({ items }, fallback)).toEqual(items);
+  });
+
+  test("uses fallback when the payload is missing", () => {
+    expect(unwrapComputerTips(undefined, fallback)).toEqual(fallback);
+    expect(unwrapComputerTips(undefined)).toEqual([]);
+  });
+
+  test("returns an array so list lookups cannot treat the response as tips", () => {
+    const tips = unwrapComputerTips({ items });
+    expect(Array.isArray(tips)).toBe(true);
+    expect(tips.findIndex((item) => item.id === "raycast")).toBe(0);
+    expect(tips.map((item) => item.title)).toEqual(["Raycast"]);
   });
 });
 

--- a/src/lib/computer.ts
+++ b/src/lib/computer.ts
@@ -9,6 +9,15 @@ export const COMPUTER_INTRO =
 
 export type ComputerTip = NotionComputerItem;
 
+export type ComputerTipsResponse = { items: ComputerTip[] };
+
+export function unwrapComputerTips(
+  data: ComputerTipsResponse | undefined,
+  fallback?: ComputerTip[],
+): ComputerTip[] {
+  return data?.items ?? fallback ?? [];
+}
+
 async function fetchAllComputerTips(): Promise<ComputerTip[]> {
   return getComputerDatabaseItems();
 }

--- a/src/lib/hooks/useComputer.ts
+++ b/src/lib/hooks/useComputer.ts
@@ -2,6 +2,7 @@
 
 import useSWR, { preload } from "swr";
 
+import { type ComputerTipsResponse, unwrapComputerTips } from "@/lib/computer";
 import { fetcher } from "@/lib/fetcher";
 import type { NotionComputerItem, NotionComputerItemWithContent } from "@/lib/notion";
 
@@ -10,15 +11,15 @@ export function prefetchComputerTip(id: string) {
 }
 
 export function useComputerTips(fallbackData?: NotionComputerItem[]) {
-  const { data, error, isLoading } = useSWR<NotionComputerItem[]>("/api/computer", fetcher, {
+  const { data, error, isLoading } = useSWR<ComputerTipsResponse>("/api/computer", fetcher, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     refreshInterval: 1000 * 60 * 5,
-    fallbackData,
+    fallbackData: fallbackData ? { items: fallbackData } : undefined,
   });
 
   return {
-    tips: data || fallbackData || [],
+    tips: unwrapComputerTips(data, fallbackData),
     isLoading: isLoading && !fallbackData,
     isError: error,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`/computer` paints from SSR `initialTips` (a real array), then client SWR revalidates `GET /api/computer` and replaces `data` with `{ items: NotionComputerItem[] }`. `useComputerTips` typed/used that response as `NotionComputerItem[]`, so `ComputerList` called `tips.findIndex` / `tips.map` on the object and crashed (`TypeError: r.findIndex is not a function`, Sentry BRIOS-H).

## Fix

`useComputerTips` now matches the API shape:

- SWR data is `{ items: NotionComputerItem[] }`
- `fallbackData` is wrapped as `{ items }` so first paint and revalidation share the same shape
- Tips are always `data?.items ?? fallbackData ?? []` via `unwrapComputerTips`

`useComputerTip` is unchanged: `GET /api/computer/[id]` already returns the item directly.

## Tests

Unit tests cover unwrap behavior only (payload items, fallback, and that `findIndex`/`map` run on the array — not the response object).

## Verification

- [ ] `bun test src/lib/computer.test.ts`
- [ ] `bun run lint`
- [ ] `bun run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a332a1b-3cfa-41d6-8bc0-fd49e763e22f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a332a1b-3cfa-41d6-8bc0-fd49e763e22f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

