### PR TITLE
Restructure /computer into a catalog index and detail-only sidebar

### DIFF
--- a/src/app/computer/ComputerCatalog.test.tsx
+++ b/src/app/computer/ComputerCatalog.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { COMPUTER_INTRO, COMPUTER_TITLE, type ComputerTip } from "@/lib/computer";
+
+import { ComputerCatalog } from "./ComputerCatalog";
+
+function tip(overrides: Partial<ComputerTip> & Pick<ComputerTip, "id" | "title">): ComputerTip {
+  return {
+    status: "Published",
+    createdTime: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("ComputerCatalog", () => {
+  test("shows the title, intro, suggest control, and tip hrefs", () => {
+    const html = renderToStaticMarkup(
+      <ComputerCatalog
+        tips={[
+          tip({ id: "raycast", title: "Raycast", icon: "⌘" }),
+          tip({ id: "hyperkeys", title: "Hyperkeys" }),
+        ]}
+      />,
+    );
+
+    expect(html).toContain(COMPUTER_TITLE);
+    expect(html).toContain(COMPUTER_INTRO);
+    expect(html).toContain("Suggest a tip");
+    expect(html).toContain("Raycast");
+    expect(html).toContain('href="/computer/raycast"');
+    expect(html).toContain("Hyperkeys");
+    expect(html).toContain('href="/computer/hyperkeys"');
+    expect(html).not.toContain("Tip title...");
+  });
+});

--- a/src/app/computer/ComputerCatalog.tsx
+++ b/src/app/computer/ComputerCatalog.tsx
@@ -1,0 +1,30 @@
+import { List, ListItem, ListItemLabel, Section } from "@/components/shared/ListComponents";
+import { PageTitle } from "@/components/Typography";
+import { COMPUTER_INTRO, COMPUTER_TITLE, type ComputerTip } from "@/lib/computer";
+
+import { ComputerTipIcon } from "./ComputerTipIcon";
+import { SuggestTipControl } from "./SuggestTipControl";
+
+export function ComputerCatalog({ tips }: { tips: ComputerTip[] }) {
+  return (
+    <div data-scrollable className="flex-1 overflow-y-auto">
+      <div className="mx-auto flex max-w-xl flex-1 flex-col gap-16 py-16 leading-[1.6]">
+        <Section>
+          <PageTitle>{COMPUTER_TITLE}</PageTitle>
+          <p className="text-secondary text-lg leading-relaxed">{COMPUTER_INTRO}</p>
+          <SuggestTipControl />
+        </Section>
+        <Section>
+          <List>
+            {tips.map((tip) => (
+              <ListItem key={tip.id} href={`/computer/${tip.id}`}>
+                <ComputerTipIcon icon={tip.icon} />
+                <ListItemLabel className="line-clamp-none">{tip.title}</ListItemLabel>
+              </ListItem>
+            ))}
+          </List>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/computer/ComputerDetailLayoutClient.tsx
+++ b/src/app/computer/ComputerDetailLayoutClient.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+import { ListDetailLayout } from "@/components/ListDetailLayout";
+import { ListDetailWrapper } from "@/components/ListDetailWrapper";
+
+import { ComputerList } from "./ComputerList";
+
+export function ComputerDetailLayoutClient({ children }: { children: React.ReactNode }) {
+  return (
+    <ListDetailWrapper>
+      <ListDetailLayout backHref="/computer" list={<ComputerList />}>
+        {children}
+      </ListDetailLayout>
+    </ListDetailWrapper>
+  );
+}

--- a/src/app/computer/ComputerLayoutClient.test.tsx
+++ b/src/app/computer/ComputerLayoutClient.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { COMPUTER_INTRO, COMPUTER_TITLE } from "@/lib/computer";
+
+import { ComputerLayoutClient } from "./ComputerLayoutClient";
+
+describe("ComputerLayoutClient", () => {
+  test("wraps children without a sidebar header", () => {
+    const html = renderToStaticMarkup(
+      <ComputerLayoutClient initialTips={[]}>
+        <p>catalog child</p>
+      </ComputerLayoutClient>,
+    );
+
+    expect(html).toContain("catalog child");
+    expect(html).not.toContain("Suggest a tip");
+    expect(html).not.toContain(COMPUTER_TITLE);
+    expect(html).not.toContain(COMPUTER_INTRO);
+  });
+});

--- a/src/app/computer/ComputerLayoutClient.tsx
+++ b/src/app/computer/ComputerLayoutClient.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import { AnimatePresence, motion } from "motion/react";
-import React, { useState } from "react";
+import React from "react";
 
-import { ListDetailLayout } from "@/components/ListDetailLayout";
-import { ListDetailWrapper } from "@/components/ListDetailWrapper";
-import { Button } from "@/components/ui";
-import { COMPUTER_INTRO, COMPUTER_TITLE, type ComputerTip } from "@/lib/computer";
+import { type ComputerTip } from "@/lib/computer";
 import { useComputerTips } from "@/lib/hooks/useComputer";
-import { cn } from "@/lib/utils";
 
 import { ComputerTipsProvider } from "./ComputerContext";
-import { ComputerList } from "./ComputerList";
-import { SuggestTipForm } from "./SuggestTipForm";
 
 export function ComputerLayoutClient({
   children,
@@ -21,49 +14,11 @@ export function ComputerLayoutClient({
   children: React.ReactNode;
   initialTips?: ComputerTip[];
 }) {
-  const [showForm, setShowForm] = useState(false);
   const { tips, isLoading, isError } = useComputerTips(initialTips);
 
   return (
     <ComputerTipsProvider tips={tips} isLoading={isLoading ?? false} isError={isError}>
-      <ListDetailWrapper>
-        <ListDetailLayout
-          backHref="/computer"
-          list={
-            <div className="flex h-full flex-1 flex-col">
-              <div className={cn("flex flex-col gap-3 px-3 py-3 md:pb-0")}>
-                <div className="flex flex-col gap-2 px-0.5">
-                  <h1 className="text-primary text-lg font-semibold">{COMPUTER_TITLE}</h1>
-                  <p className="text-tertiary text-sm leading-relaxed">{COMPUTER_INTRO}</p>
-                </div>
-
-                <Button onClick={() => setShowForm(!showForm)} variant="secondary" fullWidth>
-                  Suggest a tip
-                </Button>
-
-                <AnimatePresence initial={false}>
-                  {showForm && (
-                    <motion.div
-                      initial={{ opacity: 0, height: 0, scale: 0.98 }}
-                      animate={{ opacity: 1, height: "auto", scale: 1 }}
-                      exit={{ opacity: 0, height: 0, scale: 0.98 }}
-                      className="overflow-hidden"
-                    >
-                      <div className="mt-3 px-0.5">
-                        <SuggestTipForm onComplete={() => setShowForm(false)} autoFocus />
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-
-              <ComputerList />
-            </div>
-          }
-        >
-          {children}
-        </ListDetailLayout>
-      </ListDetailWrapper>
+      <div className="flex min-w-0 flex-1 flex-col">{children}</div>
     </ComputerTipsProvider>
   );
 }

--- a/src/app/computer/ComputerList.tsx
+++ b/src/app/computer/ComputerList.tsx
@@ -10,6 +10,7 @@ import { prefetchComputerTip } from "@/lib/hooks/useComputer";
 import { cn } from "@/lib/utils";
 
 import { useComputerTipsContext } from "./ComputerContext";
+import { ComputerTipIcon } from "./ComputerTipIcon";
 
 export function ComputerList() {
   const pathname = usePathname();
@@ -32,7 +33,7 @@ export function ComputerList() {
   }
 
   return (
-    <ul className="flex flex-col pb-4">
+    <ul className="flex w-full flex-col gap-0.5 md:p-3">
       {tips.map((item) => {
         const isSelected = item.id === currentId;
         return (
@@ -47,16 +48,7 @@ export function ComputerList() {
               href={`/computer/${item.id}`}
               onMouseEnter={() => prefetchComputerTip(item.id)}
             >
-              {item.icon ? (
-                item.icon.startsWith("http") || item.icon.startsWith("data:") ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={item.icon} alt="" className="size-5 shrink-0 rounded-sm" />
-                ) : (
-                  <span className="shrink-0 text-lg leading-none" aria-hidden>
-                    {item.icon}
-                  </span>
-                )
-              ) : null}
+              <ComputerTipIcon icon={item.icon} />
               <span className="text-primary line-clamp-3 font-medium">{item.title}</span>
             </Link>
           </li>

--- a/src/app/computer/ComputerTipIcon.tsx
+++ b/src/app/computer/ComputerTipIcon.tsx
@@ -1,0 +1,16 @@
+export function ComputerTipIcon({ icon }: { icon?: string }) {
+  if (!icon) return null;
+
+  if (icon.startsWith("http") || icon.startsWith("data:")) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={icon} alt="" className="size-5 shrink-0 rounded-sm" />
+    );
+  }
+
+  return (
+    <span className="shrink-0 text-lg leading-none" aria-hidden>
+      {icon}
+    </span>
+  );
+}

--- a/src/app/computer/SuggestTipControl.tsx
+++ b/src/app/computer/SuggestTipControl.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui";
+
+import { SuggestTipForm } from "./SuggestTipForm";
+
+export function SuggestTipControl() {
+  const [showForm, setShowForm] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Button onClick={() => setShowForm(!showForm)} variant="secondary">
+        Suggest a tip
+      </Button>
+
+      <AnimatePresence initial={false}>
+        {showForm && (
+          <motion.div
+            initial={{ opacity: 0, height: 0, scale: 0.98 }}
+            animate={{ opacity: 1, height: "auto", scale: 1 }}
+            exit={{ opacity: 0, height: 0, scale: 0.98 }}
+            className="overflow-hidden"
+          >
+            <SuggestTipForm onComplete={() => setShowForm(false)} autoFocus />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/app/computer/[id]/layout.tsx
+++ b/src/app/computer/[id]/layout.tsx
@@ -1,0 +1,7 @@
+import type { ReactNode } from "react";
+
+import { ComputerDetailLayoutClient } from "../ComputerDetailLayoutClient";
+
+export default function ComputerDetailLayout({ children }: { children: ReactNode }) {
+  return <ComputerDetailLayoutClient>{children}</ComputerDetailLayoutClient>;
+}

--- a/src/app/computer/page.tsx
+++ b/src/app/computer/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 
-import { PageTitle } from "@/components/Typography";
-import { COMPUTER_INTRO, COMPUTER_TITLE } from "@/lib/computer";
+import { COMPUTER_INTRO, COMPUTER_TITLE, type ComputerTip } from "@/lib/computer";
 import { createMetadata } from "@/lib/metadata";
+import { getComputerDatabaseItems, isPlaceholderNotionBuild } from "@/lib/notion";
+
+import { ComputerCatalog } from "./ComputerCatalog";
 
 export const metadata: Metadata = createMetadata({
   title: COMPUTER_TITLE,
@@ -10,11 +13,17 @@ export const metadata: Metadata = createMetadata({
   path: "/computer",
 });
 
-export default function ComputerPage() {
-  return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4 md:px-8 md:py-12">
-      <PageTitle>{COMPUTER_TITLE}</PageTitle>
-      <p className="text-secondary text-lg leading-relaxed">{COMPUTER_INTRO}</p>
-    </div>
-  );
+export default async function ComputerPage() {
+  const tips = await getCachedComputerTips();
+  return <ComputerCatalog tips={tips} />;
+}
+
+async function getCachedComputerTips(): Promise<ComputerTip[]> {
+  "use cache";
+  cacheLife("days");
+  cacheTag("notion:computer");
+  if (isPlaceholderNotionBuild()) {
+    return [];
+  }
+  return getComputerDatabaseItems();
 }

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -187,7 +187,7 @@ describe("use cache page islands", () => {
       writing: ["page.tsx", "writing/page.tsx", "writing/[slug]/page.tsx"],
       til: ["til/page.tsx", "til/[slug]/page.tsx"],
       ama: ["ama/layout.tsx", "ama/[id]/page.tsx"],
-      computer: ["computer/layout.tsx", "computer/[id]/page.tsx"],
+      computer: ["computer/layout.tsx", "computer/page.tsx", "computer/[id]/page.tsx"],
       stack: ["stack/page.tsx"],
       sites: ["sites/page.tsx"],
       hn: ["hn/layout.tsx", "hn/[id]/page.tsx"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/computer` was always wrapped in ListDetail, so the root page showed a sidebar (title, intro, Suggest, tip list) and an empty-ish detail pane.

This splits the two routes:

- **`/computer`** — no sidebar. Writing-style catalog: title, intro, Suggest a tip, and an inline column of published tip links to `/computer/[id]`.
- **`/computer/[id]`** — ListDetail sidebar for tip-to-tip nav. The rail is list-only (no title/intro/Suggest). The list container uses AMA’s `md:p-3` outer padding so rounded rows are not full-bleed.

The parent layout still caches Notion tips (`use cache` + `cacheTag("notion:computer")`) and provides SWR/`useComputerTips` unwrap of `{ items }`. Suggest stays on the catalog page via the existing `SuggestTipForm`.

Tests cover catalog copy/hrefs/Suggest visibility only — no className or SVG assertions.

[Computer catalog index without sidebar](https://cursor.com/agents/bc-053e996b-3975-4951-9ff0-690bddba41f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomputer_catalog_index.webp)
[Suggest a tip form open on the catalog](https://cursor.com/agents/bc-053e996b-3975-4951-9ff0-690bddba41f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomputer_suggest_form.webp)
[computer_catalog_and_suggest_form.mp4](https://cursor.com/agents/bc-053e996b-3975-4951-9ff0-690bddba41f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomputer_catalog_and_suggest_form.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-053e996b-3975-4951-9ff0-690bddba41f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-053e996b-3975-4951-9ff0-690bddba41f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

