### PR TITLE
Add native How Terminals Work essay at /how-terminals-work

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,13 @@ const eslintConfig = [
       "@typescript-eslint/no-unused-vars": "error",
     },
   },
+  {
+    files: ["src/app/how-terminals-work/demos/**/*.tsx"],
+    rules: {
+      "react/no-unescaped-entities": "off",
+      "react/jsx-no-comment-textnodes": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -201,7 +201,31 @@
     0 1px 3px 0px rgba(0, 0, 0, 0.4);
 }
 
+@font-face {
+  font-family: "JetBrainsMono Nerd Font";
+  src: url("https://cdn.jsdelivr.net/gh/ryanoasis/nerd-fonts@v3.1.1/patched-fonts/JetBrainsMono/Ligatures/Regular/JetBrainsMonoNerdFont-Regular.ttf")
+    format("truetype");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
 @layer utilities {
+  @keyframes cursor-blink {
+    0%,
+    50% {
+      opacity: 1;
+    }
+    51%,
+    100% {
+      opacity: 0;
+    }
+  }
+
+  .cursor-blink {
+    animation: cursor-blink 1s step-end infinite;
+  }
+
   @keyframes accordion-down {
     from {
       height: 0;

--- a/src/app/how-terminals-work/HowTerminalsWorkGuide.tsx
+++ b/src/app/how-terminals-work/HowTerminalsWorkGuide.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Section, SectionHeading } from "@/components/shared/ListComponents";
+import {
+  HOW_TERMINALS_WORK_SECTIONS,
+  type HowTerminalsWorkSection,
+} from "@/lib/how-terminals-work";
+
+import { AdvancedTUIDemo } from "./demos/AdvancedTUIDemo";
+import { AlternateScreenDemo } from "./demos/AlternateScreenDemo";
+import { CapabilityDiscoveryDemo } from "./demos/CapabilityDiscoveryDemo";
+import { CellZoom } from "./demos/CellZoom";
+import { EscapeDemo } from "./demos/EscapeDemo";
+import { FlowDiagram } from "./demos/FlowDiagram";
+import { GridDemo } from "./demos/GridDemo";
+import { IconsDemo } from "./demos/IconsDemo";
+import { InputModesDemo } from "./demos/InputModesDemo";
+import { KeyboardDemo } from "./demos/KeyboardDemo";
+import { MouseDemo } from "./demos/MouseDemo";
+import { SignalsDemo } from "./demos/SignalsDemo";
+import { StateManagementDemo } from "./demos/StateManagementDemo";
+import { TextSelectionDemo } from "./demos/TextSelectionDemo";
+import { VocabularyDemo } from "./demos/VocabularyDemo";
+
+function DemoForSection({ id }: { id: HowTerminalsWorkSection["id"] }) {
+  switch (id) {
+    case "grid":
+      return <GridDemo />;
+    case "cell":
+      return <CellZoom />;
+    case "escape":
+      return <EscapeDemo />;
+    case "input":
+      return (
+        <div className="flex flex-col gap-10">
+          <KeyboardDemo />
+          <MouseDemo />
+        </div>
+      );
+    case "signals":
+      return <SignalsDemo />;
+    case "input-modes":
+      return <InputModesDemo />;
+    case "flow":
+      return <FlowDiagram />;
+    case "advanced-tui":
+      return <AdvancedTUIDemo />;
+    case "alternate-screen":
+      return <AlternateScreenDemo />;
+    case "icons":
+      return <IconsDemo />;
+    case "state":
+      return <StateManagementDemo />;
+    case "selection":
+      return <TextSelectionDemo />;
+    case "capability-discovery":
+      return <CapabilityDiscoveryDemo />;
+    case "vocabulary":
+      return <VocabularyDemo />;
+  }
+}
+
+export function HowTerminalsWorkGuide() {
+  return (
+    <>
+      {HOW_TERMINALS_WORK_SECTIONS.map((section) => (
+        <div key={section.id} id={section.id} className="scroll-mt-8">
+          <Section>
+            <SectionHeading>
+              <span className="tabular-nums">{String(section.number).padStart(2, "0")}</span>{" "}
+              {section.title}
+            </SectionHeading>
+            <p className="text-secondary text-pretty">{section.insight}</p>
+            <DemoForSection id={section.id} />
+          </Section>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/app/how-terminals-work/HowTerminalsWorkGuide.tsx
+++ b/src/app/how-terminals-work/HowTerminalsWorkGuide.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Section, SectionHeading } from "@/components/shared/ListComponents";
 import {
   HOW_TERMINALS_WORK_SECTIONS,

--- a/src/app/how-terminals-work/demos/AdvancedTUIDemo.tsx
+++ b/src/app/how-terminals-work/demos/AdvancedTUIDemo.tsx
@@ -1,0 +1,601 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { FeatureBox, StepDotsNavigation, TerminalWindow } from "../ui";
+
+interface Region {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+  focusable: boolean;
+}
+
+// Simulated TUI data
+const SIDEBAR_ITEMS = [
+  { id: "deploy-1", name: "ci-fe-be-rules", status: "success" },
+  { id: "deploy-2", name: "ci-api-test", status: "running" },
+  { id: "deploy-3", name: "ci-email-service", status: "success" },
+  { id: "deploy-4", name: "ci-auth-core", status: "failed" },
+  { id: "deploy-5", name: "ci-db-migration", status: "pending" },
+];
+
+const TABS = ["Continuous", "Integration", "Logging"];
+
+type ExplainerStep =
+  | "overview"
+  | "layout-system"
+  | "focus-management"
+  | "resize-handling"
+  | "rendering";
+
+interface StepContent {
+  title: string;
+  description: string;
+  highlightRegions: string[];
+}
+
+const EXPLAINER_STEPS: Record<ExplainerStep, StepContent> = {
+  overview: {
+    title: "The Layout System",
+    description:
+      "Advanced TUIs divide the terminal into regions. Each region is a rectangular area with its own content and borders. The TUI framework tracks each region's position and size in the character grid.",
+    highlightRegions: ["tabs", "sidebar", "content"],
+  },
+  "layout-system": {
+    title: "Region Coordinates",
+    description:
+      "Each region stores its position (x, y) and dimensions (width, height) in character cells. Box-drawing characters (like ┌─┐│) create visual borders. The TUI recalculates these when content changes.",
+    highlightRegions: [],
+  },
+  "focus-management": {
+    title: "Focus & Input Routing",
+    description:
+      "Only one region is 'focused' at a time (shown with a green border). Keystrokes are routed to the focused region. Tab/arrow keys move focus between regions. The cursor position is tracked within the focused region.",
+    highlightRegions: ["sidebar"],
+  },
+  "resize-handling": {
+    title: "Terminal Resize",
+    description:
+      "When you resize the terminal window, it sends a SIGWINCH signal. The TUI queries the new size with ioctl(), then recalculates every region's dimensions and re-renders the entire screen.",
+    highlightRegions: [],
+  },
+  rendering: {
+    title: "Full-Screen Rendering",
+    description:
+      "TUIs often use 'alternate screen mode' (CSI ?1049h) for a clean canvas. They position the cursor with escape codes and draw each cell. Double-buffering prevents flicker: draw to memory first, then output all at once.",
+    highlightRegions: [],
+  },
+};
+
+export function AdvancedTUIDemo() {
+  const [currentStep, setCurrentStep] = useState<ExplainerStep>("overview");
+  const [activeTab, setActiveTab] = useState(0);
+  const [selectedItem, setSelectedItem] = useState(0);
+  const [focusedRegion, setFocusedRegion] = useState<"tabs" | "sidebar" | "content">("sidebar");
+  const [terminalSize, setTerminalSize] = useState({ cols: 60, rows: 20 });
+  const [showCoordinates, setShowCoordinates] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Handle keyboard navigation in the demo
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const regions: ("tabs" | "sidebar" | "content")[] = ["tabs", "sidebar", "content"];
+        const currentIdx = regions.indexOf(focusedRegion);
+        setFocusedRegion(regions[(currentIdx + 1) % regions.length]!);
+      } else if (focusedRegion === "tabs" && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
+        e.preventDefault();
+        setActiveTab((prev) => {
+          if (e.key === "ArrowLeft") return Math.max(0, prev - 1);
+          return Math.min(TABS.length - 1, prev + 1);
+        });
+      } else if (focusedRegion === "sidebar" && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+        e.preventDefault();
+        setSelectedItem((prev) => {
+          if (e.key === "ArrowUp") return Math.max(0, prev - 1);
+          return Math.min(SIDEBAR_ITEMS.length - 1, prev + 1);
+        });
+      }
+    },
+    [focusedRegion],
+  );
+
+  // Simulate resize
+  const simulateResize = () => {
+    setIsResizing(true);
+    const sizes = [
+      { cols: 60, rows: 20 },
+      { cols: 80, rows: 24 },
+      { cols: 50, rows: 16 },
+      { cols: 60, rows: 20 },
+    ];
+    let i = 0;
+    const interval = setInterval(() => {
+      if (i < sizes.length) {
+        setTerminalSize(sizes[i]!);
+        i++;
+      } else {
+        clearInterval(interval);
+        setIsResizing(false);
+      }
+    }, 600);
+  };
+
+  // Calculate region dimensions based on terminal size
+  const calculateRegions = (): Region[] => {
+    const sidebarWidth = Math.floor(terminalSize.cols * 0.35);
+    const contentWidth = terminalSize.cols - sidebarWidth;
+    const tabHeight = 3;
+    const contentHeight = terminalSize.rows - tabHeight;
+
+    return [
+      {
+        id: "tabs",
+        name: "Tab Bar",
+        x: 0,
+        y: 0,
+        width: terminalSize.cols,
+        height: tabHeight,
+        color: "text-secondary",
+        focusable: true,
+      },
+      {
+        id: "sidebar",
+        name: "Sidebar",
+        x: 0,
+        y: tabHeight,
+        width: sidebarWidth,
+        height: contentHeight,
+        color: "text-secondary",
+        focusable: true,
+      },
+      {
+        id: "content",
+        name: "Content",
+        x: sidebarWidth,
+        y: tabHeight,
+        width: contentWidth,
+        height: contentHeight,
+        color: "text-secondary",
+        focusable: true,
+      },
+    ];
+  };
+
+  const regions = calculateRegions();
+  const stepContent = EXPLAINER_STEPS[currentStep];
+
+  // Render the simulated TUI
+  const renderTUI = () => {
+    const selectedDeploy = SIDEBAR_ITEMS[selectedItem]!;
+    const sidebarWidth = Math.floor(terminalSize.cols * 0.35);
+
+    // Generate status content
+    const statusColor = {
+      success: "text-primary",
+      running: "text-secondary",
+      failed: "text-primary",
+      pending: "text-quaternary",
+    }[selectedDeploy.status];
+
+    return (
+      <div
+        className="font-mono text-xs leading-tight select-none"
+        style={{ minWidth: `${terminalSize.cols}ch` }}
+      >
+        {/* Tab bar */}
+        <div
+          className={`border-primary flex border-b ${focusedRegion === "tabs" ? "ring-primary ring-1" : ""}`}
+          onClick={() => setFocusedRegion("tabs")}
+        >
+          {TABS.map((tab, i) => (
+            <button
+              key={tab}
+              onClick={(e) => {
+                e.stopPropagation();
+                setActiveTab(i);
+                setFocusedRegion("tabs");
+              }}
+              className={`border-primary border-r px-3 py-1 transition-colors ${
+                i === activeTab
+                  ? "bg-primary/10 text-primary border-b-primary border-b-2"
+                  : "text-quaternary hover:text-primary"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+          {showCoordinates && (
+            <span className="text-secondary ml-auto self-center pr-2 text-[10px]">
+              Region: tabs (0,0) {terminalSize.cols}x3
+            </span>
+          )}
+        </div>
+
+        {/* Main content area */}
+        <div className="flex" style={{ height: `${(terminalSize.rows - 3) * 1.25}em` }}>
+          {/* Sidebar */}
+          <div
+            className={`border-primary overflow-hidden border-r ${focusedRegion === "sidebar" ? "ring-primary ring-1" : ""}`}
+            style={{ width: `${sidebarWidth}ch` }}
+            onClick={() => setFocusedRegion("sidebar")}
+          >
+            {showCoordinates && (
+              <div className="text-secondary border-primary border-b px-2 py-1 text-[10px]">
+                Region: sidebar (0,3) {sidebarWidth}x{terminalSize.rows - 3}
+              </div>
+            )}
+            <div className="p-1">
+              {SIDEBAR_ITEMS.map((item, i) => {
+                const statusIcon = {
+                  success: "✓",
+                  running: "◐",
+                  failed: "✗",
+                  pending: "○",
+                }[item.status];
+                const itemStatusColor = {
+                  success: "text-primary",
+                  running: "text-secondary",
+                  failed: "text-primary",
+                  pending: "text-quaternary",
+                }[item.status];
+
+                return (
+                  <div
+                    key={item.id}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSelectedItem(i);
+                      setFocusedRegion("sidebar");
+                    }}
+                    className={`flex cursor-pointer items-center gap-1 truncate px-2 py-0.5 ${
+                      i === selectedItem ? "bg-primary/10 text-primary" : "hover:bg-tertiary"
+                    }`}
+                  >
+                    <span className={itemStatusColor}>{statusIcon}</span>
+                    <span className="truncate">{item.name}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Content area */}
+          <div
+            className={`flex-1 overflow-hidden p-2 ${focusedRegion === "content" ? "ring-primary ring-1" : ""}`}
+            onClick={() => setFocusedRegion("content")}
+          >
+            {showCoordinates && (
+              <div className="text-secondary mb-2 text-[10px]">
+                Region: content ({sidebarWidth},3) {terminalSize.cols - sidebarWidth}x
+                {terminalSize.rows - 3}
+              </div>
+            )}
+            <div className="text-primary mb-2 font-bold">{selectedDeploy.name}</div>
+            <div className="text-quaternary space-y-1">
+              <div>
+                Status: <span className={statusColor}>{selectedDeploy.status}</span>
+              </div>
+              <div>Updated: 2024-01-15 14:32:00 UTC</div>
+              {selectedDeploy.status === "running" && (
+                <div className="text-secondary mt-2">Building... ████████░░░░░░░░ 52%</div>
+              )}
+              {selectedDeploy.status === "failed" && (
+                <div className="text-primary mt-2 text-[10px]">
+                  Error: Test suite failed (3 failures)
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const steps = Object.keys(EXPLAINER_STEPS) as ExplainerStep[];
+
+  return (
+    <div className="space-y-8">
+      {/* Main interactive demo */}
+      <div className="grid grid-cols-1 gap-6">
+        {/* Left: The simulated TUI */}
+        <div className="space-y-4">
+          <TerminalWindow>
+            <div
+              ref={containerRef}
+              tabIndex={0}
+              onKeyDown={handleKeyDown}
+              className="focus:outline-none"
+            >
+              {renderTUI()}
+            </div>
+          </TerminalWindow>
+
+          {/* Controls */}
+          <div className="flex flex-wrap gap-2 text-sm">
+            <button
+              onClick={() => setShowCoordinates(!showCoordinates)}
+              className={`border px-3 py-1.5 transition-colors ${
+                showCoordinates
+                  ? "bg-primary/10 border-primary text-primary"
+                  : "border-primary hover:border-primary"
+              }`}
+            >
+              {showCoordinates ? "Hide" : "Show"} Coordinates
+            </button>
+            <button
+              onClick={simulateResize}
+              disabled={isResizing}
+              className={`border px-3 py-1.5 transition-colors ${
+                isResizing
+                  ? "border-secondary text-secondary"
+                  : "border-primary hover:border-primary"
+              }`}
+            >
+              {isResizing ? "Resizing..." : "Simulate Resize"}
+            </button>
+            <span className="text-quaternary self-center">
+              Size: {terminalSize.cols}x{terminalSize.rows}
+            </span>
+          </div>
+        </div>
+
+        {/* Right: Explanation */}
+        <div className="space-y-4">
+          <div className="bg-tertiary border-primary space-y-4 border px-4 py-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="text-primary text-sm font-medium">{stepContent.title}</div>
+              <StepDotsNavigation
+                steps={steps}
+                currentStep={currentStep}
+                onStepChange={setCurrentStep}
+              />
+            </div>
+            <div className="space-y-4">
+              <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
+
+              {/* Step-specific visualizations */}
+              {currentStep === "layout-system" && (
+                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                  <div className="text-quaternary">// Region data structure</div>
+                  <div className="text-primary">
+                    {regions.map((r) => (
+                      <div key={r.id} className="ml-2">
+                        <span className={r.color}>{r.name}</span>:
+                        <span className="text-secondary">
+                          {" "}
+                          x={r.x}, y={r.y}, w={r.width}, h={r.height}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {currentStep === "focus-management" && (
+                <div className="bg-tertiary space-y-2 p-3">
+                  <div className="space-y-1 text-xs">
+                    <div className="flex items-center gap-2">
+                      <span className="border-primary bg-primary/10 h-3 w-3 rounded border-2"></span>
+                      <span>
+                        Currently focused: <span className="text-primary">{focusedRegion}</span>
+                      </span>
+                    </div>
+                    <div className="text-quaternary mt-2">
+                      Focus determines where keystrokes go. The cursor (if any) lives in the focused
+                      region.
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {currentStep === "resize-handling" && (
+                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                  <div className="text-quaternary">// Terminal resize sequence</div>
+                  <div className="space-y-1">
+                    <div>
+                      <span className="text-secondary">1.</span> User drags window edge
+                    </div>
+                    <div>
+                      <span className="text-secondary">2.</span> OS sends{" "}
+                      <span className="text-secondary">SIGWINCH</span> signal
+                    </div>
+                    <div>
+                      <span className="text-secondary">3.</span> App calls{" "}
+                      <span className="text-primary">ioctl(TIOCGWINSZ)</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">4.</span> Gets new size:{" "}
+                      <span className="text-secondary">
+                        {terminalSize.cols}×{terminalSize.rows}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">5.</span> Recalculate all region bounds
+                    </div>
+                    <div>
+                      <span className="text-secondary">6.</span> Clear screen + redraw everything
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {currentStep === "rendering" && (
+                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                  <div className="text-quaternary">// Escape sequences for TUI rendering</div>
+                  <div className="space-y-1">
+                    <div>
+                      <span className="text-secondary">\x1b[?1049h</span>{" "}
+                      <span className="text-quaternary">— Enter alternate screen</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">\x1b[2J</span>{" "}
+                      <span className="text-quaternary">— Clear entire screen</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">\x1b[H</span>{" "}
+                      <span className="text-quaternary">— Move cursor to (1,1)</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">
+                        \x1b[{"{row}"};{"{col}"}H
+                      </span>{" "}
+                      <span className="text-quaternary">— Move cursor to position</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">\x1b[?25l</span>{" "}
+                      <span className="text-quaternary">— Hide cursor while drawing</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">\x1b[?25h</span>{" "}
+                      <span className="text-quaternary">— Show cursor when done</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Detailed breakdown: How regions work */}
+      <div className="bg-tertiary border-primary space-y-6 border p-6">
+        <h3 className="text-primary text-sm font-bold">Under the Hood: TUI Architecture</h3>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <FeatureBox number={1} title="Layout Engine">
+            <p className="text-quaternary text-sm">
+              The TUI maintains a tree of regions (like a DOM). Each region knows its bounds and can
+              have children. When the container resizes, bounds propagate down the tree.
+            </p>
+          </FeatureBox>
+
+          <FeatureBox number={2} title="Event Dispatch">
+            <p className="text-quaternary text-sm">
+              Input events (keys, mouse) go to the focused region first. If unhandled, they bubble
+              up. Mouse clicks hit-test against region bounds to determine which region was clicked.
+            </p>
+          </FeatureBox>
+
+          <FeatureBox number={3} title="Render Loop">
+            <p className="text-quaternary text-sm">
+              Each region renders to a buffer (2D array of cells). Buffers merge into a final screen
+              buffer. Only changed cells get written to the terminal, minimizing escape sequences.
+            </p>
+          </FeatureBox>
+        </div>
+
+        {/* Box drawing character reference */}
+        <div className="bg-tertiary border-primary space-y-3 border p-4">
+          <div className="text-primary text-sm font-bold">Box Drawing Characters</div>
+          <div className="grid grid-cols-2 gap-4 font-mono text-sm md:grid-cols-4">
+            <div className="space-y-1">
+              <div className="text-quaternary">Corners</div>
+              <div>┌ ┐ └ ┘</div>
+            </div>
+            <div className="space-y-1">
+              <div className="text-quaternary">Lines</div>
+              <div>─ │ ═ ║</div>
+            </div>
+            <div className="space-y-1">
+              <div className="text-quaternary">T-Junctions</div>
+              <div>┬ ┴ ├ ┤</div>
+            </div>
+            <div className="space-y-1">
+              <div className="text-quaternary">Crosses</div>
+              <div>┼ ╬ ╪ ╫</div>
+            </div>
+          </div>
+          <p className="text-quaternary text-xs">
+            These Unicode characters create the borders you see in TUIs. They're just regular
+            characters—the terminal renders them like any other text.
+          </p>
+        </div>
+      </div>
+
+      {/* The cursor position explainer */}
+      <CursorPositionDemo />
+    </div>
+  );
+}
+
+// Sub-component for cursor positioning
+function CursorPositionDemo() {
+  const [cursorPos, setCursorPos] = useState({ row: 1, col: 1 });
+  const GRID_ROWS = 5;
+  const GRID_COLS = 20;
+
+  return (
+    <div className="bg-tertiary border-primary space-y-4 border p-6">
+      <h3 className="text-primary text-sm font-bold">Cursor Positioning</h3>
+      <p className="text-quaternary text-sm">
+        The terminal tracks a single cursor position. TUIs constantly move this cursor using escape
+        sequences to draw in different regions. Click any cell below to see the escape sequence that
+        would move the cursor there.
+      </p>
+
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="font-mono text-xs">
+          <div
+            className="border-primary grid gap-0 border"
+            style={{ gridTemplateColumns: `repeat(${GRID_COLS}, 1fr)` }}
+          >
+            {Array(GRID_ROWS)
+              .fill(null)
+              .map((_, row) =>
+                Array(GRID_COLS)
+                  .fill(null)
+                  .map((_, col) => {
+                    const isActive = cursorPos.row === row + 1 && cursorPos.col === col + 1;
+                    return (
+                      <div
+                        key={`${row}-${col}`}
+                        onClick={() => setCursorPos({ row: row + 1, col: col + 1 })}
+                        className={`border-primary/30 flex h-5 w-4 cursor-pointer items-center justify-center border-r border-b transition-colors ${
+                          isActive
+                            ? "bg-primary text-white dark:text-neutral-950"
+                            : "hover:bg-tertiary"
+                        }`}
+                      >
+                        {isActive ? "█" : "·"}
+                      </div>
+                    );
+                  }),
+              )}
+          </div>
+        </div>
+
+        <div className="flex-1 space-y-3">
+          <div className="bg-tertiary p-3 font-mono text-sm">
+            <div className="text-quaternary mb-2 text-xs">Escape sequence to move cursor:</div>
+            <div className="text-secondary">
+              \x1b[{cursorPos.row};{cursorPos.col}H
+            </div>
+          </div>
+          <div className="bg-tertiary p-3 font-mono text-sm">
+            <div className="text-quaternary mb-2 text-xs">In code:</div>
+            <div className="text-primary">
+              <span className="text-secondary">printf</span>
+              <span className="text-secondary">(</span>
+              <span className="text-primary">
+                "\033[{cursorPos.row};{cursorPos.col}H"
+              </span>
+              <span className="text-secondary">)</span>
+            </div>
+          </div>
+          <p className="text-quaternary text-xs">
+            Position ({cursorPos.row}, {cursorPos.col}) — Row {cursorPos.row}, Column{" "}
+            {cursorPos.col}. Terminal coordinates are 1-indexed (row 1, col 1 is top-left).
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/AdvancedTUIDemo.tsx
+++ b/src/app/how-terminals-work/demos/AdvancedTUIDemo.tsx
@@ -349,7 +349,7 @@ export function AdvancedTUIDemo() {
 
         {/* Right: Explanation */}
         <div className="space-y-4">
-          <div className="bg-tertiary border-primary space-y-4 border px-4 py-4">
+          <div className="space-y-4">
             <div className="flex items-start justify-between gap-4">
               <div className="text-primary text-sm font-medium">{stepContent.title}</div>
               <StepDotsNavigation
@@ -363,7 +363,7 @@ export function AdvancedTUIDemo() {
 
               {/* Step-specific visualizations */}
               {currentStep === "layout-system" && (
-                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="space-y-2 font-mono text-xs">
                   <div className="text-quaternary">// Region data structure</div>
                   <div className="text-primary">
                     {regions.map((r) => (
@@ -380,7 +380,7 @@ export function AdvancedTUIDemo() {
               )}
 
               {currentStep === "focus-management" && (
-                <div className="bg-tertiary space-y-2 p-3">
+                <div className="space-y-2">
                   <div className="space-y-1 text-xs">
                     <div className="flex items-center gap-2">
                       <span className="border-primary bg-primary/10 h-3 w-3 rounded border-2"></span>
@@ -397,7 +397,7 @@ export function AdvancedTUIDemo() {
               )}
 
               {currentStep === "resize-handling" && (
-                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="space-y-2 font-mono text-xs">
                   <div className="text-quaternary">// Terminal resize sequence</div>
                   <div className="space-y-1">
                     <div>
@@ -428,7 +428,7 @@ export function AdvancedTUIDemo() {
               )}
 
               {currentStep === "rendering" && (
-                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="space-y-2 font-mono text-xs">
                   <div className="text-quaternary">// Escape sequences for TUI rendering</div>
                   <div className="space-y-1">
                     <div>
@@ -466,10 +466,10 @@ export function AdvancedTUIDemo() {
       </div>
 
       {/* Detailed breakdown: How regions work */}
-      <div className="bg-tertiary border-primary space-y-6 border p-6">
-        <h3 className="text-primary text-sm font-bold">Under the Hood: TUI Architecture</h3>
+      <div className="space-y-6">
+        <h3 className="text-primary text-sm font-medium">Under the Hood: TUI Architecture</h3>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <FeatureBox number={1} title="Layout Engine">
             <p className="text-quaternary text-sm">
               The TUI maintains a tree of regions (like a DOM). Each region knows its bounds and can
@@ -493,9 +493,9 @@ export function AdvancedTUIDemo() {
         </div>
 
         {/* Box drawing character reference */}
-        <div className="bg-tertiary border-primary space-y-3 border p-4">
-          <div className="text-primary text-sm font-bold">Box Drawing Characters</div>
-          <div className="grid grid-cols-2 gap-4 font-mono text-sm md:grid-cols-4">
+        <div className="space-y-3">
+          <div className="text-primary text-sm font-medium">Box Drawing Characters</div>
+          <div className="grid grid-cols-2 gap-4 font-mono text-sm lg:grid-cols-4">
             <div className="space-y-1">
               <div className="text-quaternary">Corners</div>
               <div>┌ ┐ └ ┘</div>
@@ -533,15 +533,15 @@ function CursorPositionDemo() {
   const GRID_COLS = 20;
 
   return (
-    <div className="bg-tertiary border-primary space-y-4 border p-6">
-      <h3 className="text-primary text-sm font-bold">Cursor Positioning</h3>
+    <div className="space-y-4">
+      <h3 className="text-primary text-sm font-medium">Cursor Positioning</h3>
       <p className="text-quaternary text-sm">
         The terminal tracks a single cursor position. TUIs constantly move this cursor using escape
         sequences to draw in different regions. Click any cell below to see the escape sequence that
         would move the cursor there.
       </p>
 
-      <div className="flex flex-col gap-6 md:flex-row">
+      <div className="flex flex-col gap-6 lg:flex-row">
         <div className="font-mono text-xs">
           <div
             className="border-primary grid gap-0 border"
@@ -559,9 +559,7 @@ function CursorPositionDemo() {
                         key={`${row}-${col}`}
                         onClick={() => setCursorPos({ row: row + 1, col: col + 1 })}
                         className={`border-primary/30 flex h-5 w-4 cursor-pointer items-center justify-center border-r border-b transition-colors ${
-                          isActive
-                            ? "bg-primary text-white dark:text-neutral-950"
-                            : "hover:bg-tertiary"
+                          isActive ? "bg-primary/10 text-primary" : "hover:bg-tertiary"
                         }`}
                       >
                         {isActive ? "█" : "·"}
@@ -573,13 +571,13 @@ function CursorPositionDemo() {
         </div>
 
         <div className="flex-1 space-y-3">
-          <div className="bg-tertiary p-3 font-mono text-sm">
+          <div className="font-mono text-sm">
             <div className="text-quaternary mb-2 text-xs">Escape sequence to move cursor:</div>
             <div className="text-secondary">
               \x1b[{cursorPos.row};{cursorPos.col}H
             </div>
           </div>
-          <div className="bg-tertiary p-3 font-mono text-sm">
+          <div className="font-mono text-sm">
             <div className="text-quaternary mb-2 text-xs">In code:</div>
             <div className="text-primary">
               <span className="text-secondary">printf</span>

--- a/src/app/how-terminals-work/demos/AlternateScreenDemo.tsx
+++ b/src/app/how-terminals-work/demos/AlternateScreenDemo.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { Button, InfoPanel, StepDotsNavigation, SubsectionLabel } from "../ui";
+
+type ExplainerStep = "what" | "why" | "how" | "apps";
+
+const EXPLAINER_STEPS: Record<ExplainerStep, { title: string; description: string }> = {
+  what: {
+    title: "What Is the Alternate Screen?",
+    description:
+      "Terminals have two screen buffers: the normal screen (with your scrollback history) and the alternate screen (a separate canvas). Programs can switch between them. When they exit, your original screen reappears.",
+  },
+  why: {
+    title: "Why Does This Exist?",
+    description:
+      "Without the alternate screen, full-screen apps like vim would draw all over your terminal history. When you quit, you'd see vim's last screen mixed with your old output. The alternate screen keeps your scrollback clean.",
+  },
+  how: {
+    title: "How It Works",
+    description:
+      "Programs send an escape sequence to enter alternate screen mode: ^[[?1049h. When they exit, they send ^[[?1049l to return to the normal screen. The terminal swaps buffers, preserving your history.",
+  },
+  apps: {
+    title: "Apps That Use It",
+    description:
+      "vim, less, man, htop, tmux, and most TUI apps use the alternate screen. When you quit these apps, notice how your previous terminal output reappears? That's the alternate screen at work.",
+  },
+};
+
+// Sample terminal content for normal mode
+const NORMAL_SCREEN_CONTENT = [
+  "$ ls -la",
+  "total 32",
+  "drwxr-xr-x  5 user staff  160 Jan  8 10:30 .",
+  "drwxr-xr-x  8 user staff  256 Jan  7 14:22 ..",
+  "-rw-r--r--  1 user staff  847 Jan  8 10:30 package.json",
+  "-rw-r--r--  1 user staff 1205 Jan  8 10:28 README.md",
+  "drwxr-xr-x 12 user staff  384 Jan  8 10:30 src",
+  "$ git status",
+  "On branch main",
+  "nothing to commit, working tree clean",
+  "$ vim README.md",
+];
+
+// Simulated vim content for alternate screen
+const ALTERNATE_SCREEN_CONTENT = [
+  "# My Project",
+  "",
+  "This is a sample README file.",
+  "",
+  "## Getting Started",
+  "",
+  "```bash",
+  "npm install",
+  "npm start",
+  "```",
+  "",
+  "~",
+  "~",
+  "~",
+];
+
+export function AlternateScreenDemo() {
+  const [isAlternateScreen, setIsAlternateScreen] = useState(false);
+  const [currentStep, setCurrentStep] = useState<ExplainerStep>("what");
+
+  const steps = Object.keys(EXPLAINER_STEPS) as ExplainerStep[];
+  const stepContent = EXPLAINER_STEPS[currentStep];
+
+  const toggleScreen = () => {
+    setIsAlternateScreen((prev) => !prev);
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Main Demo */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Terminal Simulation */}
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <Button size="sm" onClick={toggleScreen}>
+              {isAlternateScreen ? "Exit vim (:q)" : "Open vim"}
+            </Button>
+            <span
+              className={`px-2 py-1 text-xs ${
+                isAlternateScreen ? "bg-primary/10 text-secondary" : "bg-primary/10 text-primary"
+              }`}
+            >
+              {isAlternateScreen ? "Alternate Buffer" : "Normal Buffer"}
+            </span>
+          </div>
+
+          <TerminalWindow>
+            <div className="relative min-h-[300px] overflow-hidden font-mono text-sm">
+              {/* Normal screen with transition */}
+              <div
+                className={`absolute inset-0 transition-all duration-300 ${
+                  isAlternateScreen
+                    ? "-translate-x-full transform opacity-0"
+                    : "translate-x-0 transform opacity-100"
+                }`}
+              >
+                {NORMAL_SCREEN_CONTENT.map((line, idx) => (
+                  <div
+                    key={idx}
+                    className={
+                      line.startsWith("$")
+                        ? "text-primary"
+                        : line.startsWith("drwx") || line.startsWith("-rw")
+                          ? "text-secondary"
+                          : "text-primary"
+                    }
+                  >
+                    {line}
+                  </div>
+                ))}
+              </div>
+
+              {/* Alternate screen (vim) with transition */}
+              <div
+                className={`absolute inset-0 transition-all duration-300 ${
+                  isAlternateScreen
+                    ? "translate-x-0 transform opacity-100"
+                    : "translate-x-full transform opacity-0"
+                }`}
+              >
+                {/* Vim header */}
+                <div className="bg-tertiary text-secondary mb-1 px-2 text-xs">README.md [+]</div>
+                {/* Vim content */}
+                {ALTERNATE_SCREEN_CONTENT.map((line, idx) => (
+                  <div
+                    key={idx}
+                    className={
+                      line === "~"
+                        ? "text-secondary"
+                        : line.startsWith("#")
+                          ? "text-secondary"
+                          : line.startsWith("```")
+                            ? "text-primary"
+                            : "text-primary"
+                    }
+                  >
+                    {line || "\u00A0"}
+                  </div>
+                ))}
+                {/* Vim status line */}
+                <div className="bg-tertiary absolute right-0 bottom-0 left-0 flex justify-between px-2 text-xs text-white dark:text-neutral-950">
+                  <span>-- INSERT --</span>
+                  <span>1,1 All</span>
+                </div>
+              </div>
+            </div>
+          </TerminalWindow>
+        </div>
+
+        {/* Escape Sequences */}
+        <div className="space-y-4">
+          <SubsectionLabel>The Escape Sequences</SubsectionLabel>
+
+          <div className="space-y-3">
+            <div
+              className={`border p-4 transition-all ${
+                !isAlternateScreen ? "border-primary bg-primary/5" : "border-primary"
+              }`}
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-primary text-sm font-bold">Enter Alternate Screen</span>
+                <code className="text-secondary text-xs">^[[?1049h</code>
+              </div>
+              <p className="text-tertiary text-sm">
+                Saves the current screen, clears display, and switches to the alternate buffer. Sent
+                when opening vim, less, htop, etc.
+              </p>
+            </div>
+
+            <div
+              className={`border p-4 transition-all ${
+                isAlternateScreen ? "border-primary bg-primary/5" : "border-primary"
+              }`}
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-secondary text-sm font-bold">Exit Alternate Screen</span>
+                <code className="text-secondary text-xs">^[[?1049l</code>
+              </div>
+              <p className="text-tertiary text-sm">
+                Restores the saved screen buffer. Your previous terminal content reappears exactly
+                as it was. Sent when quitting the app.
+              </p>
+            </div>
+          </div>
+
+          {/* Visual representation of buffer swap */}
+          <div className="bg-tertiary border-primary space-y-3 border p-4">
+            <div className="text-primary text-sm font-bold">Buffer Layout</div>
+            <div className="flex items-center gap-4">
+              <div
+                className={`flex-1 border-2 p-3 text-center text-sm transition-all ${
+                  !isAlternateScreen
+                    ? "border-primary bg-primary/5 text-primary"
+                    : "border-primary text-quaternary"
+                }`}
+              >
+                Normal Buffer
+                <div className="mt-1 text-xs opacity-70">(your history)</div>
+              </div>
+              <div className="text-quaternary">⇄</div>
+              <div
+                className={`flex-1 border-2 p-3 text-center text-sm transition-all ${
+                  isAlternateScreen
+                    ? "border-primary bg-primary/5 text-secondary"
+                    : "border-primary text-quaternary"
+                }`}
+              >
+                Alternate Buffer
+                <div className="mt-1 text-xs opacity-70">(app's canvas)</div>
+              </div>
+            </div>
+            <p className="text-quaternary text-center text-xs">
+              Only one buffer is visible at a time. The other is preserved in memory.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Explainer */}
+      <InfoPanel className="space-y-4 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="text-primary text-sm font-medium">{stepContent.title}</div>
+          <StepDotsNavigation
+            steps={steps}
+            currentStep={currentStep}
+            onStepChange={setCurrentStep}
+          />
+        </div>
+        <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
+      </InfoPanel>
+
+      {/* Without Alternate Screen */}
+      <div className="bg-tertiary border-primary space-y-4 border p-6">
+        <h3 className="text-primary text-sm font-bold">What Would Happen Without It?</h3>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <div className="text-primary text-sm font-bold">Without Alternate Screen</div>
+            <div className="bg-secondary border-primary space-y-1 border p-3 font-mono text-xs">
+              <div className="text-tertiary">$ ls</div>
+              <div className="text-tertiary">file1.txt file2.txt</div>
+              <div className="text-tertiary">$ vim README.md</div>
+              <div className="text-secondary"># My Project</div>
+              <div>~</div>
+              <div>~</div>
+              <div className="text-quaternary">-- INSERT --</div>
+              <div className="text-tertiary">... (quit vim)</div>
+              <div className="text-primary">← vim's output stays mixed with history!</div>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-primary text-sm font-bold">With Alternate Screen</div>
+            <div className="bg-secondary border-primary space-y-1 border p-3 font-mono text-xs">
+              <div className="text-tertiary">$ ls</div>
+              <div className="text-tertiary">file1.txt file2.txt</div>
+              <div className="text-tertiary">$ vim README.md</div>
+              <div className="text-quaternary">(vim opens on alternate screen...)</div>
+              <div className="text-quaternary">(you edit, then :q...)</div>
+              <div className="text-tertiary">$ ls</div>
+              <div className="text-tertiary">file1.txt file2.txt</div>
+              <div className="text-primary">← Your history is intact!</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/AlternateScreenDemo.tsx
+++ b/src/app/how-terminals-work/demos/AlternateScreenDemo.tsx
@@ -147,7 +147,7 @@ export function AlternateScreenDemo() {
                   </div>
                 ))}
                 {/* Vim status line */}
-                <div className="bg-tertiary absolute right-0 bottom-0 left-0 flex justify-between px-2 text-xs text-white dark:text-neutral-950">
+                <div className="bg-secondary text-primary absolute right-0 bottom-0 left-0 flex justify-between px-2 text-xs">
                   <span>-- INSERT --</span>
                   <span>1,1 All</span>
                 </div>
@@ -166,9 +166,9 @@ export function AlternateScreenDemo() {
                 !isAlternateScreen ? "border-primary bg-primary/5" : "border-primary"
               }`}
             >
-              <div className="mb-2 flex items-center justify-between">
-                <span className="text-primary text-sm font-bold">Enter Alternate Screen</span>
-                <code className="text-secondary text-xs">^[[?1049h</code>
+              <div className="mb-2 flex flex-col gap-0.5">
+                <code className="text-secondary shrink-0 text-xs whitespace-nowrap">^[[?1049h</code>
+                <span className="text-primary text-sm font-medium">Enter Alternate Screen</span>
               </div>
               <p className="text-tertiary text-sm">
                 Saves the current screen, clears display, and switches to the alternate buffer. Sent
@@ -181,9 +181,9 @@ export function AlternateScreenDemo() {
                 isAlternateScreen ? "border-primary bg-primary/5" : "border-primary"
               }`}
             >
-              <div className="mb-2 flex items-center justify-between">
-                <span className="text-secondary text-sm font-bold">Exit Alternate Screen</span>
-                <code className="text-secondary text-xs">^[[?1049l</code>
+              <div className="mb-2 flex flex-col gap-0.5">
+                <code className="text-secondary shrink-0 text-xs whitespace-nowrap">^[[?1049l</code>
+                <span className="text-secondary text-sm font-medium">Exit Alternate Screen</span>
               </div>
               <p className="text-tertiary text-sm">
                 Restores the saved screen buffer. Your previous terminal content reappears exactly
@@ -193,11 +193,11 @@ export function AlternateScreenDemo() {
           </div>
 
           {/* Visual representation of buffer swap */}
-          <div className="bg-tertiary border-primary space-y-3 border p-4">
-            <div className="text-primary text-sm font-bold">Buffer Layout</div>
+          <div className="space-y-3">
+            <div className="text-primary text-sm font-medium">Buffer Layout</div>
             <div className="flex items-center gap-4">
               <div
-                className={`flex-1 border-2 p-3 text-center text-sm transition-all ${
+                className={`flex-1 border p-3 text-center text-sm transition-all ${
                   !isAlternateScreen
                     ? "border-primary bg-primary/5 text-primary"
                     : "border-primary text-quaternary"
@@ -208,7 +208,7 @@ export function AlternateScreenDemo() {
               </div>
               <div className="text-quaternary">⇄</div>
               <div
-                className={`flex-1 border-2 p-3 text-center text-sm transition-all ${
+                className={`flex-1 border p-3 text-center text-sm transition-all ${
                   isAlternateScreen
                     ? "border-primary bg-primary/5 text-secondary"
                     : "border-primary text-quaternary"
@@ -226,7 +226,7 @@ export function AlternateScreenDemo() {
       </div>
 
       {/* Explainer */}
-      <InfoPanel className="space-y-4 p-4">
+      <InfoPanel className="space-y-4">
         <div className="flex items-start justify-between gap-4">
           <div className="text-primary text-sm font-medium">{stepContent.title}</div>
           <StepDotsNavigation
@@ -239,13 +239,13 @@ export function AlternateScreenDemo() {
       </InfoPanel>
 
       {/* Without Alternate Screen */}
-      <div className="bg-tertiary border-primary space-y-4 border p-6">
-        <h3 className="text-primary text-sm font-bold">What Would Happen Without It?</h3>
+      <div className="space-y-4">
+        <h3 className="text-primary text-sm font-medium">What Would Happen Without It?</h3>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
           <div className="space-y-2">
-            <div className="text-primary text-sm font-bold">Without Alternate Screen</div>
-            <div className="bg-secondary border-primary space-y-1 border p-3 font-mono text-xs">
+            <div className="text-primary text-sm font-medium">Without Alternate Screen</div>
+            <div className="space-y-1 font-mono text-xs">
               <div className="text-tertiary">$ ls</div>
               <div className="text-tertiary">file1.txt file2.txt</div>
               <div className="text-tertiary">$ vim README.md</div>
@@ -259,8 +259,8 @@ export function AlternateScreenDemo() {
           </div>
 
           <div className="space-y-2">
-            <div className="text-primary text-sm font-bold">With Alternate Screen</div>
-            <div className="bg-secondary border-primary space-y-1 border p-3 font-mono text-xs">
+            <div className="text-primary text-sm font-medium">With Alternate Screen</div>
+            <div className="space-y-1 font-mono text-xs">
               <div className="text-tertiary">$ ls</div>
               <div className="text-tertiary">file1.txt file2.txt</div>
               <div className="text-tertiary">$ vim README.md</div>

--- a/src/app/how-terminals-work/demos/CapabilityDiscoveryDemo.tsx
+++ b/src/app/how-terminals-work/demos/CapabilityDiscoveryDemo.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { DA1_CODES, FEATURE_SEQUENCES, TERM_CAPABILITIES } from "../lib/sequences";
+import { SubsectionLabel, TerminalWindow } from "../ui";
+
+const FEATURES = FEATURE_SEQUENCES;
+
+type QueryPhase = "idle" | "sending" | "responding" | "done";
+
+export function CapabilityDiscoveryDemo() {
+  const [selectedTerm, setSelectedTerm] = useState("xterm-256color");
+  const [queryPhase, setQueryPhase] = useState<QueryPhase>("idle");
+  const [enabledFeatures, setEnabledFeatures] = useState<Set<string>>(new Set());
+
+  const capabilities = TERM_CAPABILITIES[selectedTerm]!;
+
+  const runQuery = () => {
+    if (queryPhase !== "idle" && queryPhase !== "done") return;
+    setQueryPhase("sending");
+  };
+
+  useEffect(() => {
+    if (queryPhase === "sending") {
+      const timer = setTimeout(() => setQueryPhase("responding"), 800);
+      return () => clearTimeout(timer);
+    }
+    if (queryPhase === "responding") {
+      const timer = setTimeout(() => setQueryPhase("done"), 800);
+      return () => clearTimeout(timer);
+    }
+  }, [queryPhase]);
+
+  const toggleFeature = (featureId: string) => {
+    setEnabledFeatures((prev) => {
+      const next = new Set(prev);
+      if (next.has(featureId)) {
+        next.delete(featureId);
+      } else {
+        next.add(featureId);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-10">
+      {/* Section 1: TERM Variable */}
+      <div className="space-y-4">
+        <SubsectionLabel>The TERM Variable</SubsectionLabel>
+
+        <TerminalWindow>
+          <div className="space-y-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div className="flex items-center gap-2 font-mono text-sm">
+                <span className="text-quaternary">$</span>
+                <span className="text-secondary">TERM</span>
+                <span className="text-quaternary">=</span>
+                <select
+                  value={selectedTerm}
+                  onChange={(e) => setSelectedTerm(e.target.value)}
+                  className="bg-secondary border-primary text-secondary hover:border-primary focus:border-primary cursor-pointer border px-2 py-1 font-mono text-sm focus:outline-none"
+                >
+                  {Object.keys(TERM_CAPABILITIES).map((term) => (
+                    <option key={term} value={term}>
+                      {term}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <span className="text-tertiary text-sm">{capabilities.description}</span>
+            </div>
+
+            {/* Capability Grid */}
+            <div className="grid grid-cols-2 gap-3 pt-2 sm:grid-cols-4">
+              <CapabilityItem
+                label="Colors"
+                value={capabilities.colors === 0 ? "None" : capabilities.colors.toString()}
+                supported={capabilities.colors > 0}
+              />
+              <CapabilityItem
+                label="Mouse"
+                value={capabilities.mouse ? "Yes" : "No"}
+                supported={capabilities.mouse}
+              />
+              <CapabilityItem
+                label="Alt Screen"
+                value={capabilities.altScreen ? "Yes" : "No"}
+                supported={capabilities.altScreen}
+              />
+              <CapabilityItem
+                label="Unicode"
+                value={capabilities.unicode ? "Yes" : "No"}
+                supported={capabilities.unicode}
+              />
+            </div>
+          </div>
+        </TerminalWindow>
+
+        <p className="text-tertiary text-sm">
+          Programs check the <code className="text-secondary">TERM</code> environment variable to
+          look up capabilities in the terminfo database. It's just a string—the terminal doesn't
+          enforce it.
+        </p>
+      </div>
+
+      {/* Section 2: Query/Response */}
+      <div className="space-y-4">
+        <SubsectionLabel>Query & Response</SubsectionLabel>
+
+        <TerminalWindow>
+          <div className="space-y-4">
+            {/* Query visualization */}
+            <div className="flex items-center justify-between gap-4 py-2">
+              <div className="flex-1 text-center">
+                <div className="text-quaternary mb-2 text-xs uppercase">Program</div>
+                <div className="border-primary text-tertiary mx-auto flex h-12 w-12 items-center justify-center border">
+                  vim
+                </div>
+              </div>
+
+              <div className="relative h-16 flex-1">
+                {/* Query arrow */}
+                <div
+                  className={`absolute top-2 right-0 left-0 flex items-center transition-opacity duration-300 ${
+                    queryPhase === "sending" ? "opacity-100" : "opacity-30"
+                  }`}
+                >
+                  <div className="border-primary flex-1 border-t border-dashed" />
+                  <div className="text-primary px-2 font-mono text-xs whitespace-nowrap">ESC[c</div>
+                  <div className="text-primary">→</div>
+                </div>
+
+                {/* Response arrow */}
+                <div
+                  className={`absolute right-0 bottom-2 left-0 flex items-center transition-opacity duration-300 ${
+                    queryPhase === "responding" || queryPhase === "done"
+                      ? "opacity-100"
+                      : "opacity-30"
+                  }`}
+                >
+                  <div className="text-secondary">←</div>
+                  <div className="text-secondary px-2 font-mono text-xs whitespace-nowrap">
+                    ESC[?64;1;4;22c
+                  </div>
+                  <div className="border-secondary flex-1 border-t border-dashed" />
+                </div>
+              </div>
+
+              <div className="flex-1 text-center">
+                <div className="text-quaternary mb-2 text-xs uppercase">Terminal</div>
+                <div className="border-primary text-tertiary mx-auto flex h-12 w-12 items-center justify-center border">
+                  tty
+                </div>
+              </div>
+            </div>
+
+            {/* Response decoder */}
+            {(queryPhase === "responding" || queryPhase === "done") && (
+              <div className="bg-secondary border-primary space-y-2 border p-3">
+                <div className="text-quaternary text-xs uppercase">Response Decoded</div>
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="text-secondary font-mono">64</span>
+                    <span className="text-tertiary">VT420</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-secondary font-mono">1</span>
+                    <span className="text-tertiary">{DA1_CODES["1"]}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-secondary font-mono">4</span>
+                    <span className="text-tertiary">{DA1_CODES["4"]}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-secondary font-mono">22</span>
+                    <span className="text-tertiary">{DA1_CODES["22"]}</span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Query button */}
+            <div className="flex justify-center">
+              <button
+                onClick={runQuery}
+                disabled={queryPhase === "sending" || queryPhase === "responding"}
+                className={`px-4 py-2 text-sm font-medium transition-all ${
+                  queryPhase === "sending" || queryPhase === "responding"
+                    ? "bg-tertiary cursor-not-allowed text-white dark:text-neutral-950"
+                    : "bg-primary hover:bg-primary text-white dark:text-neutral-950"
+                }`}
+              >
+                {queryPhase === "sending"
+                  ? "Sending..."
+                  : queryPhase === "responding"
+                    ? "Receiving..."
+                    : queryPhase === "done"
+                      ? "Send Again"
+                      : "Send DA1 Query"}
+              </button>
+            </div>
+          </div>
+        </TerminalWindow>
+
+        <p className="text-tertiary text-sm">
+          Programs can also query the terminal directly. DA1 (
+          <code className="text-secondary">ESC[c</code>) asks "what are you?" and the terminal
+          responds with capability codes.
+        </p>
+      </div>
+
+      {/* Section 3: Feature Toggles */}
+      <div className="space-y-4">
+        <SubsectionLabel>Enabling Features</SubsectionLabel>
+
+        <TerminalWindow>
+          <div className="space-y-3">
+            {FEATURES.map((feature) => {
+              const isEnabled = enabledFeatures.has(feature.id);
+              return (
+                <div
+                  key={feature.id}
+                  className="border-primary/50 flex flex-col gap-2 border-b py-2 last:border-0 sm:flex-row sm:items-center sm:gap-4"
+                >
+                  <label className="flex flex-shrink-0 cursor-pointer items-center gap-3">
+                    <input
+                      type="checkbox"
+                      checked={isEnabled}
+                      onChange={() => toggleFeature(feature.id)}
+                      className="accent-primary h-4 w-4"
+                    />
+                    <span
+                      className={`text-sm font-medium ${isEnabled ? "text-primary" : "text-tertiary"}`}
+                    >
+                      {feature.name}
+                    </span>
+                  </label>
+
+                  <code
+                    className={`px-2 py-1 font-mono text-xs ${
+                      isEnabled ? "text-primary bg-primary/5" : "text-quaternary bg-secondary"
+                    }`}
+                  >
+                    {isEnabled ? feature.enable : feature.disable}
+                  </code>
+
+                  <span className="text-quaternary text-xs sm:ml-auto">{feature.description}</span>
+                </div>
+              );
+            })}
+          </div>
+        </TerminalWindow>
+
+        <p className="text-tertiary text-sm">
+          Features are off by default. Programs send escape sequences to enable them—that's why vim
+          sends <code className="text-secondary">^[[?1049h</code> at startup (to enter alternate
+          screen) and <code className="text-secondary">^[[?1049l</code> when you quit.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CapabilityItem({
+  label,
+  value,
+  supported,
+}: {
+  label: string;
+  value: string;
+  supported: boolean;
+}) {
+  return (
+    <div
+      className={`border px-3 py-2 ${supported ? "border-primary/50 bg-primary/5" : "border-primary bg-secondary"}`}
+    >
+      <div className="text-quaternary text-xs uppercase">{label}</div>
+      <div className={`text-sm font-medium ${supported ? "text-primary" : "text-quaternary"}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/CapabilityDiscoveryDemo.tsx
+++ b/src/app/how-terminals-work/demos/CapabilityDiscoveryDemo.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { DA1_CODES, FEATURE_SEQUENCES, TERM_CAPABILITIES } from "../lib/sequences";
-import { SubsectionLabel, TerminalWindow } from "../ui";
+import { Button, SubsectionLabel, TerminalWindow } from "../ui";
 
 const FEATURES = FEATURE_SEQUENCES;
 
@@ -158,7 +158,7 @@ export function CapabilityDiscoveryDemo() {
 
             {/* Response decoder */}
             {(queryPhase === "responding" || queryPhase === "done") && (
-              <div className="bg-secondary border-primary space-y-2 border p-3">
+              <div className="space-y-2">
                 <div className="text-quaternary text-xs uppercase">Response Decoded</div>
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   <div className="flex items-center gap-2">
@@ -183,14 +183,10 @@ export function CapabilityDiscoveryDemo() {
 
             {/* Query button */}
             <div className="flex justify-center">
-              <button
+              <Button
+                variant="primary"
                 onClick={runQuery}
                 disabled={queryPhase === "sending" || queryPhase === "responding"}
-                className={`px-4 py-2 text-sm font-medium transition-all ${
-                  queryPhase === "sending" || queryPhase === "responding"
-                    ? "bg-tertiary cursor-not-allowed text-white dark:text-neutral-950"
-                    : "bg-primary hover:bg-primary text-white dark:text-neutral-950"
-                }`}
               >
                 {queryPhase === "sending"
                   ? "Sending..."
@@ -199,7 +195,7 @@ export function CapabilityDiscoveryDemo() {
                     : queryPhase === "done"
                       ? "Send Again"
                       : "Send DA1 Query"}
-              </button>
+              </Button>
             </div>
           </div>
         </TerminalWindow>
@@ -239,7 +235,7 @@ export function CapabilityDiscoveryDemo() {
                   </label>
 
                   <code
-                    className={`px-2 py-1 font-mono text-xs ${
+                    className={`shrink-0 px-2 py-1 font-mono text-xs whitespace-nowrap ${
                       isEnabled ? "text-primary bg-primary/5" : "text-quaternary bg-secondary"
                     }`}
                   >

--- a/src/app/how-terminals-work/demos/CellZoom.tsx
+++ b/src/app/how-terminals-work/demos/CellZoom.tsx
@@ -50,7 +50,7 @@ export function CellZoom() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col items-start gap-8 md:flex-row">
+      <div className="flex flex-col items-start gap-8 lg:flex-row">
         <TerminalWindow className="flex-shrink-0">
           <div className="flex items-center justify-center p-6">
             <div
@@ -242,7 +242,7 @@ function ColorDepthExplorer() {
   const rgb = hslToRgb(truecolorHue, truecolorSat, truecolorLight);
 
   return (
-    <div className="bg-tertiary border-primary space-y-6 border p-6">
+    <div className="space-y-6">
       <div>
         <h3 className="text-primary mb-2 text-sm font-bold">Color Depth in Terminals</h3>
         <p className="text-tertiary text-sm">
@@ -291,7 +291,7 @@ function ColorDepthExplorer() {
               </div>
             ))}
           </div>
-          <div className="bg-secondary space-y-1 p-3 font-mono text-xs">
+          <div className="space-y-1 font-mono text-xs">
             <div className="text-quaternary">Escape sequence format:</div>
             <div>
               <span className="text-secondary">^[[38;5;</span>
@@ -362,7 +362,7 @@ function ColorDepthExplorer() {
           </div>
 
           {/* Selected color info */}
-          <div className="bg-secondary flex items-center gap-4 p-3">
+          <div className="flex items-center gap-4">
             <div
               className="border-primary h-12 w-12 border"
               style={{ backgroundColor: colors256[selected256] }}
@@ -380,7 +380,7 @@ function ColorDepthExplorer() {
           <SubsectionLabel>24-bit Truecolor (16 Million Colors)</SubsectionLabel>
 
           {/* Color picker */}
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             <div className="space-y-4">
               <div>
                 <label className="text-quaternary mb-1 block text-xs">Hue: {truecolorHue}°</label>

--- a/src/app/how-terminals-work/demos/CellZoom.tsx
+++ b/src/app/how-terminals-work/demos/CellZoom.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { InfoPanel, SubsectionLabel } from "../ui";
+
+type ColorMode = "16" | "256" | "truecolor";
+
+// Standard 16-color ANSI palette (matching index.css theme)
+const COLORS = {
+  // Normal colors (0-7)
+  black: "#0a0a0a",
+  red: "#f85149",
+  green: "#22c55e",
+  yellow: "#eab308",
+  blue: "#3b82f6",
+  magenta: "#a855f7",
+  cyan: "#06b6d4",
+  white: "#e5e5e5",
+  // Bright colors (8-15)
+  brightBlack: "#525252",
+  brightRed: "#ff7b72",
+  brightGreen: "#4ade80",
+  brightYellow: "#facc15",
+  brightBlue: "#60a5fa",
+  brightMagenta: "#c084fc",
+  brightCyan: "#22d3ee",
+  brightWhite: "#fafafa",
+};
+const BG_COLORS = {
+  none: "transparent",
+  dim: "#171717",
+  green: "#22c55e33",
+  red: "#f8514933",
+  blue: "#3b82f633",
+  yellow: "#eab30833",
+  magenta: "#a855f733",
+  cyan: "#06b6d433",
+};
+
+export function CellZoom() {
+  const [char, setChar] = useState("A");
+  const [fg, setFg] = useState<keyof typeof COLORS>("green");
+  const [bg, setBg] = useState<keyof typeof BG_COLORS>("none");
+  const [bold, setBold] = useState(false);
+  const [underline, setUnderline] = useState(false);
+
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%".split("");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col items-start gap-8 md:flex-row">
+        <TerminalWindow className="flex-shrink-0">
+          <div className="flex items-center justify-center p-6">
+            <div
+              className={`border-primary flex h-40 w-28 items-center justify-center border text-7xl transition-all duration-200 ${bold ? "font-bold" : ""} ${underline ? "underline" : ""}`}
+              style={{ color: COLORS[fg], backgroundColor: BG_COLORS[bg] }}
+            >
+              {char}
+            </div>
+          </div>
+        </TerminalWindow>
+
+        <div className="flex-1 space-y-5">
+          <div>
+            <SubsectionLabel>Character</SubsectionLabel>
+            <div className="flex flex-wrap gap-1">
+              {chars.slice(0, 20).map((c) => (
+                <button
+                  key={c}
+                  onClick={() => setChar(c)}
+                  className={`flex h-7 w-7 items-center justify-center border text-sm transition-colors ${char === c ? "border-primary bg-primary/10 text-primary" : "border-primary text-tertiary hover:border-primary hover:text-primary"}`}
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <SubsectionLabel>Foreground</SubsectionLabel>
+            <div className="flex flex-wrap gap-1.5">
+              {(Object.keys(COLORS) as Array<keyof typeof COLORS>).map((color) => (
+                <button
+                  key={color}
+                  onClick={() => setFg(color)}
+                  className={`h-6 w-6 focus:outline-none ${fg === color ? "ring-primary ring-offset-primary ring-2 ring-offset-2" : ""}`}
+                  style={{ backgroundColor: COLORS[color] }}
+                  title={color}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <SubsectionLabel>Background</SubsectionLabel>
+            <div className="flex flex-wrap gap-1.5">
+              {(Object.keys(BG_COLORS) as Array<keyof typeof BG_COLORS>).map((color) => (
+                <button
+                  key={color}
+                  onClick={() => setBg(color)}
+                  className={`border-primary h-6 w-6 border focus:outline-none ${bg === color ? "ring-primary ring-offset-primary ring-2 ring-offset-2" : ""}`}
+                  style={{
+                    backgroundColor: color === "none" ? "#0a0a0a" : BG_COLORS[color],
+                  }}
+                  title={color}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <SubsectionLabel>Attributes</SubsectionLabel>
+            <div className="flex gap-4">
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={bold}
+                  onChange={(e) => setBold(e.target.checked)}
+                  className="accent-primary h-4 w-4 border-0 outline-none"
+                />
+                <span className={`text-tertiary ${bold ? "text-primary font-bold" : ""}`}>
+                  Bold
+                </span>
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={underline}
+                  onChange={(e) => setUnderline(e.target.checked)}
+                  className="accent-primary h-4 w-4 border-0 outline-none"
+                />
+                <span className={`text-tertiary ${underline ? "text-primary underline" : ""}`}>
+                  Underline
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <InfoPanel>
+        <span className="text-quaternary">Cell: </span>
+        <span className="text-primary font-medium">"{char}"</span>
+        <span className="text-quaternary"> / </span>
+        <span style={{ color: COLORS[fg] }}>{fg}</span>
+        {bg !== "none" && (
+          <>
+            <span className="text-quaternary"> on </span>
+            <span className="text-tertiary">{bg}</span>
+          </>
+        )}
+        {bold && (
+          <>
+            <span className="text-quaternary"> / </span>
+            <span className="text-primary font-bold">bold</span>
+          </>
+        )}
+        {underline && (
+          <>
+            <span className="text-quaternary"> / </span>
+            <span className="text-primary underline">underlined</span>
+          </>
+        )}
+      </InfoPanel>
+
+      {/* Color Depth Exploration */}
+      <ColorDepthExplorer />
+    </div>
+  );
+}
+
+// Generate 256-color palette
+function generate256Colors(): string[] {
+  const colors: string[] = [];
+
+  // Standard 16 colors (0-15)
+  const standard16 = [
+    "#000000",
+    "#cd0000",
+    "#00cd00",
+    "#cdcd00",
+    "#0000ee",
+    "#cd00cd",
+    "#00cdcd",
+    "#e5e5e5",
+    "#7f7f7f",
+    "#ff0000",
+    "#00ff00",
+    "#ffff00",
+    "#5c5cff",
+    "#ff00ff",
+    "#00ffff",
+    "#ffffff",
+  ];
+  colors.push(...standard16);
+
+  // 216 colors (6x6x6 cube, indices 16-231)
+  const levels = [0, 95, 135, 175, 215, 255];
+  for (let r = 0; r < 6; r++) {
+    for (let g = 0; g < 6; g++) {
+      for (let b = 0; b < 6; b++) {
+        colors.push(`rgb(${levels[r]}, ${levels[g]}, ${levels[b]})`);
+      }
+    }
+  }
+
+  // 24 grayscale colors (indices 232-255)
+  for (let i = 0; i < 24; i++) {
+    const gray = 8 + i * 10;
+    colors.push(`rgb(${gray}, ${gray}, ${gray})`);
+  }
+
+  return colors;
+}
+
+function ColorDepthExplorer() {
+  const [colorMode, setColorMode] = useState<ColorMode>("16");
+  const [truecolorHue, setTruecolorHue] = useState(180);
+  const [truecolorSat, setTruecolorSat] = useState(80);
+  const [truecolorLight, setTruecolorLight] = useState(50);
+  const [selected256, setSelected256] = useState(196); // Default to bright red
+
+  const colors256 = useMemo(() => generate256Colors(), []);
+
+  const truecolorValue = `hsl(${truecolorHue}, ${truecolorSat}%, ${truecolorLight}%)`;
+
+  // Convert HSL to RGB for escape sequence display
+  // Standard HSL to RGB algorithm: https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB
+  const hslToRgb = (h: number, s: number, l: number) => {
+    s /= 100;
+    l /= 100;
+    const a = s * Math.min(l, 1 - l);
+    const f = (n: number) => {
+      const k = (n + h / 30) % 12;
+      return Math.round((l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)) * 255);
+    };
+    return { r: f(0), g: f(8), b: f(4) };
+  };
+
+  const rgb = hslToRgb(truecolorHue, truecolorSat, truecolorLight);
+
+  return (
+    <div className="bg-tertiary border-primary space-y-6 border p-6">
+      <div>
+        <h3 className="text-primary mb-2 text-sm font-bold">Color Depth in Terminals</h3>
+        <p className="text-tertiary text-sm">
+          Modern terminals support more than just 16 colors. Explore the different color modes
+          available.
+        </p>
+      </div>
+
+      {/* Mode selector */}
+      <div className="flex flex-wrap gap-2">
+        {[
+          { mode: "16" as ColorMode, label: "16 Colors", desc: "Classic ANSI" },
+          { mode: "256" as ColorMode, label: "256 Colors", desc: "Extended palette" },
+          { mode: "truecolor" as ColorMode, label: "Truecolor", desc: "16 million colors" },
+        ].map(({ mode, label, desc }) => (
+          <button
+            key={mode}
+            onClick={() => setColorMode(mode)}
+            className={`border px-4 py-2 text-sm transition-all ${
+              colorMode === mode
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-primary text-tertiary hover:text-primary"
+            }`}
+          >
+            <div className="font-bold">{label}</div>
+            <div className="text-xs opacity-70">{desc}</div>
+          </button>
+        ))}
+      </div>
+
+      {/* Color mode content */}
+      {colorMode === "16" && (
+        <div className="space-y-4">
+          <SubsectionLabel>The Original 16 Colors</SubsectionLabel>
+          <div className="grid grid-cols-8 gap-1">
+            {Object.entries(COLORS).map(([name, color]) => (
+              <div key={name} className="text-center">
+                <div
+                  className="border-primary/50 h-8 border"
+                  style={{ backgroundColor: color }}
+                  title={name}
+                />
+                <div className="text-quaternary mt-1 truncate text-[9px]">
+                  {name.replace("bright", "br")}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="bg-secondary space-y-1 p-3 font-mono text-xs">
+            <div className="text-quaternary">Escape sequence format:</div>
+            <div>
+              <span className="text-secondary">^[[38;5;</span>
+              <span className="text-secondary">{"<0-15>"}</span>
+              <span className="text-secondary">m</span>
+              <span className="text-tertiary"> — foreground</span>
+            </div>
+            <div>
+              <span className="text-secondary">^[[48;5;</span>
+              <span className="text-secondary">{"<0-15>"}</span>
+              <span className="text-secondary">m</span>
+              <span className="text-tertiary"> — background</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {colorMode === "256" && (
+        <div className="space-y-4">
+          <SubsectionLabel>256-Color Extended Palette</SubsectionLabel>
+
+          {/* Standard 16 */}
+          <div>
+            <div className="text-quaternary mb-1 text-xs">Standard 16 (0-15)</div>
+            <div className="flex gap-px">
+              {colors256.slice(0, 16).map((color, i) => (
+                <button
+                  key={i}
+                  className={`h-6 flex-1 ${selected256 === i ? "ring-primary ring-2" : ""}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => setSelected256(i)}
+                  title={`Color ${i}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* 216 color cube */}
+          <div>
+            <div className="text-quaternary mb-1 text-xs">6×6×6 Color Cube (16-231)</div>
+            <div className="grid grid-cols-36 gap-px">
+              {colors256.slice(16, 232).map((color, i) => (
+                <button
+                  key={i + 16}
+                  className={`h-3 ${selected256 === i + 16 ? "ring-primary ring-1" : ""}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => setSelected256(i + 16)}
+                  title={`Color ${i + 16}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Grayscale */}
+          <div>
+            <div className="text-quaternary mb-1 text-xs">Grayscale (232-255)</div>
+            <div className="flex gap-px">
+              {colors256.slice(232).map((color, i) => (
+                <button
+                  key={i + 232}
+                  className={`h-6 flex-1 ${selected256 === i + 232 ? "ring-primary ring-2" : ""}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => setSelected256(i + 232)}
+                  title={`Color ${i + 232}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Selected color info */}
+          <div className="bg-secondary flex items-center gap-4 p-3">
+            <div
+              className="border-primary h-12 w-12 border"
+              style={{ backgroundColor: colors256[selected256] }}
+            />
+            <div className="font-mono text-sm">
+              <div className="text-primary">Color {selected256}</div>
+              <div className="text-secondary text-xs">^[[38;5;{selected256}m</div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {colorMode === "truecolor" && (
+        <div className="space-y-4">
+          <SubsectionLabel>24-bit Truecolor (16 Million Colors)</SubsectionLabel>
+
+          {/* Color picker */}
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <div className="space-y-4">
+              <div>
+                <label className="text-quaternary mb-1 block text-xs">Hue: {truecolorHue}°</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="360"
+                  value={truecolorHue}
+                  onChange={(e) => setTruecolorHue(Number(e.target.value))}
+                  className="h-3 w-full cursor-pointer appearance-none"
+                  style={{
+                    background:
+                      "linear-gradient(to right, hsl(0,80%,50%), hsl(60,80%,50%), hsl(120,80%,50%), hsl(180,80%,50%), hsl(240,80%,50%), hsl(300,80%,50%), hsl(360,80%,50%))",
+                  }}
+                />
+              </div>
+              <div>
+                <label className="text-quaternary mb-1 block text-xs">
+                  Saturation: {truecolorSat}%
+                </label>
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={truecolorSat}
+                  onChange={(e) => setTruecolorSat(Number(e.target.value))}
+                  className="bg-tertiary h-3 w-full cursor-pointer appearance-none"
+                />
+              </div>
+              <div>
+                <label className="text-quaternary mb-1 block text-xs">
+                  Lightness: {truecolorLight}%
+                </label>
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={truecolorLight}
+                  onChange={(e) => setTruecolorLight(Number(e.target.value))}
+                  className="bg-tertiary h-3 w-full cursor-pointer appearance-none"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col items-center justify-center">
+              <div
+                className="border-primary h-24 w-24 border"
+                style={{ backgroundColor: truecolorValue }}
+              />
+              <div className="mt-2 text-center font-mono text-sm">
+                <div className="text-primary">
+                  RGB({rgb.r}, {rgb.g}, {rgb.b})
+                </div>
+                <div className="text-secondary text-xs">
+                  ^[[38;2;{rgb.r};{rgb.g};{rgb.b}m
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Gradient demonstration */}
+          <div>
+            <div className="text-quaternary mb-1 text-xs">
+              Smooth gradient (only possible with truecolor)
+            </div>
+            <div
+              className="h-8"
+              style={{
+                background: `linear-gradient(to right,
+                  hsl(0, 80%, 50%),
+                  hsl(60, 80%, 50%),
+                  hsl(120, 80%, 50%),
+                  hsl(180, 80%, 50%),
+                  hsl(240, 80%, 50%),
+                  hsl(300, 80%, 50%),
+                  hsl(360, 80%, 50%)
+                )`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Comparison */}
+      <div className="border-primary border-t pt-4">
+        <div className="text-quaternary mb-2 text-xs">Color count comparison:</div>
+        <div className="grid grid-cols-3 gap-4 text-center text-sm">
+          <div>
+            <div className="text-primary font-bold">16</div>
+            <div className="text-tertiary text-xs">Classic ANSI</div>
+          </div>
+          <div>
+            <div className="text-secondary font-bold">256</div>
+            <div className="text-tertiary text-xs">Extended</div>
+          </div>
+          <div>
+            <div className="text-secondary font-bold">16,777,216</div>
+            <div className="text-tertiary text-xs">Truecolor (24-bit)</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/EscapeDemo.tsx
+++ b/src/app/how-terminals-work/demos/EscapeDemo.tsx
@@ -192,9 +192,11 @@ export function EscapeDemo() {
               {CURSOR_SEQUENCES.map((seq) => (
                 <div
                   key={seq.effect}
-                  className="border-primary flex items-center justify-between border px-3 py-2 text-sm"
+                  className="border-primary flex flex-col gap-0.5 border px-3 py-2 text-sm"
                 >
-                  <code className="text-secondary text-xs">{seq.display}</code>
+                  <code className="text-secondary shrink-0 text-xs whitespace-nowrap">
+                    {seq.display}
+                  </code>
                   <span className="text-tertiary">{seq.desc}</span>
                 </div>
               ))}

--- a/src/app/how-terminals-work/demos/EscapeDemo.tsx
+++ b/src/app/how-terminals-work/demos/EscapeDemo.tsx
@@ -123,7 +123,7 @@ export function EscapeDemo() {
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-6 md:grid-cols-2">
+      <div className="grid gap-8 lg:grid-cols-2">
         <div className="space-y-5">
           {/* 16-Color Palette */}
           <div>

--- a/src/app/how-terminals-work/demos/EscapeDemo.tsx
+++ b/src/app/how-terminals-work/demos/EscapeDemo.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { InfoPanel, SubsectionLabel } from "../ui";
+
+// Standard 16-color ANSI escape codes (SGR - Select Graphic Rendition)
+const COLOR_SEQUENCES = [
+  // Normal colors (30-37)
+  { display: "^[[30m", desc: "Black", effect: "black", color: "#0a0a0a" },
+  { display: "^[[31m", desc: "Red", effect: "red", color: "#f85149" },
+  { display: "^[[32m", desc: "Green", effect: "green", color: "#22c55e" },
+  { display: "^[[33m", desc: "Yellow", effect: "yellow", color: "#eab308" },
+  { display: "^[[34m", desc: "Blue", effect: "blue", color: "#3b82f6" },
+  { display: "^[[35m", desc: "Magenta", effect: "magenta", color: "#a855f7" },
+  { display: "^[[36m", desc: "Cyan", effect: "cyan", color: "#06b6d4" },
+  { display: "^[[37m", desc: "White", effect: "white", color: "#e5e5e5" },
+  // Bright colors (90-97)
+  {
+    display: "^[[90m",
+    desc: "Bright Black",
+    effect: "brightBlack",
+    color: "#525252",
+  },
+  {
+    display: "^[[91m",
+    desc: "Bright Red",
+    effect: "brightRed",
+    color: "#ff7b72",
+  },
+  {
+    display: "^[[92m",
+    desc: "Bright Green",
+    effect: "brightGreen",
+    color: "#4ade80",
+  },
+  {
+    display: "^[[93m",
+    desc: "Bright Yellow",
+    effect: "brightYellow",
+    color: "#facc15",
+  },
+  {
+    display: "^[[94m",
+    desc: "Bright Blue",
+    effect: "brightBlue",
+    color: "#60a5fa",
+  },
+  {
+    display: "^[[95m",
+    desc: "Bright Magenta",
+    effect: "brightMagenta",
+    color: "#c084fc",
+  },
+  {
+    display: "^[[96m",
+    desc: "Bright Cyan",
+    effect: "brightCyan",
+    color: "#22d3ee",
+  },
+  {
+    display: "^[[97m",
+    desc: "Bright White",
+    effect: "brightWhite",
+    color: "#fafafa",
+  },
+];
+
+const STYLE_SEQUENCES = [
+  { display: "^[[1m", desc: "Bold", effect: "bold" },
+  { display: "^[[4m", desc: "Underline", effect: "underline" },
+  { display: "^[[0m", desc: "Reset all styles", effect: "reset" },
+];
+
+const CURSOR_SEQUENCES = [
+  { display: "^[[2J", desc: "Clear entire screen", effect: "clear" },
+  { display: "^[[H", desc: "Move cursor to home (0,0)", effect: "home" },
+  { display: "^[[5;10H", desc: "Move cursor to row 5, col 10", effect: "move" },
+];
+
+export function EscapeDemo() {
+  const [demoText, setDemoText] = useState("Hello World");
+  const [activeColor, setActiveColor] = useState<string | null>(null);
+  const [activeEffects, setActiveEffects] = useState<Set<string>>(new Set());
+
+  const handleColorClick = (effect: string) => {
+    setActiveColor(activeColor === effect ? null : effect);
+  };
+
+  const toggleEffect = (effect: string) => {
+    setActiveEffects((prev) => {
+      const next = new Set(prev);
+      if (effect === "reset") {
+        setActiveColor(null);
+        return new Set();
+      }
+      next.has(effect) ? next.delete(effect) : next.add(effect);
+      return next;
+    });
+  };
+
+  const getActiveColorObj = () => COLOR_SEQUENCES.find((c) => c.effect === activeColor);
+
+  const getTextStyle = (): React.CSSProperties => ({
+    color: getActiveColorObj()?.color,
+    fontWeight: activeEffects.has("bold") ? "bold" : undefined,
+    textDecoration: activeEffects.has("underline") ? "underline" : undefined,
+  });
+
+  const getActiveSequences = () => {
+    const seqs: string[] = [];
+    if (activeColor) {
+      const colorSeq = COLOR_SEQUENCES.find((c) => c.effect === activeColor);
+      if (colorSeq) seqs.push(colorSeq.display);
+    }
+    activeEffects.forEach((e) => {
+      const styleSeq = STYLE_SEQUENCES.find((s) => s.effect === e);
+      if (styleSeq) seqs.push(styleSeq.display);
+    });
+    return seqs;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-5">
+          {/* 16-Color Palette */}
+          <div>
+            <SubsectionLabel>16-Color Palette</SubsectionLabel>
+            <div className="grid grid-cols-8 gap-2">
+              {COLOR_SEQUENCES.slice(0, 8).map((seq) => (
+                <button
+                  key={seq.effect}
+                  onClick={() => handleColorClick(seq.effect)}
+                  className={`h-7 ${
+                    activeColor === seq.effect
+                      ? "ring-primary ring-offset-primary ring-2 ring-offset-2"
+                      : ""
+                  }`}
+                  style={{ backgroundColor: seq.color }}
+                  title={`${seq.desc} (${seq.display})`}
+                />
+              ))}
+            </div>
+            <div className="mt-2 grid grid-cols-8 gap-2">
+              {COLOR_SEQUENCES.slice(8).map((seq) => (
+                <button
+                  key={seq.effect}
+                  onClick={() => handleColorClick(seq.effect)}
+                  className={`h-7 ${
+                    activeColor === seq.effect
+                      ? "ring-primary ring-offset-primary ring-2 ring-offset-2"
+                      : ""
+                  }`}
+                  style={{ backgroundColor: seq.color }}
+                  title={`${seq.desc} (${seq.display})`}
+                />
+              ))}
+            </div>
+            <div className="text-quaternary mt-2 flex justify-between px-0.5 text-[10px]">
+              <span>Normal (30-37)</span>
+              <span>Bright (90-97)</span>
+            </div>
+          </div>
+
+          {/* Style Sequences */}
+          <div>
+            <SubsectionLabel>Style Sequences</SubsectionLabel>
+            <div className="flex flex-wrap gap-2">
+              {STYLE_SEQUENCES.map((seq) => (
+                <button
+                  key={seq.effect}
+                  onClick={() => toggleEffect(seq.effect)}
+                  className={`border px-3 py-1.5 text-sm transition-all ${
+                    activeEffects.has(seq.effect)
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-primary text-tertiary hover:border-primary hover:text-primary"
+                  }`}
+                >
+                  <code className="text-secondary text-xs">{seq.display}</code>
+                  <span className="ml-2">{seq.desc}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Cursor Sequences */}
+          <div>
+            <SubsectionLabel>Cursor Sequences</SubsectionLabel>
+            <div className="space-y-1">
+              {CURSOR_SEQUENCES.map((seq) => (
+                <div
+                  key={seq.effect}
+                  className="border-primary flex items-center justify-between border px-3 py-2 text-sm"
+                >
+                  <code className="text-secondary text-xs">{seq.display}</code>
+                  <span className="text-tertiary">{seq.desc}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <SubsectionLabel>Preview</SubsectionLabel>
+          <TerminalWindow>
+            <div className="flex min-h-[180px] flex-col">
+              <div className="text-quaternary mb-4 text-xs">
+                {getActiveSequences().length === 0
+                  ? "No escape sequences active"
+                  : `Active: ${getActiveSequences().join(" ")}`}
+              </div>
+              <div className="flex flex-1 items-center justify-center">
+                <span className="text-xl" style={getTextStyle()}>
+                  {demoText}
+                </span>
+              </div>
+              <input
+                type="text"
+                value={demoText}
+                onChange={(e) => setDemoText(e.target.value)}
+                placeholder="Type something..."
+                className="bg-secondary border-primary text-primary placeholder:text-quaternary focus:border-secondary mt-4 w-full border px-3 py-2 text-sm focus:outline-none"
+              />
+            </div>
+          </TerminalWindow>
+
+          {/* Color info panel */}
+          {activeColor && (
+            <InfoPanel className="mt-4">
+              <div className="flex items-center gap-3">
+                <div className="h-6 w-6" style={{ backgroundColor: getActiveColorObj()?.color }} />
+                <div>
+                  <span className="text-primary">{getActiveColorObj()?.desc}</span>
+                  <code className="text-secondary ml-2 text-xs">
+                    {getActiveColorObj()?.display}
+                  </code>
+                </div>
+              </div>
+            </InfoPanel>
+          )}
+        </div>
+      </div>
+
+      <div className="text-tertiary text-sm">
+        <code className="text-secondary">^[</code> represents the{" "}
+        <code className="text-secondary">ESC</code> character (byte 0x1B). The 16-color palette uses
+        codes 30-37 for normal colors and 90-97 for bright variants.
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/FlowDiagram.tsx
+++ b/src/app/how-terminals-work/demos/FlowDiagram.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { parseAnsiLine } from "../lib/ansi";
+import { TerminalWindow } from "../ui";
+
+type Phase =
+  | "idle"
+  | "keystroke"
+  | "terminal-encode"
+  | "pty-to-shell"
+  | "shell-process"
+  | "shell-output"
+  | "pty-to-terminal"
+  | "terminal-render"
+  | "done";
+
+interface Step {
+  phase: Phase;
+  title: string;
+  description: string;
+  terminalContent: string[];
+  highlight: "keyboard" | "terminal" | "pty" | "shell" | null;
+  dataPacket?: string;
+  dataDirection?: "down" | "up";
+}
+
+const STEPS: Step[] = [
+  {
+    phase: "idle",
+    title: "Ready",
+    description: "The terminal is waiting. The cursor blinks.",
+    terminalContent: ["$ ▌"],
+    highlight: null,
+  },
+  {
+    phase: "keystroke",
+    title: "You type 'ls'",
+    description: "Each keystroke is a separate event sent to the terminal.",
+    terminalContent: ["$ ls▌"],
+    highlight: "keyboard",
+    dataPacket: "l s",
+    dataDirection: "down",
+  },
+  {
+    phase: "terminal-encode",
+    title: "Terminal encodes keystrokes",
+    description: "The terminal converts your keystrokes into bytes: 'l' → 0x6C, 's' → 0x73",
+    terminalContent: ["$ ls▌"],
+    highlight: "terminal",
+    dataPacket: "0x6C 0x73",
+    dataDirection: "down",
+  },
+  {
+    phase: "pty-to-shell",
+    title: "PTY forwards to shell",
+    description: "The pseudo-terminal pipes the bytes to the shell process (like bash or zsh).",
+    terminalContent: ["$ ls▌"],
+    highlight: "pty",
+    dataPacket: "0x6C 0x73",
+    dataDirection: "down",
+  },
+  {
+    phase: "shell-process",
+    title: "Shell receives and echoes",
+    description:
+      "The shell reads 'ls', echoes it back so you see what you typed, and waits for Enter.",
+    terminalContent: ["$ ls▌"],
+    highlight: "shell",
+  },
+  {
+    phase: "shell-output",
+    title: "You press Enter → Shell runs 'ls'",
+    description:
+      "The shell executes 'ls', which lists files. The output is just text with escape codes for colors.",
+    terminalContent: [
+      "$ ls",
+      "\x1b[34mDocuments\x1b[0m  \x1b[34mDownloads\x1b[0m  \x1b[32mscript.sh\x1b[0m",
+      "$ ▌",
+    ],
+    highlight: "shell",
+    dataPacket: "\\x1b[34mDocuments...",
+    dataDirection: "up",
+  },
+  {
+    phase: "pty-to-terminal",
+    title: "Output flows back through PTY",
+    description: "The shell's output travels back through the PTY to the terminal.",
+    terminalContent: [
+      "$ ls",
+      "\x1b[34mDocuments\x1b[0m  \x1b[34mDownloads\x1b[0m  \x1b[32mscript.sh\x1b[0m",
+      "$ ▌",
+    ],
+    highlight: "pty",
+    dataPacket: "\\x1b[34mDocuments...",
+    dataDirection: "up",
+  },
+  {
+    phase: "terminal-render",
+    title: "Terminal renders output",
+    description:
+      "The terminal interprets escape sequences (\\x1b[34m = blue) and draws colored text to the grid.",
+    terminalContent: [
+      "$ ls",
+      "\x1b[34mDocuments\x1b[0m  \x1b[34mDownloads\x1b[0m  \x1b[32mscript.sh\x1b[0m",
+      "$ ▌",
+    ],
+    highlight: "terminal",
+  },
+  {
+    phase: "done",
+    title: "Complete",
+    description:
+      "The full round trip: keystroke → encode → shell → execute → output → render. Repeat!",
+    terminalContent: [
+      "$ ls",
+      "\x1b[34mDocuments\x1b[0m  \x1b[34mDownloads\x1b[0m  \x1b[32mscript.sh\x1b[0m",
+      "$ ▌",
+    ],
+    highlight: null,
+  },
+];
+
+function renderTerminalLine(line: string) {
+  return parseAnsiLine(line).map((p, idx) => (
+    <span key={idx} style={p.color ? { color: p.color } : undefined}>
+      {p.text.includes("▌") ? (
+        <>
+          {p.text.replace("▌", "")}
+          <span className="cursor-blink bg-primary text-white dark:text-neutral-950">▌</span>
+        </>
+      ) : (
+        p.text
+      )}
+    </span>
+  ));
+}
+
+export function FlowDiagram() {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const currentStep = STEPS[stepIndex]!;
+
+  const startAnimation = () => {
+    if (isAnimating) return;
+    setIsAnimating(true);
+    setStepIndex(0);
+  };
+
+  useEffect(() => {
+    if (!isAnimating) return;
+    if (stepIndex >= STEPS.length - 1) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- stop playback after the last step
+      setIsAnimating(false);
+      return;
+    }
+    const timer = setTimeout(() => setStepIndex((i) => i + 1), 1500);
+    return () => clearTimeout(timer);
+  }, [isAnimating, stepIndex]);
+
+  const goToStep = (index: number) => {
+    setIsAnimating(false);
+    setStepIndex(index);
+  };
+
+  const layerClass = (layer: "keyboard" | "terminal" | "pty" | "shell") =>
+    `relative px-4 py-3 border transition-all duration-300 ${
+      currentStep.highlight === layer
+        ? "border-primary bg-primary/5"
+        : "border-primary bg-secondary"
+    }`;
+
+  return (
+    <div className="space-y-6">
+      {/* Main visualization */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Left: The layer diagram */}
+        <div className="space-y-3">
+          <label className="text-secondary mb-3 block text-xs uppercase">Terminal Stack</label>
+
+          {/* Keyboard/You layer */}
+          <div className={layerClass("keyboard")}>
+            <div className="flex items-center gap-3">
+              <span className="text-quaternary">[kbd]</span>
+              <div>
+                <div className="text-sm font-bold">You (Keyboard)</div>
+                <div className="text-quaternary text-xs">Physical keystrokes</div>
+              </div>
+            </div>
+            {currentStep.dataPacket &&
+              currentStep.dataDirection === "down" &&
+              currentStep.highlight === "keyboard" && (
+                <div className="absolute -bottom-6 left-1/2 z-10 -translate-x-1/2 transform">
+                  <div className="bg-primary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                    {currentStep.dataPacket}
+                  </div>
+                </div>
+              )}
+          </div>
+
+          <div className="text-quaternary flex justify-center">
+            <span className={currentStep.dataDirection === "down" ? "text-primary" : ""}>↓</span>
+            <span className="mx-2">/</span>
+            <span className={currentStep.dataDirection === "up" ? "text-primary" : ""}>↑</span>
+          </div>
+
+          {/* Terminal layer */}
+          <div className={layerClass("terminal")}>
+            <div className="flex items-center gap-3">
+              <span className="text-quaternary">[tty]</span>
+              <div>
+                <div className="text-sm font-bold">Terminal Emulator</div>
+                <div className="text-quaternary text-xs">Encodes input, renders output</div>
+              </div>
+            </div>
+            {currentStep.dataPacket && currentStep.highlight === "terminal" && (
+              <div
+                className={`absolute ${currentStep.dataDirection === "down" ? "-bottom-6" : "-top-6"} left-1/2 z-10 -translate-x-1/2 transform`}
+              >
+                <div className="bg-tertiary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                  {currentStep.dataPacket}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="text-quaternary flex justify-center">
+            <span className={currentStep.dataDirection === "down" ? "text-primary" : ""}>↓</span>
+            <span className="mx-2">/</span>
+            <span className={currentStep.dataDirection === "up" ? "text-primary" : ""}>↑</span>
+          </div>
+
+          {/* PTY layer */}
+          <div className={layerClass("pty")}>
+            <div className="flex items-center gap-3">
+              <span className="text-quaternary">[pty]</span>
+              <div>
+                <div className="text-sm font-bold">PTY (Pseudo-Terminal)</div>
+                <div className="text-quaternary text-xs">Bidirectional pipe</div>
+              </div>
+            </div>
+            {currentStep.dataPacket && currentStep.highlight === "pty" && (
+              <div
+                className={`absolute ${currentStep.dataDirection === "down" ? "-bottom-6" : "-top-6"} left-1/2 z-10 -translate-x-1/2 transform`}
+              >
+                <div className="bg-tertiary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                  {currentStep.dataPacket}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="text-quaternary flex justify-center">
+            <span className={currentStep.dataDirection === "down" ? "text-primary" : ""}>↓</span>
+            <span className="mx-2">/</span>
+            <span className={currentStep.dataDirection === "up" ? "text-primary" : ""}>↑</span>
+          </div>
+
+          {/* Shell layer */}
+          <div className={layerClass("shell")}>
+            <div className="flex items-center gap-3">
+              <span className="text-quaternary">[sh]</span>
+              <div>
+                <div className="text-sm font-bold">Shell / Program</div>
+                <div className="text-quaternary text-xs">bash, zsh, or any CLI program</div>
+              </div>
+            </div>
+            {currentStep.dataPacket &&
+              currentStep.dataDirection === "up" &&
+              currentStep.highlight === "shell" && (
+                <div className="absolute -top-6 left-1/2 z-10 -translate-x-1/2 transform">
+                  <div className="bg-tertiary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                    {currentStep.dataPacket}
+                  </div>
+                </div>
+              )}
+          </div>
+        </div>
+
+        {/* Right: What you see */}
+        <div className="space-y-4">
+          <label className="text-secondary mb-3 block text-xs uppercase">Output</label>
+          <TerminalWindow>
+            <div className="min-h-[120px] space-y-1 font-mono text-sm">
+              {currentStep.terminalContent.map((line, i) => (
+                <div key={i}>{renderTerminalLine(line)}</div>
+              ))}
+            </div>
+          </TerminalWindow>
+
+          {/* Step info */}
+          <div className="bg-tertiary border-primary border px-4 py-3">
+            <div className="text-primary mb-1 text-sm font-medium">{currentStep.title}</div>
+            <div className="text-tertiary text-sm">{currentStep.description}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Step indicators */}
+      <div className="flex flex-wrap justify-center gap-1.5">
+        {STEPS.map((step, i) => (
+          <button
+            key={step.phase}
+            onClick={() => goToStep(i)}
+            className={`h-2 w-2 rounded-full transition-all ${
+              i === stepIndex
+                ? "bg-primary scale-125"
+                : i < stepIndex
+                  ? "bg-quaternary"
+                  : "bg-tertiary"
+            }`}
+            title={step.title}
+          />
+        ))}
+      </div>
+
+      {/* Controls */}
+      <div className="flex justify-center gap-3">
+        <button
+          onClick={() => goToStep(Math.max(0, stepIndex - 1))}
+          disabled={stepIndex === 0}
+          className="border-primary text-tertiary hover:border-primary hover:text-primary border px-4 py-2 text-sm transition-all disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <button
+          onClick={startAnimation}
+          disabled={isAnimating}
+          className={`px-5 py-2 text-sm font-medium transition-all ${
+            isAnimating
+              ? "bg-tertiary cursor-not-allowed text-white dark:text-neutral-950"
+              : "bg-primary hover:bg-primary text-white dark:text-neutral-950"
+          }`}
+        >
+          {isAnimating ? "Playing..." : "Play"}
+        </button>
+        <button
+          onClick={() => goToStep(Math.min(STEPS.length - 1, stepIndex + 1))}
+          disabled={stepIndex === STEPS.length - 1}
+          className="border-primary text-tertiary hover:border-primary hover:text-primary border px-4 py-2 text-sm transition-all disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/FlowDiagram.tsx
+++ b/src/app/how-terminals-work/demos/FlowDiagram.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { parseAnsiLine } from "../lib/ansi";
-import { TerminalWindow } from "../ui";
+import { Button, TerminalWindow } from "../ui";
 
 type Phase =
   | "idle"
@@ -128,7 +128,7 @@ function renderTerminalLine(line: string) {
       {p.text.includes("▌") ? (
         <>
           {p.text.replace("▌", "")}
-          <span className="cursor-blink bg-primary text-white dark:text-neutral-950">▌</span>
+          <span className="cursor-blink text-primary">▌</span>
         </>
       ) : (
         p.text
@@ -167,9 +167,7 @@ export function FlowDiagram() {
 
   const layerClass = (layer: "keyboard" | "terminal" | "pty" | "shell") =>
     `relative px-4 py-3 border transition-all duration-300 ${
-      currentStep.highlight === layer
-        ? "border-primary bg-primary/5"
-        : "border-primary bg-secondary"
+      currentStep.highlight === layer ? "border-primary bg-primary/5" : "border-primary"
     }`;
 
   return (
@@ -193,7 +191,7 @@ export function FlowDiagram() {
               currentStep.dataDirection === "down" &&
               currentStep.highlight === "keyboard" && (
                 <div className="absolute -bottom-6 left-1/2 z-10 -translate-x-1/2 transform">
-                  <div className="bg-primary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                  <div className="border-primary bg-secondary text-primary border px-2 py-1 font-mono text-xs">
                     {currentStep.dataPacket}
                   </div>
                 </div>
@@ -219,7 +217,7 @@ export function FlowDiagram() {
               <div
                 className={`absolute ${currentStep.dataDirection === "down" ? "-bottom-6" : "-top-6"} left-1/2 z-10 -translate-x-1/2 transform`}
               >
-                <div className="bg-tertiary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                <div className="border-primary bg-secondary text-primary border px-2 py-1 font-mono text-xs">
                   {currentStep.dataPacket}
                 </div>
               </div>
@@ -245,7 +243,7 @@ export function FlowDiagram() {
               <div
                 className={`absolute ${currentStep.dataDirection === "down" ? "-bottom-6" : "-top-6"} left-1/2 z-10 -translate-x-1/2 transform`}
               >
-                <div className="bg-tertiary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                <div className="border-primary bg-secondary text-primary border px-2 py-1 font-mono text-xs">
                   {currentStep.dataPacket}
                 </div>
               </div>
@@ -271,7 +269,7 @@ export function FlowDiagram() {
               currentStep.dataDirection === "up" &&
               currentStep.highlight === "shell" && (
                 <div className="absolute -top-6 left-1/2 z-10 -translate-x-1/2 transform">
-                  <div className="bg-tertiary px-2 py-1 font-mono text-xs text-white dark:text-neutral-950">
+                  <div className="border-primary bg-secondary text-primary border px-2 py-1 font-mono text-xs">
                     {currentStep.dataPacket}
                   </div>
                 </div>
@@ -291,9 +289,9 @@ export function FlowDiagram() {
           </TerminalWindow>
 
           {/* Step info */}
-          <div className="bg-tertiary border-primary border px-4 py-3">
-            <div className="text-primary mb-1 text-sm font-medium">{currentStep.title}</div>
-            <div className="text-tertiary text-sm">{currentStep.description}</div>
+          <div className="space-y-1">
+            <div className="text-primary text-sm font-medium">{currentStep.title}</div>
+            <div className="text-secondary text-sm">{currentStep.description}</div>
           </div>
         </div>
       </div>
@@ -318,31 +316,18 @@ export function FlowDiagram() {
 
       {/* Controls */}
       <div className="flex justify-center gap-3">
-        <button
-          onClick={() => goToStep(Math.max(0, stepIndex - 1))}
-          disabled={stepIndex === 0}
-          className="border-primary text-tertiary hover:border-primary hover:text-primary border px-4 py-2 text-sm transition-all disabled:cursor-not-allowed disabled:opacity-50"
-        >
+        <Button onClick={() => goToStep(Math.max(0, stepIndex - 1))} disabled={stepIndex === 0}>
           Previous
-        </button>
-        <button
-          onClick={startAnimation}
-          disabled={isAnimating}
-          className={`px-5 py-2 text-sm font-medium transition-all ${
-            isAnimating
-              ? "bg-tertiary cursor-not-allowed text-white dark:text-neutral-950"
-              : "bg-primary hover:bg-primary text-white dark:text-neutral-950"
-          }`}
-        >
+        </Button>
+        <Button variant="primary" onClick={startAnimation} disabled={isAnimating}>
           {isAnimating ? "Playing..." : "Play"}
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => goToStep(Math.min(STEPS.length - 1, stepIndex + 1))}
           disabled={stepIndex === STEPS.length - 1}
-          className="border-primary text-tertiary hover:border-primary hover:text-primary border px-4 py-2 text-sm transition-all disabled:cursor-not-allowed disabled:opacity-50"
         >
           Next
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/app/how-terminals-work/demos/GridDemo.tsx
+++ b/src/app/how-terminals-work/demos/GridDemo.tsx
@@ -107,14 +107,12 @@ export function GridDemo() {
                 return (
                   <div
                     key={`${rowIdx}-${colIdx}`}
-                    className={`border-primary/80 flex h-5 cursor-pointer items-center justify-center border-r border-b text-xs transition-colors duration-75 ${isHovered ? "bg-primary/10 ring-primary ring-1 ring-inset" : ""} ${isCursor ? "bg-primary" : "hover:bg-tertiary"}`}
+                    className={`border-primary/80 flex h-5 cursor-pointer items-center justify-center border-r border-b text-xs transition-colors duration-75 ${isHovered ? "bg-primary/10 ring-primary ring-1 ring-inset" : ""} ${isCursor ? "bg-primary/10 text-primary" : "hover:bg-tertiary"}`}
                     onClick={() => handleCellClick(rowIdx, colIdx)}
                     onMouseEnter={() => setHoveredCell({ row: rowIdx, col: colIdx })}
                     onMouseLeave={() => setHoveredCell(null)}
                   >
-                    <span className={isCursor ? "text-white dark:text-neutral-950" : ""}>
-                      {char}
-                    </span>
+                    <span className={isCursor ? "text-primary" : ""}>{char}</span>
                   </div>
                 );
               }),

--- a/src/app/how-terminals-work/demos/GridDemo.tsx
+++ b/src/app/how-terminals-work/demos/GridDemo.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { Button, InfoPanel } from "../ui";
+
+const ROWS = 12;
+const CELL_WIDTH = 12; // pixels per cell
+const DEMO_TEXT = "Hello, terminal world!";
+
+export function GridDemo() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cols, setCols] = useState(40);
+  const [grid, setGrid] = useState<string[][]>(() =>
+    Array(ROWS)
+      .fill(null)
+      .map(() => Array(40).fill(" ")),
+  );
+  const [hoveredCell, setHoveredCell] = useState<{
+    row: number;
+    col: number;
+  } | null>(null);
+  const [isTyping, setIsTyping] = useState(false);
+  const [typingIndex, setTypingIndex] = useState(0);
+
+  // Measure container and calculate columns
+  useEffect(() => {
+    const updateCols = () => {
+      if (containerRef.current) {
+        const width = containerRef.current.offsetWidth;
+        const newCols = Math.max(20, Math.floor(width / CELL_WIDTH));
+        setCols(newCols);
+        setGrid((prev) => {
+          // Preserve existing content when resizing
+          return Array(ROWS)
+            .fill(null)
+            .map((_, rowIdx) =>
+              Array(newCols)
+                .fill(null)
+                .map((_, colIdx) => prev[rowIdx]?.[colIdx] ?? " "),
+            );
+        });
+      }
+    };
+
+    updateCols();
+    const observer = new ResizeObserver(updateCols);
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+    return () => observer.disconnect();
+  }, []);
+
+  const clearGrid = useCallback(() => {
+    setGrid(
+      Array(ROWS)
+        .fill(null)
+        .map(() => Array(cols).fill(" ")),
+    );
+    setTypingIndex(0);
+    setIsTyping(false);
+  }, [cols]);
+
+  const startTyping = useCallback(() => {
+    clearGrid();
+    setIsTyping(true);
+    setTypingIndex(0);
+  }, [clearGrid]);
+
+  useEffect(() => {
+    if (!isTyping || typingIndex >= DEMO_TEXT.length) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- stop the typing loop when the demo string is complete
+      if (typingIndex >= DEMO_TEXT.length) setIsTyping(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setGrid((prev) => {
+        const newGrid = prev.map((row) => [...row]);
+        if (typingIndex < cols) newGrid[0]![typingIndex] = DEMO_TEXT[typingIndex]!;
+        return newGrid;
+      });
+      setTypingIndex((i) => i + 1);
+    }, 80);
+    return () => clearTimeout(timer);
+  }, [isTyping, typingIndex, cols]);
+
+  const handleCellClick = (row: number, col: number) => {
+    setGrid((prev) => {
+      const newGrid = prev.map((r) => [...r]);
+      const chars = [" ", "#", "@", "*", "X", "O"];
+      const idx = chars.indexOf(newGrid[row]![col]!);
+      newGrid[row]![col] = chars[(idx + 1) % chars.length]!;
+      return newGrid;
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <TerminalWindow noPadding>
+        <div ref={containerRef} className="w-full">
+          <div className="grid gap-0" style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
+            {grid.map((row, rowIdx) =>
+              row.map((char, colIdx) => {
+                const isHovered = hoveredCell?.row === rowIdx && hoveredCell?.col === colIdx;
+                const isCursor = isTyping && rowIdx === 0 && colIdx === typingIndex;
+                return (
+                  <div
+                    key={`${rowIdx}-${colIdx}`}
+                    className={`border-primary/80 flex h-5 cursor-pointer items-center justify-center border-r border-b text-xs transition-colors duration-75 ${isHovered ? "bg-primary/10 ring-primary ring-1 ring-inset" : ""} ${isCursor ? "bg-primary" : "hover:bg-tertiary"}`}
+                    onClick={() => handleCellClick(rowIdx, colIdx)}
+                    onMouseEnter={() => setHoveredCell({ row: rowIdx, col: colIdx })}
+                    onMouseLeave={() => setHoveredCell(null)}
+                  >
+                    <span className={isCursor ? "text-white dark:text-neutral-950" : ""}>
+                      {char}
+                    </span>
+                  </div>
+                );
+              }),
+            )}
+          </div>
+        </div>
+      </TerminalWindow>
+
+      <InfoPanel>
+        {hoveredCell ? (
+          <span className="text-tertiary">
+            Cell{" "}
+            <span className="text-primary font-medium">
+              ({hoveredCell.row}, {hoveredCell.col})
+            </span>
+          </span>
+        ) : (
+          <span className="text-quaternary">Hover over a cell</span>
+        )}
+      </InfoPanel>
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        <Button variant="primary" onClick={startTyping}>
+          Add text
+        </Button>
+        <Button variant="secondary" onClick={clearGrid}>
+          Clear
+        </Button>
+        <span className="text-quaternary text-sm">Click cells to draw</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/IconsDemo.tsx
+++ b/src/app/how-terminals-work/demos/IconsDemo.tsx
@@ -401,7 +401,7 @@ export function IconsDemo() {
               {/* Hovered file info */}
               {hoveredFile !== null && (
                 <div className="bg-secondary border-primary absolute right-4 bottom-4 z-10 border text-xs">
-                  <div className="bg-tertiary flex items-center gap-4 rounded p-2">
+                  <div className="flex items-center gap-4 p-2">
                     <div className="bg-secondary border-primary flex h-8 w-8 items-center justify-center rounded border">
                       {renderIcon(FILE_TREE[hoveredFile].icon, FILE_TREE[hoveredFile].color)}
                     </div>
@@ -427,7 +427,7 @@ export function IconsDemo() {
 
         {/* Explanation */}
         <div className="space-y-4">
-          <InfoPanel className="space-y-4 px-4 py-4">
+          <InfoPanel className="space-y-4">
             <div className="flex items-start justify-between gap-4">
               <div className="text-primary text-sm font-medium">{stepContent.title}</div>
               <StepDotsNavigation
@@ -441,7 +441,7 @@ export function IconsDemo() {
 
               {/* Step-specific content */}
               {currentStep === "pua" && (
-                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="space-y-2 font-mono text-xs">
                   <div className="text-quaternary">// Unicode Private Use Area ranges</div>
                   <div className="space-y-1">
                     <div>
@@ -464,7 +464,7 @@ export function IconsDemo() {
               )}
 
               {currentStep === "rendering" && (
-                <div className="bg-tertiary space-y-3 p-3">
+                <div className="space-y-3">
                   <div className="flex flex-wrap items-center gap-3 text-sm">
                     <div className="flex flex-col items-center">
                       <span className="text-secondary font-mono text-xs">App outputs</span>
@@ -485,7 +485,7 @@ export function IconsDemo() {
               )}
 
               {currentStep === "fonts" && (
-                <div className="bg-tertiary space-y-2 p-3 text-xs">
+                <div className="space-y-2 text-xs">
                   <div className="text-quaternary">Popular Nerd Fonts:</div>
                   <div className="grid grid-cols-2 gap-2">
                     <div className="text-primary flex items-center gap-2">
@@ -514,13 +514,13 @@ export function IconsDemo() {
       </div>
 
       {/* Icon Gallery */}
-      <div className="bg-tertiary border-primary space-y-6 border p-6">
-        <h3 className="text-primary text-sm font-bold">Nerd Font Icon Gallery</h3>
+      <div className="space-y-6">
+        <h3 className="text-primary text-sm font-medium">Nerd Font Icon Gallery</h3>
         <p className="text-quaternary text-sm">
           Click any icon to see its Unicode codepoint and how to use it in code.
         </p>
 
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Icon grid by category */}
           <div className="space-y-4">
             {categories.map((category) => (
@@ -547,9 +547,9 @@ export function IconsDemo() {
           </div>
 
           {/* Selected icon details */}
-          <div className="bg-secondary border-primary space-y-3 border p-4">
+          <div className="space-y-3">
             <div className="flex items-center gap-3">
-              <div className="bg-tertiary border-primary flex h-10 w-10 items-center justify-center border">
+              <div className="border-primary flex h-10 w-10 items-center justify-center border">
                 {renderIcon(selectedIcon.icon as IconName, selectedIcon.color)}
               </div>
               <div className="text-primary font-bold">{selectedIcon.name}</div>
@@ -585,8 +585,8 @@ export function IconsDemo() {
       </div>
 
       {/* Technical Deep Dive */}
-      <div className="bg-tertiary border-primary space-y-4 border p-6">
-        <h3 className="text-primary text-sm font-bold">Under the Hood: Why One Cell?</h3>
+      <div className="space-y-4">
+        <h3 className="text-primary text-sm font-medium">Under the Hood: Why One Cell?</h3>
 
         <div className="grid grid-cols-1 gap-4">
           <FeatureBox number={1} title="Single Codepoint">
@@ -612,8 +612,8 @@ export function IconsDemo() {
         </div>
 
         {/* Character width comparison */}
-        <div className="bg-tertiary border-primary space-y-3 border p-4">
-          <div className="text-primary text-sm font-bold">Character Width in Terminals</div>
+        <div className="space-y-3">
+          <div className="text-primary text-sm font-medium">Character Width in Terminals</div>
           <div className="space-y-2 font-mono text-sm">
             <div className="flex items-center gap-4">
               <div className="text-quaternary w-24">Single-width:</div>
@@ -621,7 +621,7 @@ export function IconsDemo() {
                 {["A", "B", "C"].map((char, i) => (
                   <div
                     key={i}
-                    className="border-primary bg-tertiary flex h-6 w-5 items-center justify-center border"
+                    className="border-primary flex h-6 w-5 items-center justify-center border"
                   >
                     {char}
                   </div>
@@ -629,7 +629,7 @@ export function IconsDemo() {
                 {[NERD_GLYPHS.folder, NERD_GLYPHS.file, NERD_GLYPHS.check].map((glyph, i) => (
                   <div
                     key={`icon-${i}`}
-                    className="border-primary bg-tertiary flex h-6 w-5 items-center justify-center border"
+                    className="border-primary flex h-6 w-5 items-center justify-center border"
                   >
                     <NerdIcon glyph={glyph} className="text-primary text-sm" />
                   </div>
@@ -643,7 +643,7 @@ export function IconsDemo() {
                 {["中", "文", "字"].map((char, i) => (
                   <div
                     key={i}
-                    className="border-primary bg-tertiary flex h-6 w-10 items-center justify-center border"
+                    className="border-primary flex h-6 w-10 items-center justify-center border"
                   >
                     {char}
                   </div>
@@ -715,8 +715,8 @@ function IconSetsReference() {
   ];
 
   return (
-    <div className="bg-tertiary border-primary space-y-4 border p-6">
-      <h3 className="text-primary text-sm font-bold">Icon Sets in Nerd Fonts</h3>
+    <div className="space-y-4">
+      <h3 className="text-primary text-sm font-medium">Icon Sets in Nerd Fonts</h3>
       <p className="text-quaternary text-sm">
         Nerd Fonts combines multiple icon sets into one font. Each set occupies a different Unicode
         range.
@@ -724,8 +724,8 @@ function IconSetsReference() {
 
       <div className="divide-primary divide-y">
         {iconSets.map((set) => (
-          <div key={set.name} className="flex flex-col gap-3 py-3 md:flex-row md:items-center">
-            <div className="md:w-32">
+          <div key={set.name} className="flex flex-col gap-3 py-3 lg:flex-row lg:items-center">
+            <div className="lg:w-32">
               <div className="text-primary text-sm font-bold">{set.name}</div>
               <div className="text-secondary font-mono text-xs">{set.range}</div>
             </div>

--- a/src/app/how-terminals-work/demos/IconsDemo.tsx
+++ b/src/app/how-terminals-work/demos/IconsDemo.tsx
@@ -1,0 +1,756 @@
+"use client";
+
+import { useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { FeatureBox, InfoPanel, StepDotsNavigation, SubsectionLabel } from "../ui";
+
+// Actual Nerd Font Unicode glyphs - these render as icons when the font is loaded
+// Using the actual codepoints from Nerd Fonts v3
+const NERD_GLYPHS = {
+  // File icons (Seti-UI + Custom)
+  folder: "\ue5ff", //
+  folderOpen: "\ue5fe", //
+  file: "\uf15b", //
+
+  // Dev icons (Devicons)
+  typescript: "\ue628", //
+  javascript: "\ue781", //
+  react: "\ue7ba", //
+  python: "\ue73c", //
+  rust: "\ue7a8", //
+
+  // Git/GitHub (Octicons)
+  git: "\uf1d3", //
+  github: "\uf408", //
+
+  // File types
+  json: "\ue60b", //
+  markdown: "\ue73e", //
+  docker: "\uf308", //
+
+  // System (Font Awesome)
+  terminal: "\uf489", //
+  gear: "\uf013", //
+  lock: "\uf023", //
+
+  // Status (Font Awesome)
+  check: "\uf00c", //
+  error: "\uf00d", //
+  warning: "\uf071", //
+  info: "\uf05a", //
+};
+
+// Component for rendering a Nerd Font icon
+function NerdIcon({ glyph, className = "" }: { glyph: string; className?: string }) {
+  return (
+    <span
+      className={`inline-block text-center leading-none ${className}`}
+      style={{ fontFamily: "'JetBrainsMono Nerd Font', monospace" }}
+    >
+      {glyph}
+    </span>
+  );
+}
+
+// Icon data with actual glyphs and codepoints
+const NERD_FONT_ICONS = [
+  {
+    icon: "folder",
+    glyph: NERD_GLYPHS.folder,
+    name: "Folder",
+    codepoint: "U+E5FF",
+    category: "Files",
+    color: "text-secondary",
+  },
+  {
+    icon: "folderOpen",
+    glyph: NERD_GLYPHS.folderOpen,
+    name: "Folder Open",
+    codepoint: "U+E5FE",
+    category: "Files",
+    color: "text-secondary",
+  },
+  {
+    icon: "file",
+    glyph: NERD_GLYPHS.file,
+    name: "File",
+    codepoint: "U+F15B",
+    category: "Files",
+    color: "text-primary",
+  },
+  {
+    icon: "typescript",
+    glyph: NERD_GLYPHS.typescript,
+    name: "TypeScript",
+    codepoint: "U+E628",
+    category: "Dev",
+    color: "text-secondary",
+  },
+  {
+    icon: "javascript",
+    glyph: NERD_GLYPHS.javascript,
+    name: "JavaScript",
+    codepoint: "U+E781",
+    category: "Dev",
+    color: "text-secondary",
+  },
+  {
+    icon: "react",
+    glyph: NERD_GLYPHS.react,
+    name: "React",
+    codepoint: "U+E7BA",
+    category: "Dev",
+    color: "text-secondary",
+  },
+  {
+    icon: "python",
+    glyph: NERD_GLYPHS.python,
+    name: "Python",
+    codepoint: "U+E73C",
+    category: "Dev",
+    color: "text-secondary",
+  },
+  {
+    icon: "rust",
+    glyph: NERD_GLYPHS.rust,
+    name: "Rust",
+    codepoint: "U+E7A8",
+    category: "Dev",
+    color: "text-primary",
+  },
+  {
+    icon: "git",
+    glyph: NERD_GLYPHS.git,
+    name: "Git",
+    codepoint: "U+F1D3",
+    category: "Dev",
+    color: "text-primary",
+  },
+  {
+    icon: "github",
+    glyph: NERD_GLYPHS.github,
+    name: "GitHub",
+    codepoint: "U+F408",
+    category: "Dev",
+    color: "text-primary",
+  },
+  {
+    icon: "docker",
+    glyph: NERD_GLYPHS.docker,
+    name: "Docker",
+    codepoint: "U+F308",
+    category: "Dev",
+    color: "text-secondary",
+  },
+  {
+    icon: "terminal",
+    glyph: NERD_GLYPHS.terminal,
+    name: "Terminal",
+    codepoint: "U+F489",
+    category: "System",
+    color: "text-primary",
+  },
+  {
+    icon: "gear",
+    glyph: NERD_GLYPHS.gear,
+    name: "Gear",
+    codepoint: "U+F013",
+    category: "System",
+    color: "text-quaternary",
+  },
+  {
+    icon: "lock",
+    glyph: NERD_GLYPHS.lock,
+    name: "Lock",
+    codepoint: "U+F023",
+    category: "System",
+    color: "text-secondary",
+  },
+  {
+    icon: "check",
+    glyph: NERD_GLYPHS.check,
+    name: "Check",
+    codepoint: "U+F00C",
+    category: "Status",
+    color: "text-primary",
+  },
+  {
+    icon: "error",
+    glyph: NERD_GLYPHS.error,
+    name: "Error",
+    codepoint: "U+F00D",
+    category: "Status",
+    color: "text-primary",
+  },
+  {
+    icon: "warning",
+    glyph: NERD_GLYPHS.warning,
+    name: "Warning",
+    codepoint: "U+F071",
+    category: "Status",
+    color: "text-secondary",
+  },
+  {
+    icon: "info",
+    glyph: NERD_GLYPHS.info,
+    name: "Info",
+    codepoint: "U+F05A",
+    category: "Status",
+    color: "text-secondary",
+  },
+] as const;
+
+type IconName = keyof typeof NERD_GLYPHS;
+
+// File tree structure for the demo
+const FILE_TREE: {
+  name: string;
+  type: "folder" | "file";
+  icon: IconName;
+  color: string;
+  indent: number;
+  codepoint: string;
+}[] = [
+  {
+    name: "src",
+    type: "folder",
+    icon: "folder",
+    color: "text-secondary",
+    indent: 0,
+    codepoint: "U+E5FF",
+  },
+  {
+    name: "components",
+    type: "folder",
+    icon: "folder",
+    color: "text-secondary",
+    indent: 1,
+    codepoint: "U+E5FF",
+  },
+  {
+    name: "App.tsx",
+    type: "file",
+    icon: "react",
+    color: "text-secondary",
+    indent: 2,
+    codepoint: "U+E7BA",
+  },
+  {
+    name: "Button.tsx",
+    type: "file",
+    icon: "react",
+    color: "text-secondary",
+    indent: 2,
+    codepoint: "U+E7BA",
+  },
+  {
+    name: "utils",
+    type: "folder",
+    icon: "folder",
+    color: "text-secondary",
+    indent: 1,
+    codepoint: "U+E5FF",
+  },
+  {
+    name: "index.ts",
+    type: "file",
+    icon: "typescript",
+    color: "text-secondary",
+    indent: 1,
+    codepoint: "U+E628",
+  },
+  {
+    name: "package.json",
+    type: "file",
+    icon: "json",
+    color: "text-primary",
+    indent: 0,
+    codepoint: "U+E60B",
+  },
+  {
+    name: ".gitignore",
+    type: "file",
+    icon: "git",
+    color: "text-primary",
+    indent: 0,
+    codepoint: "U+F1D3",
+  },
+  {
+    name: "README.md",
+    type: "file",
+    icon: "markdown",
+    color: "text-primary",
+    indent: 0,
+    codepoint: "U+E73E",
+  },
+  {
+    name: "Dockerfile",
+    type: "file",
+    icon: "docker",
+    color: "text-secondary",
+    indent: 0,
+    codepoint: "U+F308",
+  },
+];
+
+type ExplainerStep = "what" | "how" | "pua" | "fonts" | "rendering";
+
+const STEPS: Record<ExplainerStep, { title: string; description: string }> = {
+  what: {
+    title: "What Are Terminal Icons?",
+    description:
+      "Modern terminal apps like file explorers, status bars, and dev tools display icons for files, folders, and status indicators. These aren't images—they're Unicode characters rendered by special fonts.",
+  },
+  how: {
+    title: "How They Work",
+    description:
+      "Terminal icons are just regular Unicode characters. The terminal treats them exactly like letters or numbers—one character per cell. The magic is in the font, which maps these codepoints to icon glyphs.",
+  },
+  pua: {
+    title: "The Private Use Area",
+    description:
+      "Unicode reserves ranges (U+E000-U+F8FF) called Private Use Areas. Nerd Fonts place thousands of icons here—dev logos, file types, git symbols, and more. Apps output these codepoints; fonts render them as icons.",
+  },
+  fonts: {
+    title: "Nerd Fonts",
+    description:
+      "Nerd Fonts are regular programming fonts (like JetBrains Mono or Fira Code) patched with 3,600+ icons. Install one, set it as your terminal font, and icons just work. No terminal configuration needed.",
+  },
+  rendering: {
+    title: "The Rendering Pipeline",
+    description:
+      "When an app outputs an icon: 1) It prints a Unicode character (e.g., U+E628 for TypeScript). 2) The terminal looks up the character in its font. 3) The font maps U+E628 to a TypeScript logo glyph. 4) The terminal draws that glyph in a cell.",
+  },
+};
+
+export function IconsDemo() {
+  const [currentStep, setCurrentStep] = useState<ExplainerStep>("what");
+  const [selectedIcon, setSelectedIcon] = useState(NERD_FONT_ICONS[0]);
+  const [showWithIcons, setShowWithIcons] = useState(true);
+  const [hoveredFile, setHoveredFile] = useState<number | null>(null);
+
+  const steps = Object.keys(STEPS) as ExplainerStep[];
+  const stepContent = STEPS[currentStep];
+
+  const categories = [...new Set(NERD_FONT_ICONS.map((i) => i.category))];
+
+  // Render icon using actual Nerd Font glyph
+  const renderIcon = (iconName: IconName, color: string) => {
+    const glyph = NERD_GLYPHS[iconName];
+    if (!glyph) return null;
+    return <NerdIcon glyph={glyph} className={`text-base ${color}`} />;
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Main Demo */}
+      <div className="grid grid-cols-1 gap-6">
+        {/* File Explorer Demo */}
+        <div className="space-y-4">
+          <TerminalWindow>
+            <div className="min-h-[280px] font-mono text-sm">
+              {/* Toggle */}
+              <div className="border-primary mb-3 flex items-center gap-4 border-b pb-2">
+                <button
+                  onClick={() => setShowWithIcons(!showWithIcons)}
+                  className={`px-2 py-1 text-xs transition-colors ${
+                    showWithIcons
+                      ? "bg-primary/10 text-primary"
+                      : "text-quaternary hover:text-primary"
+                  }`}
+                >
+                  {showWithIcons ? "Icons ON" : "Icons OFF"}
+                </button>
+                <span className="text-quaternary text-xs">
+                  {showWithIcons ? "Showing actual Nerd Font glyphs" : "Plain text only"}
+                </span>
+              </div>
+
+              {/* File tree */}
+              <div className="space-y-0.5">
+                {FILE_TREE.map((item, idx) => {
+                  const isHovered = hoveredFile === idx;
+                  return (
+                    <div
+                      key={idx}
+                      className={`flex cursor-pointer items-center gap-3 rounded px-2 py-0.5 transition-colors ${
+                        isHovered ? "bg-primary/10" : "hover:bg-tertiary"
+                      }`}
+                      style={{ paddingLeft: `${item.indent * 16 + 8}px` }}
+                      onMouseEnter={() => setHoveredFile(idx)}
+                      onMouseLeave={() => setHoveredFile(null)}
+                    >
+                      {showWithIcons ? (
+                        <span className="flex-shrink-0">{renderIcon(item.icon, item.color)}</span>
+                      ) : (
+                        <span className="text-quaternary w-4 text-center">
+                          {item.type === "folder" ? "D" : "F"}
+                        </span>
+                      )}
+                      <span className={isHovered ? "text-primary" : "text-primary"}>
+                        {item.name}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Hovered file info */}
+              {hoveredFile !== null && (
+                <div className="bg-secondary border-primary absolute right-4 bottom-4 z-10 border text-xs">
+                  <div className="bg-tertiary flex items-center gap-4 rounded p-2">
+                    <div className="bg-secondary border-primary flex h-8 w-8 items-center justify-center rounded border">
+                      {renderIcon(FILE_TREE[hoveredFile].icon, FILE_TREE[hoveredFile].color)}
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-primary">
+                        <span className="text-secondary">{FILE_TREE[hoveredFile].name}</span>
+                      </div>
+                      <div className="text-secondary font-mono">
+                        {FILE_TREE[hoveredFile].codepoint}
+                      </div>
+                    </div>
+                    <div className="text-quaternary text-right">
+                      One character
+                      <br />
+                      One cell
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </TerminalWindow>
+        </div>
+
+        {/* Explanation */}
+        <div className="space-y-4">
+          <InfoPanel className="space-y-4 px-4 py-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="text-primary text-sm font-medium">{stepContent.title}</div>
+              <StepDotsNavigation
+                steps={steps}
+                currentStep={currentStep}
+                onStepChange={setCurrentStep}
+              />
+            </div>
+            <div className="space-y-4">
+              <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
+
+              {/* Step-specific content */}
+              {currentStep === "pua" && (
+                <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                  <div className="text-quaternary">// Unicode Private Use Area ranges</div>
+                  <div className="space-y-1">
+                    <div>
+                      <span className="text-secondary">U+E000 - U+F8FF</span>{" "}
+                      <span className="text-quaternary">— Basic Multilingual Plane PUA</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">U+F0000 - U+FFFFD</span>{" "}
+                      <span className="text-quaternary">— Supplementary PUA-A</span>
+                    </div>
+                    <div>
+                      <span className="text-secondary">U+100000 - U+10FFFD</span>{" "}
+                      <span className="text-quaternary">— Supplementary PUA-B</span>
+                    </div>
+                  </div>
+                  <div className="text-secondary mt-2">
+                    Nerd Fonts uses ~3,600 codepoints in these ranges
+                  </div>
+                </div>
+              )}
+
+              {currentStep === "rendering" && (
+                <div className="bg-tertiary space-y-3 p-3">
+                  <div className="flex flex-wrap items-center gap-3 text-sm">
+                    <div className="flex flex-col items-center">
+                      <span className="text-secondary font-mono text-xs">App outputs</span>
+                      <span className="text-secondary font-mono">U+E628</span>
+                    </div>
+                    <span className="text-quaternary">→</span>
+                    <div className="flex flex-col items-center">
+                      <span className="text-secondary font-mono text-xs">Font lookup</span>
+                      <span className="text-primary">Nerd Font</span>
+                    </div>
+                    <span className="text-quaternary">→</span>
+                    <div className="flex flex-col items-center">
+                      <span className="text-secondary font-mono text-xs">Rendered</span>
+                      <div className="h-6 w-6">{renderIcon("typescript", "text-secondary")}</div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {currentStep === "fonts" && (
+                <div className="bg-tertiary space-y-2 p-3 text-xs">
+                  <div className="text-quaternary">Popular Nerd Fonts:</div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="text-primary flex items-center gap-2">
+                      {renderIcon("check", "text-primary")}
+                      <span>JetBrainsMono Nerd Font</span>
+                    </div>
+                    <div className="text-primary flex items-center gap-2">
+                      {renderIcon("check", "text-primary")}
+                      <span>FiraCode Nerd Font</span>
+                    </div>
+                    <div className="text-primary flex items-center gap-2">
+                      {renderIcon("check", "text-primary")}
+                      <span>Hack Nerd Font</span>
+                    </div>
+                    <div className="text-primary flex items-center gap-2">
+                      {renderIcon("check", "text-primary")}
+                      <span>CaskaydiaCove Nerd Font</span>
+                    </div>
+                  </div>
+                  <div className="text-secondary mt-2">Download: nerdfonts.com</div>
+                </div>
+              )}
+            </div>
+          </InfoPanel>
+        </div>
+      </div>
+
+      {/* Icon Gallery */}
+      <div className="bg-tertiary border-primary space-y-6 border p-6">
+        <h3 className="text-primary text-sm font-bold">Nerd Font Icon Gallery</h3>
+        <p className="text-quaternary text-sm">
+          Click any icon to see its Unicode codepoint and how to use it in code.
+        </p>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {/* Icon grid by category */}
+          <div className="space-y-4">
+            {categories.map((category) => (
+              <div key={category} className="space-y-2">
+                <SubsectionLabel className="mb-0">{category}</SubsectionLabel>
+                <div className="flex flex-wrap gap-2">
+                  {NERD_FONT_ICONS.filter((i) => i.category === category).map((item) => (
+                    <button
+                      key={item.codepoint}
+                      onClick={() => setSelectedIcon(item)}
+                      className={`flex h-10 w-10 items-center justify-center border transition-all ${
+                        selectedIcon.codepoint === item.codepoint
+                          ? "border-primary bg-primary/10 scale-110"
+                          : "border-primary hover:border-primary"
+                      }`}
+                      title={item.name}
+                    >
+                      {renderIcon(item.icon as IconName, item.color)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Selected icon details */}
+          <div className="bg-secondary border-primary space-y-3 border p-4">
+            <div className="flex items-center gap-3">
+              <div className="bg-tertiary border-primary flex h-10 w-10 items-center justify-center border">
+                {renderIcon(selectedIcon.icon as IconName, selectedIcon.color)}
+              </div>
+              <div className="text-primary font-bold">{selectedIcon.name}</div>
+              <div className="text-secondary font-mono text-sm">{selectedIcon.codepoint}</div>
+            </div>
+
+            <div className="text-quaternary space-y-1 font-mono text-xs">
+              <div>
+                <span className="text-tertiary">Shell: </span>
+                <span className="text-primary">
+                  echo -e "\u
+                  {selectedIcon.codepoint.replace("U+", "").toLowerCase()}"
+                </span>
+              </div>
+              <div>
+                <span className="text-tertiary">Code: </span>
+                <span className="text-secondary">printf</span>
+                <span className="text-secondary">(</span>
+                <span className="text-primary">
+                  "\\u{selectedIcon.codepoint.replace("U+", "").toLowerCase()}"
+                </span>
+                <span className="text-secondary">)</span>
+              </div>
+              <div>
+                <span className="text-tertiary">Decimal: </span>
+                <span className="text-secondary">
+                  {parseInt(selectedIcon.codepoint.replace("U+", ""), 16)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Technical Deep Dive */}
+      <div className="bg-tertiary border-primary space-y-4 border p-6">
+        <h3 className="text-primary text-sm font-bold">Under the Hood: Why One Cell?</h3>
+
+        <div className="grid grid-cols-1 gap-4">
+          <FeatureBox number={1} title="Single Codepoint">
+            <p className="text-quaternary text-sm">
+              Each Nerd Font icon is a single Unicode codepoint. The terminal sees it as one
+              character, just like 'A' or '中'. One character = one cell.
+            </p>
+          </FeatureBox>
+
+          <FeatureBox number={2} title="Font Glyphs">
+            <p className="text-quaternary text-sm">
+              The font file contains a glyph (vector drawing) for each codepoint. Nerd Fonts add
+              thousands of icon glyphs sized to fit the terminal's cell dimensions.
+            </p>
+          </FeatureBox>
+
+          <FeatureBox number={3} title="Cell-Sized Design">
+            <p className="text-quaternary text-sm">
+              Icon glyphs are designed to fit within a monospace cell. They're square or slightly
+              rectangular to match the terminal's character grid perfectly.
+            </p>
+          </FeatureBox>
+        </div>
+
+        {/* Character width comparison */}
+        <div className="bg-tertiary border-primary space-y-3 border p-4">
+          <div className="text-primary text-sm font-bold">Character Width in Terminals</div>
+          <div className="space-y-2 font-mono text-sm">
+            <div className="flex items-center gap-4">
+              <div className="text-quaternary w-24">Single-width:</div>
+              <div className="flex">
+                {["A", "B", "C"].map((char, i) => (
+                  <div
+                    key={i}
+                    className="border-primary bg-tertiary flex h-6 w-5 items-center justify-center border"
+                  >
+                    {char}
+                  </div>
+                ))}
+                {[NERD_GLYPHS.folder, NERD_GLYPHS.file, NERD_GLYPHS.check].map((glyph, i) => (
+                  <div
+                    key={`icon-${i}`}
+                    className="border-primary bg-tertiary flex h-6 w-5 items-center justify-center border"
+                  >
+                    <NerdIcon glyph={glyph} className="text-primary text-sm" />
+                  </div>
+                ))}
+              </div>
+              <span className="text-quaternary text-xs">1 cell each</span>
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="text-quaternary w-24">Double-width:</div>
+              <div className="flex">
+                {["中", "文", "字"].map((char, i) => (
+                  <div
+                    key={i}
+                    className="border-primary bg-tertiary flex h-6 w-10 items-center justify-center border"
+                  >
+                    {char}
+                  </div>
+                ))}
+              </div>
+              <span className="text-quaternary text-xs">2 cells each (CJK)</span>
+            </div>
+          </div>
+          <p className="text-quaternary text-xs">
+            Nerd Font icons are single-width characters. CJK characters and some emoji are
+            double-width.
+          </p>
+        </div>
+      </div>
+
+      {/* Common Icon Sets Reference */}
+      <IconSetsReference />
+    </div>
+  );
+}
+
+// Powerline glyphs
+const POWERLINE_GLYPHS = {
+  arrowRight: "\ue0b0",
+  arrowLeft: "\ue0b2",
+  roundedRight: "\ue0b4",
+};
+
+function IconSetsReference() {
+  const iconSets = [
+    {
+      name: "Powerline",
+      description: "Status bar separators and arrows",
+      range: "U+E0A0-E0D4",
+      glyphs: [
+        POWERLINE_GLYPHS.arrowRight,
+        POWERLINE_GLYPHS.arrowLeft,
+        POWERLINE_GLYPHS.roundedRight,
+      ],
+      fontSize: 12,
+    },
+    {
+      name: "Font Awesome",
+      description: "General purpose icons",
+      range: "U+F000-F2E0",
+      glyphs: [NERD_GLYPHS.folder, NERD_GLYPHS.file, NERD_GLYPHS.gear, NERD_GLYPHS.lock],
+      fontSize: 14,
+    },
+    {
+      name: "Devicons",
+      description: "Programming language logos",
+      range: "U+E700-E7C5",
+      glyphs: [
+        NERD_GLYPHS.typescript,
+        NERD_GLYPHS.javascript,
+        NERD_GLYPHS.react,
+        NERD_GLYPHS.python,
+        NERD_GLYPHS.rust,
+      ],
+      fontSize: 16,
+    },
+    {
+      name: "Octicons",
+      description: "GitHub-style icons",
+      range: "U+F400-F532",
+      glyphs: [NERD_GLYPHS.github, NERD_GLYPHS.git, NERD_GLYPHS.terminal],
+      fontSize: 14,
+    },
+  ];
+
+  return (
+    <div className="bg-tertiary border-primary space-y-4 border p-6">
+      <h3 className="text-primary text-sm font-bold">Icon Sets in Nerd Fonts</h3>
+      <p className="text-quaternary text-sm">
+        Nerd Fonts combines multiple icon sets into one font. Each set occupies a different Unicode
+        range.
+      </p>
+
+      <div className="divide-primary divide-y">
+        {iconSets.map((set) => (
+          <div key={set.name} className="flex flex-col gap-3 py-3 md:flex-row md:items-center">
+            <div className="md:w-32">
+              <div className="text-primary text-sm font-bold">{set.name}</div>
+              <div className="text-secondary font-mono text-xs">{set.range}</div>
+            </div>
+            <div className="text-quaternary flex-1 text-xs">{set.description}</div>
+            <div className="flex gap-2">
+              {set.glyphs.map((glyph, i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-center overflow-hidden"
+                  style={{ width: 20, height: 20 }}
+                >
+                  <span
+                    className="text-primary"
+                    style={{
+                      fontFamily: "'JetBrainsMono Nerd Font', monospace",
+                      fontSize: set.fontSize,
+                      lineHeight: 1,
+                    }}
+                  >
+                    {glyph}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/IconsDemo.tsx
+++ b/src/app/how-terminals-work/demos/IconsDemo.tsx
@@ -326,7 +326,9 @@ const STEPS: Record<ExplainerStep, { title: string; description: string }> = {
 
 export function IconsDemo() {
   const [currentStep, setCurrentStep] = useState<ExplainerStep>("what");
-  const [selectedIcon, setSelectedIcon] = useState(NERD_FONT_ICONS[0]);
+  const [selectedIcon, setSelectedIcon] = useState<(typeof NERD_FONT_ICONS)[number]>(
+    NERD_FONT_ICONS[0],
+  );
   const [showWithIcons, setShowWithIcons] = useState(true);
   const [hoveredFile, setHoveredFile] = useState<number | null>(null);
 

--- a/src/app/how-terminals-work/demos/InputModesDemo.tsx
+++ b/src/app/how-terminals-work/demos/InputModesDemo.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { Button, InfoPanel, StepDotsNavigation, SubsectionLabel } from "../ui";
+
+type InputMode = "cooked" | "raw";
+
+type ExplainerStep = "cooked" | "raw" | "difference" | "examples";
+
+const EXPLAINER_STEPS: Record<ExplainerStep, { title: string; description: string }> = {
+  cooked: {
+    title: "Cooked Mode (Line-Buffered)",
+    description:
+      "In cooked mode (also called canonical mode), the terminal collects your input into a line buffer. You can edit with backspace, and nothing is sent to the program until you press Enter. This is how your shell normally works.",
+  },
+  raw: {
+    title: "Raw Mode (Character-at-a-Time)",
+    description:
+      "In raw mode, every keystroke is sent to the program immediately—no buffering, no line editing. The program sees each key the instant you press it. This is how vim, htop, and other interactive programs work.",
+  },
+  difference: {
+    title: "Why Two Modes?",
+    description:
+      "Your terminal always sends the same bytes—the difference is how the kernel processes them. In cooked mode, the kernel's line discipline buffers input and handles editing. In raw mode, bytes pass straight through to the program. This lets simple programs get free line editing, while complex TUIs get full control.",
+  },
+  examples: {
+    title: "Real-World Examples",
+    description:
+      "Your shell (bash/zsh) uses cooked mode—type, edit, then press Enter. Vim uses raw mode—press j and you immediately move down. SSH uses raw mode to forward your keys. Even Ctrl+C works differently: in cooked mode, the line discipline generates SIGINT; in raw mode, the byte reaches the program directly.",
+  },
+};
+
+export function InputModesDemo() {
+  const [mode, setMode] = useState<InputMode>("cooked");
+  const [buffer, setBuffer] = useState("");
+  const [sentLines, setSentLines] = useState<string[]>([]);
+  const [rawKeyHistory, setRawKeyHistory] = useState<string[]>([]);
+  const [currentStep, setCurrentStep] = useState<ExplainerStep>("cooked");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const steps = Object.keys(EXPLAINER_STEPS) as ExplainerStep[];
+  const stepContent = EXPLAINER_STEPS[currentStep];
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (mode === "cooked") {
+        // Cooked mode: standard behavior, only send on Enter
+        if (e.key === "Enter") {
+          e.preventDefault();
+          if (buffer.trim()) {
+            setSentLines((prev) => [...prev, buffer]);
+            setBuffer("");
+          }
+        }
+        // Backspace and other editing is handled automatically
+      } else {
+        // Raw mode: every key is immediately "sent"
+        e.preventDefault();
+        let keyName = e.key;
+        if (e.key === " ") keyName = "Space";
+        if (e.key === "Backspace") keyName = "BS";
+        if (e.key === "Enter") keyName = "Enter";
+        if (e.key === "Escape") keyName = "Esc";
+        if (e.key === "ArrowUp") keyName = "↑";
+        if (e.key === "ArrowDown") keyName = "↓";
+        if (e.key === "ArrowLeft") keyName = "←";
+        if (e.key === "ArrowRight") keyName = "→";
+        if (e.key === "Tab") keyName = "Tab";
+
+        setRawKeyHistory((prev) => [...prev.slice(-11), keyName]);
+      }
+    },
+    [mode, buffer],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (mode === "cooked") {
+        setBuffer(e.target.value);
+      }
+      // In raw mode, onChange doesn't do anything meaningful
+    },
+    [mode],
+  );
+
+  const reset = useCallback(() => {
+    setBuffer("");
+    setSentLines([]);
+    setRawKeyHistory([]);
+  }, []);
+
+  // Reset state when mode changes
+  const handleModeChange = useCallback((newMode: InputMode) => {
+    setMode(newMode);
+    setBuffer("");
+    setSentLines([]);
+    setRawKeyHistory([]);
+  }, []);
+
+  // Focus input when clicking anywhere in the terminal
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <div className="space-y-8">
+      {/* Mode Toggle */}
+      <div className="flex items-center gap-4">
+        <SubsectionLabel className="mb-0">Input Mode:</SubsectionLabel>
+        <div className="inline-flex">
+          <button
+            onClick={() => handleModeChange("cooked")}
+            className={`border px-4 py-2 text-sm transition-all ${
+              mode === "cooked"
+                ? "border-primary bg-primary/10 text-primary z-10"
+                : "border-primary text-tertiary hover:text-primary"
+            }`}
+          >
+            Cooked (Line-Buffered)
+          </button>
+          <button
+            onClick={() => handleModeChange("raw")}
+            className={`-ml-px border px-4 py-2 text-sm transition-all ${
+              mode === "raw"
+                ? "border-primary bg-primary/10 text-primary z-10"
+                : "border-primary text-tertiary hover:text-primary"
+            }`}
+          >
+            Raw (Immediate)
+          </button>
+        </div>
+      </div>
+
+      {/* Interactive Demo */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Terminal Simulation */}
+        <div className="space-y-4">
+          <SubsectionLabel>
+            {mode === "cooked" ? "Type, Edit, Then Enter" : "Every Key Sent Instantly"}
+          </SubsectionLabel>
+          <TerminalWindow>
+            <div className="min-h-[200px] cursor-text font-mono text-sm" onClick={focusInput}>
+              {mode === "cooked" ? (
+                <>
+                  {/* Cooked mode: show line history and current buffer */}
+                  {sentLines.map((line, idx) => (
+                    <div key={idx} className="text-tertiary">
+                      $ {line}
+                    </div>
+                  ))}
+                  <div className="flex items-center">
+                    <span className="text-primary">$</span>
+                    <span className="text-primary ml-2">{buffer}</span>
+                    <span className="cursor-blink">█</span>
+                  </div>
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={buffer}
+                    onChange={handleChange}
+                    onKeyDown={handleKeyDown}
+                    className="sr-only"
+                  />
+                </>
+              ) : (
+                <>
+                  {/* Raw mode: show key-by-key display */}
+                  <div className="flex min-h-[60px] flex-wrap gap-1">
+                    {rawKeyHistory.map((key, idx) => (
+                      <span
+                        key={idx}
+                        className={`border-primary border px-2 py-1 text-xs ${
+                          idx === rawKeyHistory.length - 1
+                            ? "bg-primary/10 text-primary border-primary"
+                            : "bg-tertiary text-primary"
+                        }`}
+                        style={{
+                          opacity: 0.5 + (idx / rawKeyHistory.length) * 0.5,
+                        }}
+                      >
+                        {key}
+                      </span>
+                    ))}
+                    {rawKeyHistory.length === 0 && (
+                      <span className="text-quaternary text-xs">Start typing...</span>
+                    )}
+                  </div>
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value=""
+                    onChange={() => {}}
+                    onKeyDown={handleKeyDown}
+                    className="sr-only"
+                  />
+                  <div className="text-quaternary mt-4 text-xs">
+                    Click here and type. Each key appears instantly.
+                  </div>
+                </>
+              )}
+            </div>
+          </TerminalWindow>
+          <Button size="sm" variant="secondary" onClick={reset}>
+            Clear
+          </Button>
+        </div>
+
+        {/* What's Happening */}
+        <div className="space-y-4">
+          <SubsectionLabel>What's Happening</SubsectionLabel>
+          <div className="bg-tertiary border-primary space-y-4 border p-4">
+            {mode === "cooked" ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <span className="text-primary font-bold">Cooked Mode</span>
+                  <span className="text-quaternary text-sm">(canonical)</span>
+                </div>
+                <div className="space-y-3 text-sm">
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">1.</span>
+                    <span className="text-tertiary">
+                      You type characters. The kernel's{" "}
+                      <span className="text-secondary">line discipline</span> buffers them.
+                    </span>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">2.</span>
+                    <span className="text-tertiary">
+                      <span className="text-secondary">Backspace</span>: the line discipline removes
+                      a character from the buffer.
+                    </span>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">3.</span>
+                    <span className="text-tertiary">
+                      <span className="text-secondary">Enter</span> sends the entire line to the
+                      program.
+                    </span>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">4.</span>
+                    <span className="text-tertiary">
+                      The program sees: <code className="text-primary">"{buffer || "..."}\\n"</code>
+                    </span>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="flex items-center gap-2">
+                  <span className="text-primary font-bold">Raw Mode</span>
+                  <span className="text-quaternary text-sm">(non-canonical)</span>
+                </div>
+                <div className="space-y-3 text-sm">
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">1.</span>
+                    <span className="text-tertiary">
+                      You press a key. It's <span className="text-secondary">immediately</span>{" "}
+                      sent.
+                    </span>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">2.</span>
+                    <span className="text-tertiary">
+                      <span className="text-secondary">No buffering</span>
+                      —the line discipline passes bytes straight through.
+                    </span>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">3.</span>
+                    <span className="text-tertiary">
+                      <span className="text-secondary">Backspace</span> is just another key the
+                      program receives.
+                    </span>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="text-secondary">4.</span>
+                    <span className="text-tertiary">
+                      The program handles everything: cursor, display, editing.
+                    </span>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Explainer */}
+      <InfoPanel className="space-y-4 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="text-primary text-sm font-medium">{stepContent.title}</div>
+          <StepDotsNavigation
+            steps={steps}
+            currentStep={currentStep}
+            onStepChange={setCurrentStep}
+          />
+        </div>
+        <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
+      </InfoPanel>
+
+      {/* Comparison Table */}
+      <div className="bg-tertiary border-primary space-y-4 border p-6">
+        <h3 className="text-primary text-sm font-bold">Cooked vs Raw: Quick Comparison</h3>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-primary border-b">
+                <th className="text-quaternary py-2 text-left">Behavior</th>
+                <th className="text-primary py-2 text-left">Cooked Mode</th>
+                <th className="text-primary py-2 text-left">Raw Mode</th>
+              </tr>
+            </thead>
+            <tbody className="text-tertiary">
+              <tr className="border-primary/50 border-b">
+                <td className="py-2">When input is sent</td>
+                <td className="py-2">After pressing Enter</td>
+                <td className="py-2">Immediately per key</td>
+              </tr>
+              <tr className="border-primary/50 border-b">
+                <td className="py-2">Backspace</td>
+                <td className="py-2">Deletes from buffer</td>
+                <td className="py-2">Just another key</td>
+              </tr>
+              <tr className="border-primary/50 border-b">
+                <td className="py-2">Ctrl+C</td>
+                <td className="py-2">Line discipline generates SIGINT</td>
+                <td className="py-2">Program receives 0x03</td>
+              </tr>
+              <tr className="border-primary/50 border-b">
+                <td className="py-2">Arrow keys</td>
+                <td className="py-2">Line recall (history)</td>
+                <td className="py-2">Program handles it</td>
+              </tr>
+              <tr>
+                <td className="py-2">Used by</td>
+                <td className="text-secondary py-2">bash, zsh, cat</td>
+                <td className="text-secondary py-2">vim, htop, ssh, less</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/InputModesDemo.tsx
+++ b/src/app/how-terminals-work/demos/InputModesDemo.tsx
@@ -210,7 +210,7 @@ export function InputModesDemo() {
         {/* What's Happening */}
         <div className="space-y-4">
           <SubsectionLabel>What's Happening</SubsectionLabel>
-          <div className="bg-tertiary border-primary space-y-4 border p-4">
+          <div className="space-y-4">
             {mode === "cooked" ? (
               <>
                 <div className="flex items-center gap-2">
@@ -289,7 +289,7 @@ export function InputModesDemo() {
       </div>
 
       {/* Explainer */}
-      <InfoPanel className="space-y-4 p-4">
+      <InfoPanel className="space-y-4">
         <div className="flex items-start justify-between gap-4">
           <div className="text-primary text-sm font-medium">{stepContent.title}</div>
           <StepDotsNavigation
@@ -302,8 +302,8 @@ export function InputModesDemo() {
       </InfoPanel>
 
       {/* Comparison Table */}
-      <div className="bg-tertiary border-primary space-y-4 border p-6">
-        <h3 className="text-primary text-sm font-bold">Cooked vs Raw: Quick Comparison</h3>
+      <div className="space-y-4">
+        <h3 className="text-primary text-sm font-medium">Cooked vs Raw: Quick Comparison</h3>
 
         <div className="overflow-x-auto">
           <table className="w-full text-sm">

--- a/src/app/how-terminals-work/demos/KeyboardDemo.tsx
+++ b/src/app/how-terminals-work/demos/KeyboardDemo.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { SPECIAL_KEYS } from "../lib/sequences";
+import { TerminalWindow } from "../ui";
+
+interface KeyInfo {
+  key: string;
+  bytes: string;
+  sequence: string;
+  desc: string;
+}
+
+export function KeyboardDemo() {
+  const [lastKey, setLastKey] = useState<KeyInfo | null>(null);
+  const [history, setHistory] = useState<KeyInfo[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const special = SPECIAL_KEYS[e.code] || SPECIAL_KEYS[e.key];
+    const keyInfo: KeyInfo = special
+      ? {
+          key: e.key,
+          bytes: special.bytes,
+          sequence: special.sequence,
+          desc: special.desc,
+        }
+      : {
+          key: e.key,
+          bytes: e.key.charCodeAt(0).toString(16).padStart(2, "0"),
+          sequence: e.key,
+          desc: `Character '${e.key}'`,
+        };
+
+    if (special) e.preventDefault();
+    setLastKey(keyInfo);
+    setHistory((prev) => [keyInfo, ...prev].slice(0, 8));
+  };
+
+  return (
+    <div className="space-y-6">
+      <TerminalWindow>
+        <div
+          className="flex min-h-[180px] cursor-text flex-col items-center justify-center"
+          onClick={() => inputRef.current?.focus()}
+        >
+          <input
+            ref={inputRef}
+            type="text"
+            className="pointer-events-none absolute opacity-0"
+            onKeyDown={handleKeyDown}
+          />
+          {lastKey ? (
+            <div className="space-y-4 text-center">
+              <div className="text-primary text-3xl font-medium">
+                {lastKey.key === " " ? "Space" : lastKey.key}
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div className="bg-secondary p-3">
+                  <div className="text-quaternary mb-1 text-xs uppercase">Bytes</div>
+                  <code className="text-secondary">{lastKey.bytes}</code>
+                </div>
+                <div className="bg-secondary p-3">
+                  <div className="text-quaternary mb-1 text-xs uppercase">Sequence</div>
+                  <code className="text-secondary">{lastKey.sequence}</code>
+                </div>
+              </div>
+              <div className="text-tertiary text-sm">{lastKey.desc}</div>
+            </div>
+          ) : (
+            <div className="text-tertiary text-center">
+              <div className="mb-1 text-base">Press any key</div>
+              <div className="text-quaternary text-sm">Try arrow keys, Enter, Tab, or letters</div>
+            </div>
+          )}
+        </div>
+      </TerminalWindow>
+
+      {history.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {history.map((k, i) => (
+            <div
+              key={i}
+              className="bg-tertiary border-primary border px-3 py-1.5 text-sm"
+              style={{ opacity: 1 - i * 0.1 }}
+            >
+              <span className="text-primary">{k.key === " " ? "␣" : k.key}</span>
+              <span className="text-quaternary mx-2">→</span>
+              <code className="text-secondary">{k.bytes}</code>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="text-tertiary text-sm">
+        When you press an arrow key, your terminal doesn't send "arrow up" — it sends{" "}
+        <code className="text-secondary">ESC [ A</code> (three bytes). Programs that don't
+        understand this will print <code className="text-secondary">^[[A</code> literally.
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/KeyboardDemo.tsx
+++ b/src/app/how-terminals-work/demos/KeyboardDemo.tsx
@@ -57,11 +57,11 @@ export function KeyboardDemo() {
                 {lastKey.key === " " ? "Space" : lastKey.key}
               </div>
               <div className="grid grid-cols-2 gap-3 text-sm">
-                <div className="bg-secondary p-3">
+                <div>
                   <div className="text-quaternary mb-1 text-xs uppercase">Bytes</div>
                   <code className="text-secondary">{lastKey.bytes}</code>
                 </div>
-                <div className="bg-secondary p-3">
+                <div>
                   <div className="text-quaternary mb-1 text-xs uppercase">Sequence</div>
                   <code className="text-secondary">{lastKey.sequence}</code>
                 </div>
@@ -82,7 +82,7 @@ export function KeyboardDemo() {
           {history.map((k, i) => (
             <div
               key={i}
-              className="bg-tertiary border-primary border px-3 py-1.5 text-sm"
+              className="border-primary border px-3 py-1.5 text-sm"
               style={{ opacity: 1 - i * 0.1 }}
             >
               <span className="text-primary">{k.key === " " ? "␣" : k.key}</span>

--- a/src/app/how-terminals-work/demos/MouseDemo.tsx
+++ b/src/app/how-terminals-work/demos/MouseDemo.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { encodeMouseClick } from "../lib/sequences";
+import { TerminalWindow } from "../ui";
+
+const GRID_ROWS = 10;
+const CELL_WIDTH = 20; // pixels per cell
+
+interface ClickInfo {
+  x: number;
+  y: number;
+  button: number;
+  sequence: string;
+  bytes: string;
+}
+
+export function MouseDemo() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cols, setCols] = useState(20);
+  const [lastClick, setLastClick] = useState<ClickInfo | null>(null);
+  const [mouseEnabled, setMouseEnabled] = useState(true);
+
+  // Measure container and calculate columns
+  useEffect(() => {
+    const updateCols = () => {
+      if (containerRef.current) {
+        const width = containerRef.current.offsetWidth;
+        const newCols = Math.max(10, Math.floor(width / CELL_WIDTH));
+        setCols(newCols);
+      }
+    };
+
+    updateCols();
+    const observer = new ResizeObserver(updateCols);
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+    return () => observer.disconnect();
+  }, []);
+
+  const handleCellClick = (row: number, col: number, e: React.MouseEvent) => {
+    if (!mouseEnabled) return;
+    setLastClick(encodeMouseClick(row, col, e.button));
+  };
+
+  return (
+    <div className="space-y-6">
+      <TerminalWindow>
+        <div className="space-y-4">
+          <div className="flex items-center gap-4 text-sm">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={mouseEnabled}
+                onChange={(e) => setMouseEnabled(e.target.checked)}
+                className="accent-primary h-4 w-4"
+              />
+              <span className="text-tertiary">
+                Mouse tracking{" "}
+                <span className={mouseEnabled ? "text-primary" : "text-quaternary"}>
+                  {mouseEnabled ? "enabled" : "disabled"}
+                </span>
+              </span>
+            </label>
+            <span className="text-quaternary text-xs">
+              <code className="text-secondary">^[[?1000h</code>
+            </span>
+          </div>
+
+          <div
+            ref={containerRef}
+            className={`border-primary grid w-full gap-0 border ${mouseEnabled ? "" : "opacity-50"}`}
+            style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+          >
+            {Array(GRID_ROWS)
+              .fill(null)
+              .map((_, row) =>
+                Array(cols)
+                  .fill(null)
+                  .map((_, col) => {
+                    const isClicked = lastClick?.x === col + 1 && lastClick?.y === row + 1;
+                    return (
+                      <div
+                        key={`${row}-${col}`}
+                        onClick={(e) => handleCellClick(row, col, e)}
+                        onContextMenu={(e) => {
+                          e.preventDefault();
+                          handleCellClick(row, col, e);
+                        }}
+                        className={`border-primary/80 flex h-5 cursor-crosshair items-center justify-center border-r border-b text-xs transition-colors ${isClicked ? "bg-primary text-white dark:text-neutral-950" : "hover:bg-tertiary"}`}
+                      >
+                        {isClicked ? "×" : ""}
+                      </div>
+                    );
+                  }),
+              )}
+          </div>
+
+          {lastClick && mouseEnabled ? (
+            <div className="space-y-3 p-4">
+              <div className="grid grid-cols-3 gap-4 text-center text-sm">
+                <div>
+                  <div className="text-quaternary mb-1 text-xs uppercase">Position</div>
+                  <div className="text-primary">
+                    ({lastClick.x}, {lastClick.y})
+                  </div>
+                </div>
+                <div>
+                  <div className="text-quaternary mb-1 text-xs uppercase">Button</div>
+                  <div className="text-secondary">
+                    {["Left", "Middle", "Right"][lastClick.button]}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-quaternary mb-1 text-xs uppercase">Sequence</div>
+                  <code className="text-secondary">{lastClick.sequence}</code>
+                </div>
+              </div>
+              <div className="text-center text-sm">
+                <span className="text-quaternary">Bytes: </span>
+                <code className="text-secondary">{lastClick.bytes}</code>
+              </div>
+            </div>
+          ) : (
+            <div className="text-tertiary py-4 text-center text-sm">
+              {mouseEnabled
+                ? "Click anywhere in the grid"
+                : "Enable mouse tracking to capture clicks"}
+            </div>
+          )}
+        </div>
+      </TerminalWindow>
+
+      <div className="text-tertiary text-sm">
+        By default, terminals don't send mouse events. Programs request mouse tracking, then clicks
+        become escape sequences with coordinates.
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/MouseDemo.tsx
+++ b/src/app/how-terminals-work/demos/MouseDemo.tsx
@@ -89,7 +89,7 @@ export function MouseDemo() {
                           e.preventDefault();
                           handleCellClick(row, col, e);
                         }}
-                        className={`border-primary/80 flex h-5 cursor-crosshair items-center justify-center border-r border-b text-xs transition-colors ${isClicked ? "bg-primary text-white dark:text-neutral-950" : "hover:bg-tertiary"}`}
+                        className={`border-primary/80 flex h-5 cursor-crosshair items-center justify-center border-r border-b text-xs transition-colors ${isClicked ? "bg-primary/10 text-primary" : "hover:bg-tertiary"}`}
                       >
                         {isClicked ? "×" : ""}
                       </div>

--- a/src/app/how-terminals-work/demos/SignalsDemo.tsx
+++ b/src/app/how-terminals-work/demos/SignalsDemo.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { Button, InfoPanel, StepDotsNavigation, SubsectionLabel } from "../ui";
+
+type Signal = "SIGINT" | "SIGTSTP";
+
+interface SignalInfo {
+  key: string;
+  signal: Signal;
+  name: string;
+  action: string;
+  description: string;
+  example: string;
+}
+
+const SIGNALS: SignalInfo[] = [
+  {
+    key: "Ctrl+C",
+    signal: "SIGINT",
+    name: "Interrupt",
+    action: "Stop the running program",
+    description:
+      "Sends SIGINT (signal interrupt) to the foreground process. Most programs respond by stopping immediately. It's how you cancel a long-running command or exit a program that's stuck.",
+    example: "Running `sleep 100` and pressing Ctrl+C stops it immediately.",
+  },
+  {
+    key: "Ctrl+Z",
+    signal: "SIGTSTP",
+    name: "Suspend",
+    action: "Pause and move to background",
+    description:
+      "Sends SIGTSTP (signal terminal stop) to suspend the process. The program pauses but stays in memory. Use `fg` to resume it in the foreground, or `bg` to continue it in the background.",
+    example: "Suspend vim with Ctrl+Z, run another command, then type `fg` to return.",
+  },
+];
+
+type ExplainerStep = "what" | "how" | "path" | "handling";
+
+const EXPLAINER_STEPS: Record<ExplainerStep, { title: string; description: string }> = {
+  what: {
+    title: "What Are Signals?",
+    description:
+      "Signals are a way for the operating system to communicate with running programs. When you press Ctrl+C, your terminal sends a byte (0x03) to the PTY—but the kernel intercepts it and converts it into a signal before your program ever sees it.",
+  },
+  how: {
+    title: "The Line Discipline",
+    description:
+      "The kernel's PTY has a component called the line discipline. It inspects every byte passing through. When it sees 0x03 (Ctrl+C) and signal handling is enabled, it generates SIGINT instead of passing the byte to the program. This happens in the kernel, not in your terminal emulator.",
+  },
+  path: {
+    title: "The Signal Path",
+    description:
+      "When you press Ctrl+C: 1) Your terminal sends byte 0x03 to the PTY master. 2) The kernel line discipline intercepts it. 3) Instead of forwarding the byte, it sends SIGINT to the foreground process group. 4) The process handles or terminates.",
+  },
+  handling: {
+    title: "Signal Handling",
+    description:
+      "Programs can choose how to handle signals. Some ignore Ctrl+C (like vim during certain operations). Some catch it to clean up before exiting. Some (like sleep) just die immediately. The default is to terminate.",
+  },
+};
+
+export function SignalsDemo() {
+  const [selectedSignal, setSelectedSignal] = useState<SignalInfo>(SIGNALS[0]);
+  const [terminalState, setTerminalState] = useState<
+    "idle" | "running" | "interrupted" | "suspended"
+  >("idle");
+  const [output, setOutput] = useState<string[]>(["$ "]);
+  const [currentStep, setCurrentStep] = useState<ExplainerStep>("what");
+
+  const steps = Object.keys(EXPLAINER_STEPS) as ExplainerStep[];
+  const stepContent = EXPLAINER_STEPS[currentStep];
+
+  const simulateCommand = useCallback(() => {
+    setTerminalState("running");
+    setOutput(["$ sleep 100", "sleeping..."]);
+  }, []);
+
+  // Apply the effect of a signal to the terminal state
+  const applySignalEffect = useCallback((signal: Signal) => {
+    if (signal === "SIGINT") {
+      setTerminalState("interrupted");
+      setOutput((prev) => [...prev, "^C", "$ "]);
+    } else if (signal === "SIGTSTP") {
+      setTerminalState("suspended");
+      setOutput((prev) => [...prev, "^Z", "[1]+  Stopped                 sleep 100", "$ "]);
+    }
+  }, []);
+
+  const simulateSignal = useCallback(
+    (signal: Signal) => {
+      if (terminalState !== "running") {
+        // Start a "command" first, then apply signal after delay
+        simulateCommand();
+        setTimeout(() => applySignalEffect(signal), 500);
+      } else {
+        applySignalEffect(signal);
+      }
+    },
+    [terminalState, simulateCommand, applySignalEffect],
+  );
+
+  const resetTerminal = useCallback(() => {
+    setTerminalState("idle");
+    setOutput(["$ "]);
+  }, []);
+
+  return (
+    <div className="space-y-8">
+      {/* Signal Glossary - side-by-side layout like VocabularyDemo */}
+      <div className="bg-tertiary border-primary flex flex-col border lg:flex-row">
+        {/* Signal list */}
+        <div className="border-primary p-4 lg:w-1/2 lg:border-r">
+          <div className="space-y-1 font-mono text-sm">
+            {SIGNALS.map((sig) => {
+              const isActive = selectedSignal.key === sig.key;
+              return (
+                <div
+                  key={sig.key}
+                  onMouseEnter={() => setSelectedSignal(sig)}
+                  className={`flex w-full cursor-default items-center justify-between px-3 py-3 text-left transition-all ${
+                    isActive
+                      ? "bg-tertiary border-primary border-l-2"
+                      : "border-l-2 border-transparent"
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <code className="text-secondary font-bold">{sig.key}</code>
+                    <span className="text-primary">{sig.name}</span>
+                  </div>
+                  <span className="text-secondary text-sm">{sig.signal}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Signal details */}
+        <div className="border-primary border-t p-4 lg:w-1/2 lg:border-t-0">
+          <div className="space-y-4">
+            <div>
+              <div className="flex items-center gap-3">
+                <code className="text-secondary text-base font-bold">{selectedSignal.key}</code>
+                <span className="text-quaternary">→</span>
+                <span className="text-primary font-bold">{selectedSignal.signal}</span>
+              </div>
+              <p className="text-tertiary mt-1 text-xs">{selectedSignal.action}</p>
+            </div>
+
+            <p className="text-tertiary text-sm leading-relaxed">{selectedSignal.description}</p>
+
+            <div className="bg-secondary border-primary border p-3 text-sm">
+              <span className="text-quaternary">Example: </span>
+              <span className="text-primary">{selectedSignal.example}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Interactive Terminal - now below the glossary */}
+      <div className="space-y-4">
+        <SubsectionLabel>Try It</SubsectionLabel>
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <TerminalWindow>
+            <div className="min-h-[180px] font-mono text-sm">
+              {output.map((line, idx) => {
+                const isLastLine = idx === output.length - 1;
+                const showCursor =
+                  isLastLine && (terminalState === "idle" || terminalState === "running");
+                return (
+                  <div key={idx} className={line.startsWith("^") ? "text-primary" : ""}>
+                    {line}
+                    {showCursor && <span className="cursor-blink">█</span>}
+                  </div>
+                );
+              })}
+            </div>
+          </TerminalWindow>
+
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" onClick={simulateCommand} disabled={terminalState === "running"}>
+                Run Command
+              </Button>
+              <Button size="sm" variant="secondary" onClick={() => simulateSignal("SIGINT")}>
+                Ctrl+C
+              </Button>
+              <Button size="sm" variant="secondary" onClick={() => simulateSignal("SIGTSTP")}>
+                Ctrl+Z
+              </Button>
+              <Button size="sm" variant="secondary" onClick={resetTerminal}>
+                Reset
+              </Button>
+            </div>
+
+            {terminalState !== "idle" && terminalState !== "running" && (
+              <div className="text-sm">
+                <span className="text-quaternary">State: </span>
+                <span
+                  className={terminalState === "interrupted" ? "text-primary" : "text-secondary"}
+                >
+                  {terminalState === "interrupted" && "Process interrupted (killed)"}
+                  {terminalState === "suspended" && "Process suspended (use `fg` to resume)"}
+                </span>
+              </div>
+            )}
+
+            <p className="text-quaternary text-sm">
+              Click "Run Command" to start a simulated process, then try sending different signals.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Explainer */}
+      <InfoPanel className="space-y-4 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="text-primary text-sm font-medium">{stepContent.title}</div>
+          <StepDotsNavigation
+            steps={steps}
+            currentStep={currentStep}
+            onStepChange={setCurrentStep}
+          />
+        </div>
+        <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
+      </InfoPanel>
+
+      {/* Signal vs Character Comparison */}
+      <div className="bg-tertiary border-primary space-y-4 border p-6">
+        <h3 className="text-primary text-sm font-bold">Signals vs Regular Keys</h3>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="bg-secondary border-primary space-y-3 border p-4">
+            <div className="text-primary text-sm font-bold">Regular Keys</div>
+            <div className="space-y-1 font-mono text-sm">
+              <div>
+                <span className="text-secondary">a</span>
+                <span className="text-quaternary"> → </span>
+                <span className="text-secondary">0x61</span>
+                <span className="text-tertiary"> (character sent to program)</span>
+              </div>
+              <div>
+                <span className="text-secondary">Enter</span>
+                <span className="text-quaternary"> → </span>
+                <span className="text-secondary">0x0D</span>
+                <span className="text-tertiary"> (carriage return)</span>
+              </div>
+              <div>
+                <span className="text-secondary">↑</span>
+                <span className="text-quaternary"> → </span>
+                <span className="text-secondary">^[[A</span>
+                <span className="text-tertiary"> (escape sequence)</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-secondary border-primary space-y-3 border p-4">
+            <div className="text-primary text-sm font-bold">Signal Keys</div>
+            <div className="space-y-1 font-mono text-sm">
+              <div>
+                <span className="text-secondary">Ctrl+C</span>
+                <span className="text-quaternary"> → </span>
+                <span className="text-secondary">0x03</span>
+                <span className="text-quaternary"> → </span>
+                <span className="text-primary">SIGINT</span>
+              </div>
+              <div>
+                <span className="text-secondary">Ctrl+Z</span>
+                <span className="text-quaternary"> → </span>
+                <span className="text-secondary">0x1A</span>
+                <span className="text-quaternary"> → </span>
+                <span className="text-primary">SIGTSTP</span>
+              </div>
+              <div className="text-quaternary mt-2 text-xs">
+                Bytes intercepted by line discipline → converted to signals
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-quaternary text-sm">
+          Regular keys become bytes that flow through the PTY to the program. Signal keys also
+          become bytes, but the kernel's line discipline intercepts them and generates OS signals
+          before they reach the program.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/SignalsDemo.tsx
+++ b/src/app/how-terminals-work/demos/SignalsDemo.tsx
@@ -110,9 +110,9 @@ export function SignalsDemo() {
   return (
     <div className="space-y-8">
       {/* Signal Glossary - side-by-side layout like VocabularyDemo */}
-      <div className="bg-tertiary border-primary flex flex-col border lg:flex-row">
+      <div className="flex flex-col gap-8 lg:flex-row">
         {/* Signal list */}
-        <div className="border-primary p-4 lg:w-1/2 lg:border-r">
+        <div className="lg:w-1/2">
           <div className="space-y-1 font-mono text-sm">
             {SIGNALS.map((sig) => {
               const isActive = selectedSignal.key === sig.key;
@@ -122,7 +122,7 @@ export function SignalsDemo() {
                   onMouseEnter={() => setSelectedSignal(sig)}
                   className={`flex w-full cursor-default items-center justify-between px-3 py-3 text-left transition-all ${
                     isActive
-                      ? "bg-tertiary border-primary border-l-2"
+                      ? "bg-primary/10 border-primary border-l-2"
                       : "border-l-2 border-transparent"
                   }`}
                 >
@@ -138,7 +138,7 @@ export function SignalsDemo() {
         </div>
 
         {/* Signal details */}
-        <div className="border-primary border-t p-4 lg:w-1/2 lg:border-t-0">
+        <div className="lg:w-1/2">
           <div className="space-y-4">
             <div>
               <div className="flex items-center gap-3">
@@ -151,7 +151,7 @@ export function SignalsDemo() {
 
             <p className="text-tertiary text-sm leading-relaxed">{selectedSignal.description}</p>
 
-            <div className="bg-secondary border-primary border p-3 text-sm">
+            <div className="text-sm">
               <span className="text-quaternary">Example: </span>
               <span className="text-primary">{selectedSignal.example}</span>
             </div>
@@ -215,7 +215,7 @@ export function SignalsDemo() {
       </div>
 
       {/* Explainer */}
-      <InfoPanel className="space-y-4 p-4">
+      <InfoPanel className="space-y-4">
         <div className="flex items-start justify-between gap-4">
           <div className="text-primary text-sm font-medium">{stepContent.title}</div>
           <StepDotsNavigation
@@ -228,12 +228,12 @@ export function SignalsDemo() {
       </InfoPanel>
 
       {/* Signal vs Character Comparison */}
-      <div className="bg-tertiary border-primary space-y-4 border p-6">
-        <h3 className="text-primary text-sm font-bold">Signals vs Regular Keys</h3>
+      <div className="space-y-4">
+        <h3 className="text-primary text-sm font-medium">Signals vs Regular Keys</h3>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <div className="bg-secondary border-primary space-y-3 border p-4">
-            <div className="text-primary text-sm font-bold">Regular Keys</div>
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+          <div className="space-y-3">
+            <div className="text-primary text-sm font-medium">Regular Keys</div>
             <div className="space-y-1 font-mono text-sm">
               <div>
                 <span className="text-secondary">a</span>
@@ -256,8 +256,8 @@ export function SignalsDemo() {
             </div>
           </div>
 
-          <div className="bg-secondary border-primary space-y-3 border p-4">
-            <div className="text-primary text-sm font-bold">Signal Keys</div>
+          <div className="space-y-3">
+            <div className="text-primary text-sm font-medium">Signal Keys</div>
             <div className="space-y-1 font-mono text-sm">
               <div>
                 <span className="text-secondary">Ctrl+C</span>

--- a/src/app/how-terminals-work/demos/StateManagementDemo.tsx
+++ b/src/app/how-terminals-work/demos/StateManagementDemo.tsx
@@ -187,12 +187,12 @@ export function StateManagementDemo() {
 
         {/* State Inspector */}
         {showStateInspector && (
-          <div className="bg-secondary border-primary space-y-4 border p-4">
-            <div className="text-primary text-sm font-bold">
+          <div className="border-primary space-y-4 border p-4">
+            <div className="text-primary text-sm font-medium">
               State Inspector (What the App Remembers)
             </div>
-            <div className="grid grid-cols-1 gap-4 font-mono text-xs md:grid-cols-2">
-              <div className="bg-tertiary space-y-2 p-3">
+            <div className="grid grid-cols-1 gap-4 font-mono text-xs lg:grid-cols-2">
+              <div className="space-y-2">
                 <div className="text-quaternary">// Current state variables</div>
                 <div>
                   <span className="text-secondary">currentMode</span>:{" "}
@@ -207,7 +207,7 @@ export function StateManagementDemo() {
                   <span className="text-secondary">{history.length}</span>
                 </div>
               </div>
-              <div className="bg-tertiary space-y-2 p-3">
+              <div className="space-y-2">
                 <div className="text-quaternary">// Render output for mode indicator</div>
                 <div className="text-primary">
                   <span className="text-secondary">moveCursor</span>(3, 1);
@@ -229,7 +229,7 @@ export function StateManagementDemo() {
 
       {/* How it works explanation */}
       <div className="space-y-4">
-        <div className="bg-tertiary border-primary space-y-4 border px-4 py-4">
+        <div className="space-y-4">
           <div className="flex items-start justify-between gap-4">
             <div className="text-primary text-sm font-medium">{stepContent.title}</div>
             <StepDotsNavigation
@@ -242,7 +242,7 @@ export function StateManagementDemo() {
             <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
 
             {currentStep === "memory" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// App's internal state (in memory)</div>
                 <div className="space-y-1">
                   <div>
@@ -266,7 +266,7 @@ export function StateManagementDemo() {
             )}
 
             {currentStep === "rendering" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// On mode change:</div>
                 <div className="space-y-1">
                   <div>
@@ -297,7 +297,7 @@ export function StateManagementDemo() {
             )}
 
             {currentStep === "input-handling" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// Shift+Tab byte sequence</div>
                 <div className="space-y-1">
                   <div>
@@ -325,7 +325,7 @@ export function StateManagementDemo() {
             )}
 
             {currentStep === "persistence" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// State persistence options</div>
                 <div className="space-y-1">
                   <div>
@@ -350,10 +350,10 @@ export function StateManagementDemo() {
       </div>
 
       {/* The data flow breakdown */}
-      <div className="bg-tertiary border-primary space-y-6 border p-6">
-        <h3 className="text-primary text-sm font-bold">The State Update Cycle</h3>
+      <div className="space-y-6">
+        <h3 className="text-primary text-sm font-medium">The State Update Cycle</h3>
 
-        <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
+        <div className="flex flex-col items-start justify-between gap-6 lg:flex-row">
           <FeatureBox number={1} title="Input" className="flex-1">
             <div className="text-quaternary text-sm">User presses Shift+Tab</div>
             <div className="text-secondary mt-2 font-mono text-xs">ESC [ Z</div>

--- a/src/app/how-terminals-work/demos/StateManagementDemo.tsx
+++ b/src/app/how-terminals-work/demos/StateManagementDemo.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { FeatureBox, StepDotsNavigation } from "../ui";
+
+// Simulating different modes like Claude Code's accept edits / plan mode toggle
+type Mode = "accept" | "plan" | "chat";
+
+interface ModeConfig {
+  name: string;
+  indicator: string;
+  colorClass: string;
+  colorName: string;
+}
+
+const MODES: Record<Mode, ModeConfig> = {
+  accept: {
+    name: "accept edits on",
+    indicator: ">>",
+    colorClass: "text-secondary",
+    colorName: "MAGENTA",
+  },
+  plan: {
+    name: "plan mode",
+    indicator: "??",
+    colorClass: "text-secondary",
+    colorName: "YELLOW",
+  },
+  chat: {
+    name: "chat mode",
+    indicator: "~~",
+    colorClass: "text-secondary",
+    colorName: "CYAN",
+  },
+};
+
+const MODE_ORDER: Mode[] = ["accept", "plan", "chat"];
+
+type ExplainerStep = "overview" | "memory" | "rendering" | "input-handling" | "persistence";
+
+interface StepContent {
+  title: string;
+  description: string;
+}
+
+const EXPLAINER_STEPS: Record<ExplainerStep, StepContent> = {
+  overview: {
+    title: "State in Terminal Apps",
+    description:
+      "Terminal apps maintain state in memory just like GUI apps. The difference is how they display it: by printing characters to specific positions. When state changes, they redraw the relevant parts of the screen.",
+  },
+  memory: {
+    title: "Where State Lives",
+    description:
+      "The app keeps variables in memory: currentMode, inputBuffer, history, etc. These are just regular program variables. The terminal itself doesn't store your app's state—it only displays whatever characters you send it.",
+  },
+  rendering: {
+    title: "Rendering State Changes",
+    description:
+      "When the mode changes, the app: 1) Updates the variable in memory, 2) Moves the cursor to where the indicator is displayed, 3) Clears that region, 4) Prints the new indicator with appropriate colors. The user sees a seamless transition.",
+  },
+  "input-handling": {
+    title: "Input Triggers State Changes",
+    description:
+      "Key combinations like Shift+Tab are just byte sequences. The app receives these bytes, recognizes the pattern, updates internal state, and re-renders. The terminal doesn't know anything about 'modes'—it just passes bytes through.",
+  },
+  persistence: {
+    title: "Persistence & Sessions",
+    description:
+      "Terminal apps can save state to files (config, history) but lose in-memory state when they exit. Some apps use the terminal's alternate screen buffer—when they exit, the original screen content is restored, as if the app was never there.",
+  },
+};
+
+export function StateManagementDemo() {
+  const [currentMode, setCurrentMode] = useState<Mode>("accept");
+  const [inputValue, setInputValue] = useState("");
+  const [history, setHistory] = useState<{ mode: Mode; text: string }[]>([]);
+  const [currentStep, setCurrentStep] = useState<ExplainerStep>("overview");
+  const [showStateInspector, setShowStateInspector] = useState(false);
+  const [lastKeySequence, setLastKeySequence] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const cycleMode = useCallback(() => {
+    const currentIndex = MODE_ORDER.indexOf(currentMode);
+    const nextIndex = (currentIndex + 1) % MODE_ORDER.length;
+    setCurrentMode(MODE_ORDER[nextIndex]!);
+    setLastKeySequence("Shift+Tab → cycle mode");
+    setTimeout(() => setLastKeySequence(null), 1500);
+  }, [currentMode]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Tab" && e.shiftKey) {
+        e.preventDefault();
+        cycleMode();
+      } else if (e.key === "Enter" && inputValue.trim()) {
+        e.preventDefault();
+        setHistory((prev) => [...prev, { mode: currentMode, text: inputValue }].slice(-5));
+        setInputValue("");
+        setLastKeySequence("Enter → submit");
+        setTimeout(() => setLastKeySequence(null), 1500);
+      }
+    },
+    [cycleMode, currentMode, inputValue],
+  );
+
+  const modeConfig = MODES[currentMode];
+  const steps = Object.keys(EXPLAINER_STEPS) as ExplainerStep[];
+  const stepContent = EXPLAINER_STEPS[currentStep];
+
+  return (
+    <div className="space-y-8">
+      {/* Interactive Demo */}
+      <div className="space-y-4">
+        <TerminalWindow>
+          <div
+            className="min-h-[280px] cursor-text font-mono text-sm"
+            onClick={() => inputRef.current?.focus()}
+          >
+            {/* History */}
+            {history.length > 0 && (
+              <div className="mb-4 space-y-2 opacity-60">
+                {history.map((entry, i) => (
+                  <div key={i} className="flex gap-2">
+                    <span className={`${MODES[entry.mode].colorClass}`}>
+                      {MODES[entry.mode].indicator}
+                    </span>
+                    <span className="text-quaternary">{entry.text}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Current prompt line */}
+            <div className="flex items-start gap-2">
+              <span className="text-quaternary">&gt;</span>
+              <div className="flex-1">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="text-primary w-full bg-transparent outline-none"
+                  placeholder="Type something and press Enter..."
+                />
+              </div>
+            </div>
+
+            {/* Mode indicator line - this is what we're explaining */}
+            <div className="mt-2 flex items-center gap-2">
+              <span className={`${modeConfig.colorClass} transition-colors duration-200`}>
+                {modeConfig.indicator}
+              </span>
+              <span className={`${modeConfig.colorClass} transition-colors duration-200`}>
+                {modeConfig.name}
+              </span>
+              <span className="text-quaternary">(shift+tab to cycle)</span>
+            </div>
+            {lastKeySequence && (
+              <div className="text-quaternary mt-2 text-xs">{lastKeySequence}</div>
+            )}
+          </div>
+        </TerminalWindow>
+
+        {/* Controls */}
+        <div className="flex flex-wrap gap-2 text-sm">
+          <button
+            onClick={cycleMode}
+            className="border-primary hover:border-primary border px-3 py-1.5 transition-colors"
+          >
+            Cycle Mode (Shift+Tab)
+          </button>
+          <button
+            onClick={() => setShowStateInspector(!showStateInspector)}
+            className={`border px-3 py-1.5 transition-colors ${
+              showStateInspector
+                ? "bg-primary/10 border-primary text-primary"
+                : "border-primary hover:border-primary"
+            }`}
+          >
+            {showStateInspector ? "Hide" : "Show"} State Inspector
+          </button>
+        </div>
+
+        {/* State Inspector */}
+        {showStateInspector && (
+          <div className="bg-secondary border-primary space-y-4 border p-4">
+            <div className="text-primary text-sm font-bold">
+              State Inspector (What the App Remembers)
+            </div>
+            <div className="grid grid-cols-1 gap-4 font-mono text-xs md:grid-cols-2">
+              <div className="bg-tertiary space-y-2 p-3">
+                <div className="text-quaternary">// Current state variables</div>
+                <div>
+                  <span className="text-secondary">currentMode</span>:{" "}
+                  <span className={`${modeConfig.colorClass}`}>"{currentMode}"</span>
+                </div>
+                <div>
+                  <span className="text-secondary">inputBuffer</span>:{" "}
+                  <span className="text-primary">"{inputValue}"</span>
+                </div>
+                <div>
+                  <span className="text-secondary">historyLength</span>:{" "}
+                  <span className="text-secondary">{history.length}</span>
+                </div>
+              </div>
+              <div className="bg-tertiary space-y-2 p-3">
+                <div className="text-quaternary">// Render output for mode indicator</div>
+                <div className="text-primary">
+                  <span className="text-secondary">moveCursor</span>(3, 1);
+                </div>
+                <div className="text-primary">
+                  <span className="text-secondary">setColor</span>(
+                  <span className={`${modeConfig.colorClass}`}>{modeConfig.colorName}</span>
+                  );
+                </div>
+                <div className="text-primary">
+                  <span className="text-secondary">print</span>("
+                  {modeConfig.indicator} {modeConfig.name}");
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* How it works explanation */}
+      <div className="space-y-4">
+        <div className="bg-tertiary border-primary space-y-4 border px-4 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="text-primary text-sm font-medium">{stepContent.title}</div>
+            <StepDotsNavigation
+              steps={steps}
+              currentStep={currentStep}
+              onStepChange={setCurrentStep}
+            />
+          </div>
+          <div className="space-y-4">
+            <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
+
+            {currentStep === "memory" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// App's internal state (in memory)</div>
+                <div className="space-y-1">
+                  <div>
+                    <span className="text-secondary">struct</span> AppState {"{"}
+                  </div>
+                  <div className="ml-4">
+                    <span className="text-secondary">mode</span>: Mode,
+                  </div>
+                  <div className="ml-4">
+                    <span className="text-secondary">input_buffer</span>: String,
+                  </div>
+                  <div className="ml-4">
+                    <span className="text-secondary">history</span>: Vec&lt;Entry&gt;,
+                  </div>
+                  <div className="ml-4">
+                    <span className="text-secondary">cursor_pos</span>: (u16, u16),
+                  </div>
+                  <div>{"}"}</div>
+                </div>
+              </div>
+            )}
+
+            {currentStep === "rendering" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// On mode change:</div>
+                <div className="space-y-1">
+                  <div>
+                    <span className="text-secondary">1.</span>{" "}
+                    <span className="text-secondary">state.mode</span> = new_mode;
+                  </div>
+                  <div>
+                    <span className="text-secondary">2.</span>{" "}
+                    <span className="text-primary">print!("\x1b[3;1H")</span>;{" "}
+                    <span className="text-quaternary">// move to line 3</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">3.</span>{" "}
+                    <span className="text-primary">print!("\x1b[2K")</span>;{" "}
+                    <span className="text-quaternary">// clear line</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">4.</span>{" "}
+                    <span className="text-primary">print!("\x1b[35m")</span>;{" "}
+                    <span className="text-quaternary">// set color</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">5. </span>{" "}
+                    <span className="text-primary">print!("{">> accept edits on"}")</span>;
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {currentStep === "input-handling" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// Shift+Tab byte sequence</div>
+                <div className="space-y-1">
+                  <div>
+                    Bytes received: <span className="text-secondary">1b 5b 5a</span>
+                  </div>
+                  <div>
+                    Sequence: <span className="text-secondary">ESC [ Z</span> (CSI Z = Shift+Tab)
+                  </div>
+                  <div className="text-quaternary mt-2">// App's key handler:</div>
+                  <div>
+                    <span className="text-secondary">match</span> key {"{"}
+                  </div>
+                  <div className="ml-4">
+                    ShiftTab =&gt; <span className="text-secondary">cycle_mode()</span>,
+                  </div>
+                  <div className="ml-4">
+                    Enter =&gt; <span className="text-secondary">submit_input()</span>,
+                  </div>
+                  <div className="ml-4">
+                    _ =&gt; <span className="text-secondary">append_to_buffer(key)</span>,
+                  </div>
+                  <div>{"}"}</div>
+                </div>
+              </div>
+            )}
+
+            {currentStep === "persistence" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// State persistence options</div>
+                <div className="space-y-1">
+                  <div>
+                    <span className="text-primary">~/.config/app/settings.json</span>{" "}
+                    <span className="text-quaternary">— user preferences</span>
+                  </div>
+                  <div>
+                    <span className="text-primary">~/.local/state/app/history</span>{" "}
+                    <span className="text-quaternary">— command history</span>
+                  </div>
+                  <div>
+                    <span className="text-primary">/tmp/app.sock</span>{" "}
+                    <span className="text-quaternary">— inter-process state</span>
+                  </div>
+                  <div className="text-quaternary mt-2">// But current mode? Just in memory.</div>
+                  <div className="text-quaternary">// When you restart, it resets to default.</div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* The data flow breakdown */}
+      <div className="bg-tertiary border-primary space-y-6 border p-6">
+        <h3 className="text-primary text-sm font-bold">The State Update Cycle</h3>
+
+        <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
+          <FeatureBox number={1} title="Input" className="flex-1">
+            <div className="text-quaternary text-sm">User presses Shift+Tab</div>
+            <div className="text-secondary mt-2 font-mono text-xs">ESC [ Z</div>
+          </FeatureBox>
+          <div className="text-quaternary hidden text-2xl md:block"></div>
+          <FeatureBox number={2} title="Process" className="flex-1">
+            <div className="text-quaternary text-sm">App recognizes sequence</div>
+            <div className="text-secondary mt-2 font-mono text-xs">mode = nextMode()</div>
+          </FeatureBox>
+          <div className="text-quaternary hidden text-2xl md:block"></div>
+          <FeatureBox number={3} title="Render" className="flex-1">
+            <div className="text-quaternary text-sm">Redraw mode indicator</div>
+            <div className="text-primary mt-2 font-mono text-xs">print(indicator)</div>
+          </FeatureBox>
+        </div>
+
+        <div className="text-quaternary text-sm">
+          The terminal never "knows" about modes. It just displays whatever characters the app
+          sends. All the intelligence—tracking state, responding to input, deciding what to
+          draw—lives in the app.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/TextSelectionDemo.tsx
+++ b/src/app/how-terminals-work/demos/TextSelectionDemo.tsx
@@ -1,0 +1,506 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { TerminalWindow } from "../ui";
+import { StepDotsNavigation } from "../ui";
+
+type SelectionMode = "terminal" | "app";
+
+const SAMPLE_TEXT = [
+  "~/projects $ ls -la",
+  "total 24",
+  "drwxr-xr-x  5 user staff  160 Jan  7 10:00 .",
+  "drwxr-xr-x 12 user staff  384 Jan  6 15:30 ..",
+  "-rw-r--r--  1 user staff  234 Jan  7 09:45 README.md",
+  "-rw-r--r--  1 user staff 1024 Jan  7 10:00 index.ts",
+  "drwxr-xr-x  3 user staff   96 Jan  5 14:20 src",
+  '~/projects $ echo "Hello, World!"',
+  "Hello, World!",
+  "~/projects $ _",
+];
+
+interface CursorPosition {
+  row: number;
+  col: number;
+}
+
+type ExplainerStep =
+  | "overview"
+  | "terminal-selection"
+  | "cursor-positioning"
+  | "option-click"
+  | "why-different";
+
+const EXPLAINER_STEPS: Record<ExplainerStep, { title: string; description: string }> = {
+  overview: {
+    title: "Two Types of Selection",
+    description:
+      "In terminals, there are two completely different 'selections': terminal-level text selection (what the terminal emulator handles) and cursor position (where the app thinks the cursor is). They're independent and often confuse people.",
+  },
+  "terminal-selection": {
+    title: "Terminal-Level Selection",
+    description:
+      "When you click and drag in a terminal, the terminal emulator (iTerm, Terminal.app, etc.) handles selection. It's highlighting text on screen for copy/paste. The running program doesn't know you're selecting—it just sees characters on a grid.",
+  },
+  "cursor-positioning": {
+    title: "App Cursor Position",
+    description:
+      "The blinking cursor in vim or your shell prompt is controlled by the app, not the terminal. The app sends escape sequences like ESC[5;10H to move the cursor to row 5, column 10. Clicking on the screen doesn't automatically move this cursor.",
+  },
+  "option-click": {
+    title: "Option+Click: The Bridge",
+    description:
+      "Some terminals support Option+Click (or Alt+Click) to move the cursor. When you do this, the terminal calculates where you clicked and sends arrow key sequences to move the cursor there. It's simulating keypresses, not directly moving the cursor!",
+  },
+  "why-different": {
+    title: "Why They're Separate",
+    description:
+      "The terminal is just a character display. It doesn't know if you're in vim (where clicking should move cursor) or running 'cat' (where there's no cursor). The app must opt into mouse handling. Without it, clicks are just for terminal-level selection.",
+  },
+};
+
+export function TextSelectionDemo() {
+  const [mode, setMode] = useState<SelectionMode>("terminal");
+  const [cursorPos, setCursorPos] = useState<CursorPosition>({
+    row: 9,
+    col: 15,
+  });
+  const [selectedRange, setSelectedRange] = useState<{
+    start: CursorPosition;
+    end: CursorPosition;
+  } | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState<CursorPosition | null>(null);
+  const [showArrowKeys, setShowArrowKeys] = useState<string[]>([]);
+  const [currentStep, setCurrentStep] = useState<ExplainerStep>("overview");
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const handleCellMouseDown = useCallback(
+    (row: number, col: number, e: React.MouseEvent) => {
+      e.preventDefault();
+
+      if (mode === "terminal") {
+        // Terminal selection mode - start drag selection
+        setIsDragging(true);
+        setDragStart({ row, col });
+        setSelectedRange({ start: { row, col }, end: { row, col } });
+      } else {
+        // App mode with option click - show cursor movement
+        if (e.altKey) {
+          // Option+click - calculate arrow keys needed
+          const arrows: string[] = [];
+          const rowDiff = row - cursorPos.row;
+          const colDiff = col - cursorPos.col;
+
+          if (rowDiff > 0) for (let i = 0; i < rowDiff; i++) arrows.push("↓");
+          if (rowDiff < 0) for (let i = 0; i < -rowDiff; i++) arrows.push("↑");
+          if (colDiff > 0) for (let i = 0; i < colDiff; i++) arrows.push("→");
+          if (colDiff < 0) for (let i = 0; i < -colDiff; i++) arrows.push("←");
+
+          setShowArrowKeys(arrows);
+          setCursorPos({ row, col });
+
+          // Clear arrow display after animation
+          setTimeout(() => setShowArrowKeys([]), 1500);
+        }
+      }
+    },
+    [mode, cursorPos],
+  );
+
+  const handleCellMouseMove = useCallback(
+    (row: number, col: number) => {
+      if (isDragging && dragStart && mode === "terminal") {
+        setSelectedRange({ start: dragStart, end: { row, col } });
+      }
+    },
+    [isDragging, dragStart, mode],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+    setDragStart(null);
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => document.removeEventListener("mouseup", handleMouseUp);
+  }, [handleMouseUp]);
+
+  const isInSelection = useCallback(
+    (row: number, col: number): boolean => {
+      if (!selectedRange) return false;
+
+      // Normalize selection direction (start should be before end in reading order)
+      let startRow = selectedRange.start.row;
+      let startCol = selectedRange.start.col;
+      let endRow = selectedRange.end.row;
+      let endCol = selectedRange.end.col;
+
+      // Swap if selection is backwards
+      if (startRow > endRow || (startRow === endRow && startCol > endCol)) {
+        [startRow, endRow] = [endRow, startRow];
+        [startCol, endCol] = [endCol, startCol];
+      }
+
+      // Line-based selection like real terminals:
+      // - First row: from startCol to end of line
+      // - Middle rows: entire line
+      // - Last row: from start to endCol
+      if (startRow === endRow) {
+        // Single row selection
+        return row === startRow && col >= startCol && col <= endCol;
+      } else {
+        // Multi-row selection
+        if (row === startRow) {
+          // First row: from start column to end of line
+          return col >= startCol;
+        } else if (row === endRow) {
+          // Last row: from start of line to end column
+          return col <= endCol;
+        } else if (row > startRow && row < endRow) {
+          // Middle rows: entire line
+          return true;
+        }
+        return false;
+      }
+    },
+    [selectedRange],
+  );
+
+  const getSelectedText = useCallback((): string => {
+    if (!selectedRange) return "";
+
+    // Normalize selection direction
+    let startRow = selectedRange.start.row;
+    let startCol = selectedRange.start.col;
+    let endRow = selectedRange.end.row;
+    let endCol = selectedRange.end.col;
+
+    if (startRow > endRow || (startRow === endRow && startCol > endCol)) {
+      [startRow, endRow] = [endRow, startRow];
+      [startCol, endCol] = [endCol, startCol];
+    }
+
+    const lines: string[] = [];
+    for (let r = startRow; r <= endRow; r++) {
+      const line = SAMPLE_TEXT[r] || "";
+      if (startRow === endRow) {
+        // Single row
+        lines.push(line.slice(startCol, endCol + 1));
+      } else if (r === startRow) {
+        // First row: from startCol to end
+        lines.push(line.slice(startCol));
+      } else if (r === endRow) {
+        // Last row: from start to endCol
+        lines.push(line.slice(0, endCol + 1));
+      } else {
+        // Middle rows: entire line
+        lines.push(line);
+      }
+    }
+    return lines.join("\n");
+  }, [selectedRange]);
+
+  const steps = Object.keys(EXPLAINER_STEPS) as ExplainerStep[];
+  const stepContent = EXPLAINER_STEPS[currentStep];
+
+  // Get max line length for grid
+  const maxCols = Math.max(...SAMPLE_TEXT.map((line) => line.length), 40);
+
+  return (
+    <div className="space-y-8">
+      {/* Interactive Demo */}
+      <div className="space-y-4">
+        <TerminalWindow>
+          <div className="space-y-4">
+            {/* Mode Toggle */}
+            <div className="flex items-center gap-4 text-sm">
+              <span className="text-quaternary">Mode:</span>
+              <button
+                onClick={() => {
+                  setMode("terminal");
+                  setSelectedRange(null);
+                  setShowArrowKeys([]);
+                }}
+                className={`px-3 py-1 transition-colors ${
+                  mode === "terminal"
+                    ? "bg-tertiary text-white dark:text-neutral-950"
+                    : "border-primary hover:border-primary border"
+                }`}
+              >
+                Terminal Selection
+              </button>
+              <button
+                onClick={() => {
+                  setMode("app");
+                  setSelectedRange(null);
+                }}
+                className={`px-3 py-1 transition-colors ${
+                  mode === "app"
+                    ? "bg-primary text-white dark:text-neutral-950"
+                    : "border-primary hover:border-primary border"
+                }`}
+              >
+                App Cursor (Option+Click)
+              </button>
+            </div>
+
+            {/* Terminal Grid */}
+            <div
+              ref={gridRef}
+              className="bg-secondary border-primary overflow-x-auto rounded border p-4 font-mono text-sm"
+              style={{ userSelect: "none" }}
+            >
+              {SAMPLE_TEXT.map((line, row) => (
+                <div key={row} className="flex whitespace-pre">
+                  {Array(maxCols)
+                    .fill(null)
+                    .map((_, col) => {
+                      const char = line[col] || " ";
+                      const isSelected = mode === "terminal" && isInSelection(row, col);
+                      const isCursor =
+                        mode === "app" && cursorPos.row === row && cursorPos.col === col;
+
+                      return (
+                        <span
+                          key={col}
+                          onMouseDown={(e) => handleCellMouseDown(row, col, e)}
+                          onMouseMove={() => handleCellMouseMove(row, col)}
+                          className={`inline-block h-[1.4em] w-[0.6em] text-center leading-[1.4em] transition-colors ${isSelected ? "bg-white text-black" : ""} ${isCursor ? "bg-primary text-white dark:text-neutral-950" : ""} ${mode === "terminal" ? "cursor-text" : "cursor-pointer"} `}
+                        >
+                          {char === "_" && row === SAMPLE_TEXT.length - 1 && col === 15 ? (
+                            <span>_</span>
+                          ) : (
+                            char
+                          )}
+                        </span>
+                      );
+                    })}
+                </div>
+              ))}
+            </div>
+
+            {/* Status Area */}
+            <div className="min-h-[80px] rounded">
+              {mode === "terminal" ? (
+                selectedRange ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-4">
+                      <span className="text-quaternary text-sm">Selected:</span>
+                      <code className="text-secondary text-sm">
+                        ({selectedRange.start.row},{selectedRange.start.col}) to (
+                        {selectedRange.end.row},{selectedRange.end.col})
+                      </code>
+                    </div>
+                    <div className="text-quaternary text-sm">
+                      The app doesn't know about this selection. It's handled entirely by the
+                      terminal emulator for copy/paste.
+                    </div>
+                    {getSelectedText() && (
+                      <div className="mt-2">
+                        <span className="text-quaternary text-sm">Would copy: </span>
+                        <code className="text-secondary bg-tertiary px-2 py-1 text-xs">
+                          {getSelectedText().slice(0, 50)}
+                          {getSelectedText().length > 50 ? "..." : ""}
+                        </code>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="text-quaternary p-4 text-center text-sm text-pretty">
+                    Click and drag to select text. This is handled by the terminal, not the running
+                    program.
+                  </div>
+                )
+              ) : (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-4">
+                    <span className="text-quaternary text-sm">Cursor position:</span>
+                    <code className="text-primary text-sm">
+                      row {cursorPos.row + 1}, col {cursorPos.col + 1}
+                    </code>
+                  </div>
+                  {showArrowKeys.length > 0 ? (
+                    <div className="space-y-2">
+                      <div className="text-quaternary text-sm">Arrow keys sent by terminal:</div>
+                      <div className="flex flex-wrap gap-1">
+                        {showArrowKeys.map((arrow, i) => (
+                          <span
+                            key={i}
+                            className="bg-tertiary/20 text-secondary inline-block px-2 py-0.5 font-mono text-xs"
+                          >
+                            {arrow}
+                          </span>
+                        ))}
+                      </div>
+                      <div className="text-quaternary text-xs">
+                        The terminal simulates {showArrowKeys.length} keypresses to move the cursor!
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="text-quaternary text-sm">
+                      Hold <kbd className="bg-tertiary rounded px-1">Option</kbd> and click anywhere
+                      to move the cursor. Watch the arrow key simulation!
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </TerminalWindow>
+      </div>
+
+      {/* How it works explanation */}
+      <div className="space-y-4">
+        <div className="bg-tertiary border-primary space-y-4 border px-4 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="text-primary text-sm font-medium">{stepContent.title}</div>
+            <StepDotsNavigation
+              steps={steps}
+              currentStep={currentStep}
+              onStepChange={setCurrentStep}
+            />
+          </div>
+          <div className="space-y-4">
+            <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
+
+            {currentStep === "terminal-selection" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// Terminal emulator handles selection</div>
+                <div className="space-y-1">
+                  <div>
+                    <span className="text-secondary">1.</span> You click at position (5, 10)
+                  </div>
+                  <div>
+                    <span className="text-secondary">2.</span> Terminal emulator stores selection
+                    start
+                  </div>
+                  <div>
+                    <span className="text-secondary">3.</span> You drag to (5, 20)
+                  </div>
+                  <div>
+                    <span className="text-secondary">4.</span> Terminal highlights cells &amp;
+                    stores in clipboard
+                  </div>
+                  <div className="text-quaternary mt-2">// The running program sees NOTHING</div>
+                  <div className="text-quaternary">// (unless it enabled mouse tracking)</div>
+                </div>
+              </div>
+            )}
+
+            {currentStep === "cursor-positioning" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// App controls cursor with escape sequences</div>
+                <div className="space-y-1">
+                  <div>
+                    <span className="text-primary">ESC[H</span>{" "}
+                    <span className="text-quaternary">— move cursor to (1,1)</span>
+                  </div>
+                  <div>
+                    <span className="text-primary">ESC[5;10H</span>{" "}
+                    <span className="text-quaternary">— move to row 5, col 10</span>
+                  </div>
+                  <div>
+                    <span className="text-primary">ESC[A</span>{" "}
+                    <span className="text-quaternary">— move cursor up one line</span>
+                  </div>
+                  <div>
+                    <span className="text-primary">ESC[C</span>{" "}
+                    <span className="text-quaternary">— move cursor right one col</span>
+                  </div>
+                  <div className="text-quaternary mt-2">// Terminal just obeys these commands</div>
+                  <div className="text-quaternary">// It doesn't move cursor on click!</div>
+                </div>
+              </div>
+            )}
+
+            {currentStep === "option-click" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// Option+Click at (5, 15), cursor at (3, 5)</div>
+                <div className="space-y-1">
+                  <div>
+                    <span className="text-secondary">1.</span> Terminal calculates: need to go down
+                    2, right 10
+                  </div>
+                  <div>
+                    <span className="text-secondary">2.</span> Terminal sends:{" "}
+                    <span className="text-secondary">ESC[B ESC[B</span>{" "}
+                    <span className="text-quaternary">(2x down)</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">3.</span> Terminal sends:{" "}
+                    <span className="text-secondary">ESC[C ESC[C ...</span>{" "}
+                    <span className="text-quaternary">(10x right)</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">4.</span> App receives arrow keys, moves its
+                    cursor
+                  </div>
+                  <div className="text-quaternary mt-2">// It's simulating 12 keypresses!</div>
+                </div>
+              </div>
+            )}
+
+            {currentStep === "why-different" && (
+              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+                <div className="text-quaternary">// Terminal doesn't know what you're running:</div>
+                <div className="mt-2 space-y-1">
+                  <div>
+                    <span className="text-secondary">$ vim file.txt</span>{" "}
+                    <span className="text-quaternary">← click should move cursor</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">$ cat longfile.txt</span>{" "}
+                    <span className="text-quaternary">← no cursor to move</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">$ python</span>{" "}
+                    <span className="text-quaternary">← cursor in REPL prompt</span>
+                  </div>
+                  <div>
+                    <span className="text-secondary">$ htop</span>{" "}
+                    <span className="text-quaternary">← click selects process</span>
+                  </div>
+                  <div className="text-quaternary mt-2">// Each app handles mouse differently</div>
+                  <div className="text-quaternary">// So terminal can't assume anything!</div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Key Insight Box */}
+      <div className="border-primary bg-tertiary space-y-6 border p-6">
+        <h3 className="text-primary text-sm font-bold">
+          Why You Can't Just Click to Move the Cursor
+        </h3>
+
+        <div className="flex flex-col items-stretch gap-4 md:flex-row">
+          <div className="bg-tertiary flex-1 p-4">
+            <div className="text-primary mb-2 text-sm font-bold">What You Expect</div>
+            <div className="text-quaternary text-xs">
+              Click at position → cursor moves there instantly, like in a text editor or browser.
+            </div>
+          </div>
+          <div className="text-quaternary flex items-center justify-center text-2xl">≠</div>
+          <div className="bg-tertiary flex-1 p-4">
+            <div className="text-primary mb-2 text-sm font-bold">What Actually Happens</div>
+            <div className="text-quaternary text-xs">
+              Click → terminal shows selection OR sends mouse event to app (if enabled) → app
+              decides what to do.
+            </div>
+          </div>
+        </div>
+
+        <div className="text-quaternary text-sm">
+          The terminal is a dumb display. It shows characters where the app tells it to. Cursor
+          position is owned by the running program, and the terminal can only influence it by
+          sending keypress events that the program interprets.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/TextSelectionDemo.tsx
+++ b/src/app/how-terminals-work/demos/TextSelectionDemo.tsx
@@ -226,7 +226,7 @@ export function TextSelectionDemo() {
                 }}
                 className={`px-3 py-1 transition-colors ${
                   mode === "terminal"
-                    ? "bg-tertiary text-white dark:text-neutral-950"
+                    ? "border-primary bg-primary/10 text-primary border"
                     : "border-primary hover:border-primary border"
                 }`}
               >
@@ -239,7 +239,7 @@ export function TextSelectionDemo() {
                 }}
                 className={`px-3 py-1 transition-colors ${
                   mode === "app"
-                    ? "bg-primary text-white dark:text-neutral-950"
+                    ? "border-primary bg-primary/10 text-primary border"
                     : "border-primary hover:border-primary border"
                 }`}
               >
@@ -250,7 +250,7 @@ export function TextSelectionDemo() {
             {/* Terminal Grid */}
             <div
               ref={gridRef}
-              className="bg-secondary border-primary overflow-x-auto rounded border p-4 font-mono text-sm"
+              className="overflow-x-auto font-mono text-sm"
               style={{ userSelect: "none" }}
             >
               {SAMPLE_TEXT.map((line, row) => (
@@ -268,7 +268,7 @@ export function TextSelectionDemo() {
                           key={col}
                           onMouseDown={(e) => handleCellMouseDown(row, col, e)}
                           onMouseMove={() => handleCellMouseMove(row, col)}
-                          className={`inline-block h-[1.4em] w-[0.6em] text-center leading-[1.4em] transition-colors ${isSelected ? "bg-white text-black" : ""} ${isCursor ? "bg-primary text-white dark:text-neutral-950" : ""} ${mode === "terminal" ? "cursor-text" : "cursor-pointer"} `}
+                          className={`inline-block h-[1.4em] w-[0.6em] text-center leading-[1.4em] transition-colors ${isSelected ? "bg-primary/10 text-primary" : ""} ${isCursor ? "bg-primary/10 text-primary" : ""} ${mode === "terminal" ? "cursor-text" : "cursor-pointer"} `}
                         >
                           {char === "_" && row === SAMPLE_TEXT.length - 1 && col === 15 ? (
                             <span>_</span>
@@ -354,7 +354,7 @@ export function TextSelectionDemo() {
 
       {/* How it works explanation */}
       <div className="space-y-4">
-        <div className="bg-tertiary border-primary space-y-4 border px-4 py-4">
+        <div className="space-y-4">
           <div className="flex items-start justify-between gap-4">
             <div className="text-primary text-sm font-medium">{stepContent.title}</div>
             <StepDotsNavigation
@@ -367,7 +367,7 @@ export function TextSelectionDemo() {
             <p className="text-tertiary text-sm leading-relaxed">{stepContent.description}</p>
 
             {currentStep === "terminal-selection" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// Terminal emulator handles selection</div>
                 <div className="space-y-1">
                   <div>
@@ -391,7 +391,7 @@ export function TextSelectionDemo() {
             )}
 
             {currentStep === "cursor-positioning" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// App controls cursor with escape sequences</div>
                 <div className="space-y-1">
                   <div>
@@ -417,7 +417,7 @@ export function TextSelectionDemo() {
             )}
 
             {currentStep === "option-click" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// Option+Click at (5, 15), cursor at (3, 5)</div>
                 <div className="space-y-1">
                   <div>
@@ -444,7 +444,7 @@ export function TextSelectionDemo() {
             )}
 
             {currentStep === "why-different" && (
-              <div className="bg-tertiary space-y-2 p-3 font-mono text-xs">
+              <div className="space-y-2 font-mono text-xs">
                 <div className="text-quaternary">// Terminal doesn't know what you're running:</div>
                 <div className="mt-2 space-y-1">
                   <div>
@@ -473,21 +473,21 @@ export function TextSelectionDemo() {
       </div>
 
       {/* Key Insight Box */}
-      <div className="border-primary bg-tertiary space-y-6 border p-6">
-        <h3 className="text-primary text-sm font-bold">
+      <div className="space-y-6">
+        <h3 className="text-primary text-sm font-medium">
           Why You Can't Just Click to Move the Cursor
         </h3>
 
-        <div className="flex flex-col items-stretch gap-4 md:flex-row">
-          <div className="bg-tertiary flex-1 p-4">
-            <div className="text-primary mb-2 text-sm font-bold">What You Expect</div>
+        <div className="flex flex-col items-stretch gap-6 lg:flex-row">
+          <div className="flex-1">
+            <div className="text-primary mb-2 text-sm font-medium">What You Expect</div>
             <div className="text-quaternary text-xs">
               Click at position → cursor moves there instantly, like in a text editor or browser.
             </div>
           </div>
           <div className="text-quaternary flex items-center justify-center text-2xl">≠</div>
-          <div className="bg-tertiary flex-1 p-4">
-            <div className="text-primary mb-2 text-sm font-bold">What Actually Happens</div>
+          <div className="flex-1">
+            <div className="text-primary mb-2 text-sm font-medium">What Actually Happens</div>
             <div className="text-quaternary text-xs">
               Click → terminal shows selection OR sends mouse event to app (if enabled) → app
               decides what to do.

--- a/src/app/how-terminals-work/demos/VocabularyDemo.tsx
+++ b/src/app/how-terminals-work/demos/VocabularyDemo.tsx
@@ -1,0 +1,671 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button, NumberedStepNavigation } from "../ui";
+
+type Term = "terminal" | "shell" | "terminal-emulator" | "pty" | "bash" | "zsh" | "console" | "cli";
+
+interface TermDefinition {
+  name: string;
+  shortName?: string;
+  category: "hardware" | "software" | "shell" | "interface";
+  definition: string;
+  examples: string[];
+  alsoKnownAs?: string[];
+}
+
+const TERMS: Record<Term, TermDefinition> = {
+  terminal: {
+    name: "Terminal",
+    category: "hardware",
+    definition:
+      "Originally a physical device with a screen and keyboard that connected to a mainframe computer. Today, the word usually refers to a terminal emulator.",
+    examples: ["VT100", "VT220", "IBM 3270"],
+    alsoKnownAs: ["TTY", "Teletype"],
+  },
+  "terminal-emulator": {
+    name: "Terminal Emulator",
+    category: "software",
+    definition:
+      "A program that emulates a physical terminal. It draws the character grid, handles input/output, and connects to a shell. This is what you actually run on your computer.",
+    examples: [
+      "iTerm2",
+      "Terminal.app",
+      "Windows Terminal",
+      "Alacritty",
+      "kitty",
+      "Warp",
+      "Ghostty",
+      "WezTerm",
+    ],
+  },
+  shell: {
+    name: "Shell",
+    category: "software",
+    definition:
+      "A program that interprets commands. The shell reads what you type, executes programs, and handles things like pipes, redirects, and scripting. The terminal emulator is just the window; the shell is the program running inside it.",
+    examples: ["sh", "bash", "zsh", "fish", "ksh", "tcsh", "PowerShell", "nushell"],
+  },
+  pty: {
+    name: "PTY (Pseudo-Terminal)",
+    shortName: "PTY",
+    category: "software",
+    definition:
+      "A kernel feature that creates a fake terminal device. It has two ends: the master (connected to your terminal emulator) and the slave (connected to the shell). This is the pipe that connects your terminal to the shell.",
+    examples: ["/dev/pts/0", "/dev/ttys000"],
+    alsoKnownAs: ["Pseudoterminal", "Pseudo-TTY"],
+  },
+  bash: {
+    name: "Bash",
+    category: "shell",
+    definition:
+      'The "Bourne Again Shell"—the default shell on most Linux systems. Known for its scripting capabilities and POSIX compliance. Uses .bashrc and .bash_profile for configuration.',
+    examples: ["#!/bin/bash", "source ~/.bashrc"],
+  },
+  zsh: {
+    name: "Zsh",
+    category: "shell",
+    definition:
+      'The "Z Shell"—the default shell on macOS since Catalina. Has better tab completion, theming (Oh My Zsh), and interactive features than bash. Mostly compatible with bash syntax.',
+    examples: ["#!/bin/zsh", "source ~/.zshrc"],
+  },
+  console: {
+    name: "Console",
+    category: "interface",
+    definition:
+      'Historically, the physical terminal directly attached to a computer. In modern usage, often used interchangeably with "terminal" or to mean a text-based interface.',
+    examples: ["Linux virtual console (Ctrl+Alt+F1)", "Browser developer console"],
+    alsoKnownAs: ["System console"],
+  },
+  cli: {
+    name: "CLI (Command-Line Interface)",
+    shortName: "CLI",
+    category: "interface",
+    definition:
+      "A text-based interface where you interact by typing commands. The opposite of a GUI. Both the shell and programs you run in the terminal are CLIs.",
+    examples: ["git", "npm", "docker", "curl"],
+  },
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  hardware: "text-secondary",
+  software: "text-secondary",
+  shell: "text-primary",
+  interface: "text-secondary",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  hardware: "Hardware",
+  software: "Software",
+  shell: "Shell",
+  interface: "Interface Type",
+};
+
+// Architecture diagram showing the relationship between components
+function ArchitectureDiagram({ highlightedTerm }: { highlightedTerm: Term | null }) {
+  const isHighlighted = (terms: Term[]) => {
+    if (!highlightedTerm) return false;
+    return terms.includes(highlightedTerm);
+  };
+
+  return (
+    <div className="bg-tertiary border-primary border p-6">
+      <div className="text-primary mb-6 text-sm font-bold">How They Fit Together</div>
+
+      {/* Nested boxes showing containment */}
+      <div className="font-mono text-sm">
+        {/* Nested layers */}
+        <div
+          className={`border-2 p-4 transition-all ${
+            isHighlighted(["terminal-emulator", "terminal"])
+              ? "border-primary bg-primary/5"
+              : "border-primary/40"
+          }`}
+        >
+          <div className="mb-3 flex items-center gap-2">
+            <span className="text-secondary font-bold">Terminal Emulator</span>
+            <span className="text-tertiary text-xs">iTerm2, Ghostty, kitty</span>
+          </div>
+
+          <div
+            className={`border-2 p-4 transition-all ${
+              isHighlighted(["pty"]) ? "border-secondary bg-primary/5" : "border-secondary/40"
+            }`}
+          >
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-secondary font-bold">PTY</span>
+              <span className="text-tertiary text-xs">pseudo-terminal in kernel</span>
+            </div>
+
+            <div
+              className={`border-2 p-4 transition-all ${
+                isHighlighted(["shell", "bash", "zsh"])
+                  ? "border-primary bg-primary/5"
+                  : "border-primary/40"
+              }`}
+            >
+              <div className="mb-3 flex items-center gap-2">
+                <span className="text-primary font-bold">Shell</span>
+                <span className="text-tertiary text-xs">zsh, bash, fish</span>
+              </div>
+
+              <div
+                className={`border-2 p-3 transition-all ${
+                  isHighlighted(["cli"]) ? "border-primary bg-primary/5" : "border-primary/40"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-secondary font-bold">CLI Programs</span>
+                  <span className="text-tertiary text-xs">git, npm, vim</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Data flow annotation */}
+        <div className="border-primary text-tertiary mt-4 border-t pt-4 text-xs">
+          <span className="text-primary">Data flows both ways:</span> keystrokes travel inward,
+          output travels outward. Each layer transforms the data.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Shell family tree and comparison
+function ShellLandscape() {
+  const [selectedShell, setSelectedShell] = useState<string>("zsh");
+
+  const shells = {
+    sh: {
+      name: "sh (Bourne Shell)",
+      year: "1979",
+      creator: "Stephen Bourne at Bell Labs",
+      description:
+        "The original Unix shell. Established scripting conventions still used today. The standard for portable scripts.",
+      config: "/etc/profile, ~/.profile",
+      defaultOn: "POSIX systems (as /bin/sh)",
+      color: "text-quaternary",
+    },
+    bash: {
+      name: "Bash (Bourne Again Shell)",
+      year: "1989",
+      creator: "Brian Fox for GNU",
+      description:
+        "Backwards compatible with sh, adding command history, job control, and better scripting. The most common shell on Linux.",
+      config: "~/.bashrc, ~/.bash_profile",
+      defaultOn: "Most Linux distros",
+      color: "text-secondary",
+    },
+    zsh: {
+      name: "Zsh (Z Shell)",
+      year: "1990",
+      creator: "Paul Falstad",
+      description:
+        "Combines features from bash, ksh, and tcsh. Known for powerful tab completion, spelling correction, and theming via Oh My Zsh.",
+      config: "~/.zshrc, ~/.zprofile",
+      defaultOn: "macOS (since 2019)",
+      color: "text-secondary",
+    },
+    fish: {
+      name: "Fish (Friendly Interactive Shell)",
+      year: "2005",
+      creator: "Axel Liljencrantz",
+      description:
+        "Prioritizes user-friendliness over POSIX compatibility. Built-in syntax highlighting, autosuggestions, and web-based config.",
+      config: "~/.config/fish/config.fish",
+      defaultOn: "None (opt-in)",
+      color: "text-primary",
+    },
+    ksh: {
+      name: "Ksh (Korn Shell)",
+      year: "1983",
+      creator: "David Korn at Bell Labs",
+      description:
+        "Combines sh compatibility with C shell features. Popular in enterprise Unix environments. Has associative arrays and better loop syntax.",
+      config: "~/.kshrc",
+      defaultOn: "Some commercial Unix",
+      color: "text-secondary",
+    },
+    tcsh: {
+      name: "Tcsh (TENEX C Shell)",
+      year: "1981",
+      creator: "Ken Greer",
+      description:
+        "Enhanced C shell with command-line editing and completion. C-like scripting syntax. Was the default on older BSDs and early macOS.",
+      config: "~/.tcshrc, ~/.cshrc",
+      defaultOn: "FreeBSD (historically)",
+      color: "text-primary",
+    },
+    nushell: {
+      name: "Nushell",
+      year: "2019",
+      creator: "Jonathan Turner et al.",
+      description:
+        "Modern shell treating data as structured tables, not text. Pipelines pass typed data. Not POSIX-compatible but very powerful for data manipulation.",
+      config: "~/.config/nushell/config.nu",
+      defaultOn: "None (opt-in)",
+      color: "text-secondary",
+    },
+  };
+
+  const shellKeys = Object.keys(shells) as Array<keyof typeof shells>;
+  const selected = shells[selectedShell as keyof typeof shells];
+
+  return (
+    <div className="bg-tertiary border-primary space-y-4 border p-6">
+      <div className="text-primary text-sm font-bold">The Shell Family Tree</div>
+
+      <div className="flex flex-wrap gap-2">
+        {shellKeys.map((key) => (
+          <button
+            key={key}
+            onClick={() => setSelectedShell(key)}
+            className={`border px-3 py-1.5 text-sm transition-colors ${
+              selectedShell === key
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-primary text-tertiary hover:text-primary"
+            }`}
+          >
+            {key}
+          </button>
+        ))}
+      </div>
+
+      {selected && (
+        <div className="space-y-3">
+          <div>
+            <span className={`font-bold ${selected.color}`}>{selected.name}</span>
+            <span className="text-quaternary ml-2 text-sm">({selected.year})</span>
+          </div>
+          <p className="text-tertiary text-sm leading-relaxed">{selected.description}</p>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <div className="text-quaternary mb-1 text-xs uppercase">Config</div>
+              <div className="text-secondary font-mono text-xs">{selected.config}</div>
+            </div>
+            <div>
+              <div className="text-quaternary mb-1 text-xs uppercase">Default on</div>
+              <div className="text-primary text-xs">{selected.defaultOn}</div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Terminal emulator landscape
+function TerminalLandscape() {
+  const [selectedTerminal, setSelectedTerminal] = useState<string>("iterm2");
+
+  const terminals = {
+    vt100: {
+      name: "VT100 (1978)",
+      type: "Hardware",
+      description:
+        "The DEC terminal that defined the standard. First ANSI-compliant terminal. Most modern terminal emulators trace their roots here.",
+      features: ["ANSI escape codes", "80×24 display", "Scrolling regions"],
+      color: "text-secondary",
+    },
+    xterm: {
+      name: "xterm (1984)",
+      type: "Classic",
+      description:
+        "The original X Window System terminal emulator. Added mouse tracking and 256 colors. Still the reference implementation.",
+      features: ["VT102 emulation", "Mouse tracking", "256 colors"],
+      color: "text-quaternary",
+    },
+    iterm2: {
+      name: "iTerm2",
+      type: "Feature-rich",
+      description:
+        "The most popular macOS terminal. Split panes, search, triggers, Python scripting API. Native tmux integration.",
+      features: ["Split panes", "Tmux integration", "Autocomplete", "Triggers"],
+      color: "text-primary",
+    },
+    alacritty: {
+      name: "Alacritty",
+      type: "Minimal/Fast",
+      description:
+        "GPU-accelerated, written in Rust. Focused on speed and simplicity. No tabs, no splits—use tmux instead.",
+      features: ["GPU rendering", "Cross-platform", "Vi mode", "Fast"],
+      color: "text-secondary",
+    },
+    kitty: {
+      name: "kitty",
+      type: "Feature-rich",
+      description:
+        'GPU-based with its own image protocol. Extensible via "kittens". Defined the kitty keyboard protocol now adopted widely.',
+      features: ["GPU rendering", "Image support", "Kittens", "Tabs/splits"],
+      color: "text-secondary",
+    },
+    warp: {
+      name: "Warp",
+      type: "Modern/AI",
+      description:
+        "Reimagines the terminal with blocks, AI assistance, and team features. Input at bottom, modern text editing.",
+      features: ["AI assistance", "Blocks", "Team sharing", "Modern UI"],
+      color: "text-secondary",
+    },
+    ghostty: {
+      name: "Ghostty",
+      type: "Modern/Fast",
+      description:
+        "By Mitchell Hashimoto (Vagrant, Terraform). Native GPU rendering, kitty graphics, sensible defaults. Open-sourced in late 2024.",
+      features: ["Native rendering", "Kitty graphics", "Fast", "Clean defaults"],
+      color: "text-primary",
+    },
+  };
+
+  const terminalKeys = Object.keys(terminals) as Array<keyof typeof terminals>;
+  const selected = terminals[selectedTerminal as keyof typeof terminals];
+
+  return (
+    <div className="bg-tertiary border-primary space-y-4 border p-6">
+      <div className="text-primary text-sm font-bold">Terminal Emulators</div>
+
+      <div className="flex flex-wrap gap-2">
+        {terminalKeys.map((key) => (
+          <button
+            key={key}
+            onClick={() => setSelectedTerminal(key)}
+            className={`border px-3 py-1.5 text-sm transition-colors ${
+              selectedTerminal === key
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-primary text-tertiary hover:text-primary"
+            }`}
+          >
+            {key === "vt100" ? "VT100" : key === "iterm2" ? "iTerm2" : key}
+          </button>
+        ))}
+      </div>
+
+      {selected && (
+        <div className="space-y-3">
+          <div>
+            <span className={`font-bold ${selected.color}`}>{selected.name}</span>
+            <span className="text-quaternary ml-2 text-sm">• {selected.type}</span>
+          </div>
+          <p className="text-tertiary text-sm leading-relaxed">{selected.description}</p>
+          <div>
+            <div className="text-quaternary mb-2 text-xs uppercase">Key features</div>
+            <div className="flex flex-wrap gap-2">
+              {selected.features.map((feature) => (
+                <span
+                  key={feature}
+                  className="bg-secondary border-primary text-primary border px-2 py-1 text-xs"
+                >
+                  {feature}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Interactive demo showing what happens when you type
+function CommandFlowDemo() {
+  const [step, setStep] = useState(0);
+
+  const steps = [
+    {
+      label: "You type",
+      content: "ls -la",
+      description: "You press keys on your keyboard",
+      highlight: "input",
+    },
+    {
+      label: "Terminal receives",
+      content: "l, s, space, -, l, a",
+      description: "Terminal emulator receives keystrokes and displays them",
+      highlight: "terminal",
+    },
+    {
+      label: "Shell receives",
+      content: "ls -la\\n",
+      description: "When you press Enter, the shell receives the full line",
+      highlight: "shell",
+    },
+    {
+      label: "Shell parses",
+      content: "command: ls, args: [-l, -a]",
+      description: "Shell interprets the command and arguments",
+      highlight: "shell",
+    },
+    {
+      label: "Shell executes",
+      content: "/bin/ls -l -a",
+      description: "Shell finds and runs the ls program",
+      highlight: "program",
+    },
+    {
+      label: "Output flows back",
+      content: "drwxr-xr-x  5 user ...",
+      description: "Program output goes through PTY to terminal",
+      highlight: "output",
+    },
+  ];
+
+  const currentStep = steps[step];
+
+  return (
+    <div className="bg-tertiary border-primary space-y-4 border p-6">
+      <div className="text-primary text-sm font-bold">Follow a Command</div>
+
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => setStep(Math.max(0, step - 1))} disabled={step === 0}>
+          Previous
+        </Button>
+        <NumberedStepNavigation
+          totalSteps={steps.length}
+          currentStep={step}
+          onStepChange={setStep}
+        />
+        <Button
+          size="sm"
+          onClick={() => setStep(Math.min(steps.length - 1, step + 1))}
+          disabled={step === steps.length - 1}
+        >
+          Next
+        </Button>
+      </div>
+
+      <div className="bg-secondary border-primary space-y-3 border p-4">
+        <div className="flex items-center gap-3">
+          <span className="text-secondary text-sm font-bold">{currentStep?.label}</span>
+        </div>
+        <div className="text-primary font-mono">{currentStep?.content}</div>
+        <div className="text-tertiary text-sm">{currentStep?.description}</div>
+      </div>
+    </div>
+  );
+}
+
+export function VocabularyDemo() {
+  const [activeTerm, setActiveTerm] = useState<Term>("terminal");
+  const termData = activeTerm ? TERMS[activeTerm] : null;
+
+  const termOrder: Term[] = [
+    "terminal",
+    "terminal-emulator",
+    "shell",
+    "pty",
+    "bash",
+    "zsh",
+    "console",
+    "cli",
+  ];
+
+  return (
+    <div className="space-y-8">
+      {/* Glossary */}
+      <div className="bg-tertiary border-primary flex flex-col border lg:flex-row">
+        {/* Term list */}
+        <div className="border-primary p-4 lg:w-1/2 lg:border-r">
+          <div className="min-h-[320px] space-y-1 font-mono text-sm">
+            {termOrder.map((term) => {
+              const data = TERMS[term];
+              const isActive = activeTerm === term;
+              return (
+                <div
+                  key={term}
+                  onMouseEnter={() => setActiveTerm(term)}
+                  className={`flex w-full cursor-default items-center gap-3 px-3 py-2 text-left transition-all ${
+                    isActive
+                      ? "bg-tertiary border-primary border-l-2"
+                      : "border-l-2 border-transparent"
+                  }`}
+                >
+                  <span className={`w-16 text-xs uppercase ${CATEGORY_COLORS[data.category]}`}>
+                    {CATEGORY_LABELS[data.category]?.split(" ")[0]}
+                  </span>
+                  <span className="text-primary">{data.shortName || data.name}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Term details */}
+        <div className="border-primary border-t p-4 lg:w-1/2 lg:border-t-0">
+          {termData && (
+            <div className="space-y-4">
+              <div>
+                <div className={`text-xs uppercase ${CATEGORY_COLORS[termData.category]}`}>
+                  {CATEGORY_LABELS[termData.category]}
+                </div>
+                <div className="text-primary mt-2 text-base font-bold">{termData.name}</div>
+                {termData.alsoKnownAs && (
+                  <div className="text-tertiary text-xs">
+                    AKA: {termData.alsoKnownAs.join(", ")}
+                  </div>
+                )}
+              </div>
+
+              <p className="text-tertiary text-sm leading-relaxed">{termData.definition}</p>
+
+              <div className="space-y-2">
+                <div className="text-tertiary text-xs uppercase">Examples</div>
+                <div className="flex flex-wrap gap-2">
+                  {termData.examples.map((ex) => (
+                    <span
+                      key={ex}
+                      className={`bg-secondary border-primary border px-2 py-1 font-mono text-xs ${CATEGORY_COLORS[termData.category]}`}
+                    >
+                      {ex}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Architecture Diagram */}
+      <ArchitectureDiagram highlightedTerm={activeTerm} />
+
+      {/* Shell Landscape */}
+      <ShellLandscape />
+
+      {/* Terminal Emulator Landscape */}
+      <TerminalLandscape />
+
+      {/* Command Flow Demo */}
+      <CommandFlowDemo />
+
+      {/* Common Confusions */}
+      <div className="bg-tertiary border-primary space-y-4 border p-6">
+        <h3 className="text-primary text-sm font-bold">Common Confusions</h3>
+
+        <div className="grid grid-cols-1 gap-4">
+          <div className="bg-tertiary space-y-2 p-4">
+            <div className="text-primary text-sm font-bold">"I opened my terminal"</div>
+            <p className="text-tertiary text-sm">
+              You probably mean you opened a{" "}
+              <span className="text-secondary">terminal emulator</span> (like iTerm2), which started
+              a <span className="text-primary">shell</span> (like zsh) inside it.
+            </p>
+          </div>
+
+          <div className="bg-tertiary space-y-2 p-4">
+            <div className="text-primary text-sm font-bold">
+              "My terminal can't find the command"
+            </div>
+            <p className="text-tertiary text-sm">
+              It's actually your <span className="text-primary">shell</span> that searches for
+              commands in your PATH. The terminal just displays what the shell outputs.
+            </p>
+          </div>
+
+          <div className="bg-tertiary space-y-2 p-4">
+            <div className="text-primary text-sm font-bold">"bash vs zsh—which should I use?"</div>
+            <p className="text-tertiary text-sm">
+              For interactive use, <span className="text-secondary">zsh</span> has better features.
+              For scripts, <span className="text-secondary">bash</span> is more portable. Most
+              commands work identically in both.
+            </p>
+          </div>
+
+          <div className="bg-tertiary space-y-2 p-4">
+            <div className="text-primary text-sm font-bold">
+              "Terminal settings vs shell config"
+            </div>
+            <p className="text-tertiary text-sm">
+              <span className="text-secondary">Terminal settings</span> control appearance (fonts,
+              colors, window size). <span className="text-primary">Shell config</span> (.zshrc)
+              controls aliases, PATH, and prompt.
+            </p>
+          </div>
+
+          <div className="bg-tertiary space-y-2 p-4">
+            <div className="text-primary text-sm font-bold">
+              "How does Up arrow recall previous commands?"
+            </div>
+            <p className="text-tertiary text-sm">
+              That's your <span className="text-primary">shell</span>, not your terminal. The shell
+              keeps a history file (like <span className="text-secondary">~/.zsh_history</span>) and
+              sends recalled commands back to the terminal for display.
+            </p>
+          </div>
+
+          <div className="bg-tertiary space-y-2 p-4">
+            <div className="text-primary text-sm font-bold">
+              "Why restart terminal after editing .zshrc?"
+            </div>
+            <p className="text-tertiary text-sm">
+              Your shell reads <span className="text-secondary">.zshrc</span> once at startup.
+              Existing shells already loaded their config. Opening a new terminal starts a fresh
+              shell that reads your updated file. (Or run{" "}
+              <span className="text-primary">source ~/.zshrc</span> to reload without restarting.)
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Quick Reference */}
+      <div className="bg-tertiary border-primary space-y-4 border p-6">
+        <h3 className="text-primary text-sm font-bold">Quick Reference</h3>
+
+        <div className="bg-secondary border-primary space-y-2 border p-4 font-mono text-sm">
+          <div className="text-tertiary"># Which shell am I using?</div>
+          <div className="text-primary">echo $SHELL</div>
+          <div className="text-tertiary mt-3"># What terminal am I in?</div>
+          <div className="text-primary">echo $TERM_PROGRAM</div>
+          <div className="text-tertiary mt-3"># What's my PTY device?</div>
+          <div className="text-primary">tty</div>
+          <div className="text-tertiary mt-3"># List available shells</div>
+          <div className="text-primary">cat /etc/shells</div>
+          <div className="text-tertiary mt-3"># Change default shell to zsh</div>
+          <div className="text-primary">chsh -s /bin/zsh</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/demos/VocabularyDemo.tsx
+++ b/src/app/how-terminals-work/demos/VocabularyDemo.tsx
@@ -110,14 +110,14 @@ function ArchitectureDiagram({ highlightedTerm }: { highlightedTerm: Term | null
   };
 
   return (
-    <div className="bg-tertiary border-primary border p-6">
-      <div className="text-primary mb-6 text-sm font-bold">How They Fit Together</div>
+    <div className="space-y-6">
+      <div className="text-primary text-sm font-medium">How They Fit Together</div>
 
       {/* Nested boxes showing containment */}
       <div className="font-mono text-sm">
         {/* Nested layers */}
         <div
-          className={`border-2 p-4 transition-all ${
+          className={`border p-4 transition-all ${
             isHighlighted(["terminal-emulator", "terminal"])
               ? "border-primary bg-primary/5"
               : "border-primary/40"
@@ -129,7 +129,7 @@ function ArchitectureDiagram({ highlightedTerm }: { highlightedTerm: Term | null
           </div>
 
           <div
-            className={`border-2 p-4 transition-all ${
+            className={`border p-4 transition-all ${
               isHighlighted(["pty"]) ? "border-secondary bg-primary/5" : "border-secondary/40"
             }`}
           >
@@ -139,7 +139,7 @@ function ArchitectureDiagram({ highlightedTerm }: { highlightedTerm: Term | null
             </div>
 
             <div
-              className={`border-2 p-4 transition-all ${
+              className={`border p-4 transition-all ${
                 isHighlighted(["shell", "bash", "zsh"])
                   ? "border-primary bg-primary/5"
                   : "border-primary/40"
@@ -151,7 +151,7 @@ function ArchitectureDiagram({ highlightedTerm }: { highlightedTerm: Term | null
               </div>
 
               <div
-                className={`border-2 p-3 transition-all ${
+                className={`border p-3 transition-all ${
                   isHighlighted(["cli"]) ? "border-primary bg-primary/5" : "border-primary/40"
                 }`}
               >
@@ -255,8 +255,8 @@ function ShellLandscape() {
   const selected = shells[selectedShell as keyof typeof shells];
 
   return (
-    <div className="bg-tertiary border-primary space-y-4 border p-6">
-      <div className="text-primary text-sm font-bold">The Shell Family Tree</div>
+    <div className="space-y-4">
+      <div className="text-primary text-sm font-medium">The Shell Family Tree</div>
 
       <div className="flex flex-wrap gap-2">
         {shellKeys.map((key) => (
@@ -364,8 +364,8 @@ function TerminalLandscape() {
   const selected = terminals[selectedTerminal as keyof typeof terminals];
 
   return (
-    <div className="bg-tertiary border-primary space-y-4 border p-6">
-      <div className="text-primary text-sm font-bold">Terminal Emulators</div>
+    <div className="space-y-4">
+      <div className="text-primary text-sm font-medium">Terminal Emulators</div>
 
       <div className="flex flex-wrap gap-2">
         {terminalKeys.map((key) => (
@@ -455,8 +455,8 @@ function CommandFlowDemo() {
   const currentStep = steps[step];
 
   return (
-    <div className="bg-tertiary border-primary space-y-4 border p-6">
-      <div className="text-primary text-sm font-bold">Follow a Command</div>
+    <div className="space-y-4">
+      <div className="text-primary text-sm font-medium">Follow a Command</div>
 
       <div className="flex gap-2">
         <Button size="sm" onClick={() => setStep(Math.max(0, step - 1))} disabled={step === 0}>
@@ -476,7 +476,7 @@ function CommandFlowDemo() {
         </Button>
       </div>
 
-      <div className="bg-secondary border-primary space-y-3 border p-4">
+      <div className="space-y-3">
         <div className="flex items-center gap-3">
           <span className="text-secondary text-sm font-bold">{currentStep?.label}</span>
         </div>
@@ -505,9 +505,9 @@ export function VocabularyDemo() {
   return (
     <div className="space-y-8">
       {/* Glossary */}
-      <div className="bg-tertiary border-primary flex flex-col border lg:flex-row">
+      <div className="flex flex-col gap-8 lg:flex-row">
         {/* Term list */}
-        <div className="border-primary p-4 lg:w-1/2 lg:border-r">
+        <div className="lg:w-1/2">
           <div className="min-h-[320px] space-y-1 font-mono text-sm">
             {termOrder.map((term) => {
               const data = TERMS[term];
@@ -518,7 +518,7 @@ export function VocabularyDemo() {
                   onMouseEnter={() => setActiveTerm(term)}
                   className={`flex w-full cursor-default items-center gap-3 px-3 py-2 text-left transition-all ${
                     isActive
-                      ? "bg-tertiary border-primary border-l-2"
+                      ? "bg-primary/10 border-primary border-l-2"
                       : "border-l-2 border-transparent"
                   }`}
                 >
@@ -533,7 +533,7 @@ export function VocabularyDemo() {
         </div>
 
         {/* Term details */}
-        <div className="border-primary border-t p-4 lg:w-1/2 lg:border-t-0">
+        <div className="lg:w-1/2">
           {termData && (
             <div className="space-y-4">
               <div>
@@ -581,11 +581,11 @@ export function VocabularyDemo() {
       <CommandFlowDemo />
 
       {/* Common Confusions */}
-      <div className="bg-tertiary border-primary space-y-4 border p-6">
-        <h3 className="text-primary text-sm font-bold">Common Confusions</h3>
+      <div className="space-y-4">
+        <h3 className="text-primary text-sm font-medium">Common Confusions</h3>
 
         <div className="grid grid-cols-1 gap-4">
-          <div className="bg-tertiary space-y-2 p-4">
+          <div className="space-y-2">
             <div className="text-primary text-sm font-bold">"I opened my terminal"</div>
             <p className="text-tertiary text-sm">
               You probably mean you opened a{" "}
@@ -594,7 +594,7 @@ export function VocabularyDemo() {
             </p>
           </div>
 
-          <div className="bg-tertiary space-y-2 p-4">
+          <div className="space-y-2">
             <div className="text-primary text-sm font-bold">
               "My terminal can't find the command"
             </div>
@@ -604,7 +604,7 @@ export function VocabularyDemo() {
             </p>
           </div>
 
-          <div className="bg-tertiary space-y-2 p-4">
+          <div className="space-y-2">
             <div className="text-primary text-sm font-bold">"bash vs zsh—which should I use?"</div>
             <p className="text-tertiary text-sm">
               For interactive use, <span className="text-secondary">zsh</span> has better features.
@@ -613,7 +613,7 @@ export function VocabularyDemo() {
             </p>
           </div>
 
-          <div className="bg-tertiary space-y-2 p-4">
+          <div className="space-y-2">
             <div className="text-primary text-sm font-bold">
               "Terminal settings vs shell config"
             </div>
@@ -624,7 +624,7 @@ export function VocabularyDemo() {
             </p>
           </div>
 
-          <div className="bg-tertiary space-y-2 p-4">
+          <div className="space-y-2">
             <div className="text-primary text-sm font-bold">
               "How does Up arrow recall previous commands?"
             </div>
@@ -635,7 +635,7 @@ export function VocabularyDemo() {
             </p>
           </div>
 
-          <div className="bg-tertiary space-y-2 p-4">
+          <div className="space-y-2">
             <div className="text-primary text-sm font-bold">
               "Why restart terminal after editing .zshrc?"
             </div>
@@ -650,10 +650,10 @@ export function VocabularyDemo() {
       </div>
 
       {/* Quick Reference */}
-      <div className="bg-tertiary border-primary space-y-4 border p-6">
-        <h3 className="text-primary text-sm font-bold">Quick Reference</h3>
+      <div className="space-y-4">
+        <h3 className="text-primary text-sm font-medium">Quick Reference</h3>
 
-        <div className="bg-secondary border-primary space-y-2 border p-4 font-mono text-sm">
+        <div className="space-y-2 font-mono text-sm">
           <div className="text-tertiary"># Which shell am I using?</div>
           <div className="text-primary">echo $SHELL</div>
           <div className="text-tertiary mt-3"># What terminal am I in?</div>

--- a/src/app/how-terminals-work/layout.tsx
+++ b/src/app/how-terminals-work/layout.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function HowTerminalsWorkLayout({ children }: { children: React.ReactNode }) {
+  return <div className="flex min-w-0 flex-1 flex-col">{children}</div>;
+}

--- a/src/app/how-terminals-work/lib/ansi.test.ts
+++ b/src/app/how-terminals-work/lib/ansi.test.ts
@@ -32,7 +32,7 @@ describe("generate256Colors", () => {
 
 describe("hslToRgb", () => {
   test("converts hue/saturation/lightness used by the truecolor picker", () => {
-    expect(hslToRgb(0, 80, 50)).toEqual({ r: 230, g: 26, b: 26 });
-    expect(hslToRgb(180, 80, 50)).toEqual({ r: 26, g: 230, b: 230 });
+    expect(hslToRgb(0, 80, 50)).toEqual({ r: 230, g: 25, b: 25 });
+    expect(hslToRgb(180, 80, 50)).toEqual({ r: 25, g: 230, b: 230 });
   });
 });

--- a/src/app/how-terminals-work/lib/ansi.test.ts
+++ b/src/app/how-terminals-work/lib/ansi.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { generate256Colors, hslToRgb, parseAnsiLine } from "./ansi";
+
+describe("parseAnsiLine", () => {
+  test("keeps plain text without a color", () => {
+    expect(parseAnsiLine("$ ls")).toEqual([{ text: "$ ls" }]);
+  });
+
+  test("applies and resets SGR colors", () => {
+    const parts = parseAnsiLine("\x1b[34mDocuments\x1b[0m  \x1b[32mscript.sh\x1b[0m");
+    expect(parts).toEqual([
+      { text: "Documents", color: "#3b82f6" },
+      { text: "  " },
+      { text: "script.sh", color: "#22c55e" },
+    ]);
+  });
+});
+
+describe("generate256Colors", () => {
+  test("builds the 256-color palette in ANSI order", () => {
+    const colors = generate256Colors();
+    expect(colors).toHaveLength(256);
+    expect(colors[0]).toBe("#000000");
+    expect(colors[15]).toBe("#ffffff");
+    expect(colors[16]).toBe("rgb(0, 0, 0)");
+    expect(colors[231]).toBe("rgb(255, 255, 255)");
+    expect(colors[232]).toBe("rgb(8, 8, 8)");
+    expect(colors[255]).toBe("rgb(238, 238, 238)");
+  });
+});
+
+describe("hslToRgb", () => {
+  test("converts hue/saturation/lightness used by the truecolor picker", () => {
+    expect(hslToRgb(0, 80, 50)).toEqual({ r: 230, g: 26, b: 26 });
+    expect(hslToRgb(180, 80, 50)).toEqual({ r: 26, g: 230, b: 230 });
+  });
+});

--- a/src/app/how-terminals-work/lib/ansi.ts
+++ b/src/app/how-terminals-work/lib/ansi.ts
@@ -1,0 +1,117 @@
+/** Standard 16-color ANSI palette used by the cell and escape demos. */
+export const ANSI_16 = {
+  black: "#0a0a0a",
+  red: "#f85149",
+  green: "#22c55e",
+  yellow: "#eab308",
+  blue: "#3b82f6",
+  magenta: "#a855f7",
+  cyan: "#06b6d4",
+  white: "#e5e5e5",
+  brightBlack: "#525252",
+  brightRed: "#ff7b72",
+  brightGreen: "#4ade80",
+  brightYellow: "#facc15",
+  brightBlue: "#60a5fa",
+  brightMagenta: "#c084fc",
+  brightCyan: "#22d3ee",
+  brightWhite: "#fafafa",
+} as const;
+
+export const ANSI_SGR_COLORS: Record<string, string> = {
+  "30": ANSI_16.black,
+  "31": ANSI_16.red,
+  "32": ANSI_16.green,
+  "33": ANSI_16.yellow,
+  "34": ANSI_16.blue,
+  "35": ANSI_16.magenta,
+  "36": ANSI_16.cyan,
+  "37": ANSI_16.white,
+  "90": ANSI_16.brightBlack,
+  "91": ANSI_16.brightRed,
+  "92": ANSI_16.brightGreen,
+  "93": ANSI_16.brightYellow,
+  "94": ANSI_16.brightBlue,
+  "95": ANSI_16.brightMagenta,
+  "96": ANSI_16.brightCyan,
+  "97": ANSI_16.brightWhite,
+};
+
+export type AnsiSpan = { text: string; color?: string };
+
+export function parseAnsiLine(line: string): AnsiSpan[] {
+  const parts: AnsiSpan[] = [];
+  let current = "";
+  let currentColor: string | undefined;
+  let i = 0;
+
+  while (i < line.length) {
+    if (line[i] === "\x1b" && line[i + 1] === "[") {
+      if (current) {
+        parts.push({ text: current, color: currentColor });
+        current = "";
+      }
+      let j = i + 2;
+      while (j < line.length && line[j] !== "m") j++;
+      const code = line.slice(i + 2, j);
+      if (code === "0") currentColor = undefined;
+      else if (ANSI_SGR_COLORS[code]) currentColor = ANSI_SGR_COLORS[code];
+      i = j + 1;
+    } else {
+      current += line[i];
+      i++;
+    }
+  }
+  if (current) parts.push({ text: current, color: currentColor });
+  return parts;
+}
+
+export function generate256Colors(): string[] {
+  const colors: string[] = [];
+  const standard16 = [
+    "#000000",
+    "#cd0000",
+    "#00cd00",
+    "#cdcd00",
+    "#0000ee",
+    "#cd00cd",
+    "#00cdcd",
+    "#e5e5e5",
+    "#7f7f7f",
+    "#ff0000",
+    "#00ff00",
+    "#ffff00",
+    "#5c5cff",
+    "#ff00ff",
+    "#00ffff",
+    "#ffffff",
+  ];
+  colors.push(...standard16);
+
+  const levels = [0, 95, 135, 175, 215, 255];
+  for (let r = 0; r < 6; r++) {
+    for (let g = 0; g < 6; g++) {
+      for (let b = 0; b < 6; b++) {
+        colors.push(`rgb(${levels[r]}, ${levels[g]}, ${levels[b]})`);
+      }
+    }
+  }
+
+  for (let i = 0; i < 24; i++) {
+    const gray = 8 + i * 10;
+    colors.push(`rgb(${gray}, ${gray}, ${gray})`);
+  }
+
+  return colors;
+}
+
+export function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  s /= 100;
+  l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    return Math.round((l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)) * 255);
+  };
+  return { r: f(0), g: f(8), b: f(4) };
+}

--- a/src/app/how-terminals-work/lib/sequences.test.ts
+++ b/src/app/how-terminals-work/lib/sequences.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { encodeMouseClick, FEATURE_SEQUENCES, SPECIAL_KEYS, TERM_CAPABILITIES } from "./sequences";
+
+describe("SPECIAL_KEYS", () => {
+  test("maps arrow keys and control keys to their byte sequences", () => {
+    expect(SPECIAL_KEYS.ArrowUp).toEqual({
+      bytes: "1b 5b 41",
+      sequence: "^[[A",
+      desc: "Cursor Up",
+    });
+    expect(SPECIAL_KEYS.Enter).toEqual({
+      bytes: "0d",
+      sequence: "^M",
+      desc: "Carriage Return",
+    });
+    expect(SPECIAL_KEYS.Escape).toEqual({ bytes: "1b", sequence: "^[", desc: "Escape" });
+  });
+});
+
+describe("encodeMouseClick", () => {
+  test("encodes X10 mouse reporting from 0-based grid cells", () => {
+    expect(encodeMouseClick(0, 0, 0)).toEqual({
+      x: 1,
+      y: 1,
+      button: 0,
+      sequence: `^[[M${String.fromCharCode(32)}${String.fromCharCode(33)}${String.fromCharCode(33)}`,
+      bytes: "1b 5b 4d 20 21 21",
+    });
+  });
+});
+
+describe("TERM_CAPABILITIES", () => {
+  test("describes modern and legacy terminals", () => {
+    expect(TERM_CAPABILITIES["xterm-256color"]?.colors).toBe(256);
+    expect(TERM_CAPABILITIES["xterm-256color"]?.mouse).toBe(true);
+    expect(TERM_CAPABILITIES.vt100?.colors).toBe(0);
+    expect(TERM_CAPABILITIES.vt100?.mouse).toBe(false);
+    expect(TERM_CAPABILITIES.dumb?.description).toBe("No special capabilities");
+  });
+});
+
+describe("FEATURE_SEQUENCES", () => {
+  test("uses the enable/disable sequences programs send", () => {
+    const alt = FEATURE_SEQUENCES.find((feature) => feature.id === "altscreen");
+    expect(alt?.enable).toBe("^[[?1049h");
+    expect(alt?.disable).toBe("^[[?1049l");
+    expect(FEATURE_SEQUENCES.find((feature) => feature.id === "mouse")?.enable).toBe("^[[?1000h");
+  });
+});

--- a/src/app/how-terminals-work/lib/sequences.ts
+++ b/src/app/how-terminals-work/lib/sequences.ts
@@ -1,0 +1,114 @@
+export const SPECIAL_KEYS: Record<string, { bytes: string; sequence: string; desc: string }> = {
+  ArrowUp: { bytes: "1b 5b 41", sequence: "^[[A", desc: "Cursor Up" },
+  ArrowDown: { bytes: "1b 5b 42", sequence: "^[[B", desc: "Cursor Down" },
+  ArrowRight: { bytes: "1b 5b 43", sequence: "^[[C", desc: "Cursor Right" },
+  ArrowLeft: { bytes: "1b 5b 44", sequence: "^[[D", desc: "Cursor Left" },
+  Enter: { bytes: "0d", sequence: "^M", desc: "Carriage Return" },
+  Tab: { bytes: "09", sequence: "^I", desc: "Horizontal Tab" },
+  Backspace: { bytes: "7f", sequence: "^?", desc: "Delete" },
+  Escape: { bytes: "1b", sequence: "^[", desc: "Escape" },
+};
+
+export function encodeMouseClick(
+  row: number,
+  col: number,
+  button: number,
+): { x: number; y: number; button: number; sequence: string; bytes: string } {
+  const x = col + 1 + 32;
+  const y = row + 1 + 32;
+  const encodedButton = button + 32;
+  return {
+    x: col + 1,
+    y: row + 1,
+    button,
+    sequence: `^[[M${String.fromCharCode(encodedButton)}${String.fromCharCode(x)}${String.fromCharCode(y)}`,
+    bytes: `1b 5b 4d ${encodedButton.toString(16)} ${x.toString(16)} ${y.toString(16)}`,
+  };
+}
+
+export const TERM_CAPABILITIES: Record<
+  string,
+  {
+    colors: number;
+    mouse: boolean;
+    altScreen: boolean;
+    unicode: boolean;
+    description: string;
+  }
+> = {
+  "xterm-256color": {
+    colors: 256,
+    mouse: true,
+    altScreen: true,
+    unicode: true,
+    description: "Modern terminal with 256-color support",
+  },
+  xterm: {
+    colors: 16,
+    mouse: true,
+    altScreen: true,
+    unicode: true,
+    description: "Standard X terminal emulator",
+  },
+  "screen-256color": {
+    colors: 256,
+    mouse: true,
+    altScreen: true,
+    unicode: true,
+    description: "GNU Screen with 256 colors",
+  },
+  vt100: {
+    colors: 0,
+    mouse: false,
+    altScreen: false,
+    unicode: false,
+    description: "DEC terminal from 1978",
+  },
+  dumb: {
+    colors: 0,
+    mouse: false,
+    altScreen: false,
+    unicode: false,
+    description: "No special capabilities",
+  },
+};
+
+export const FEATURE_SEQUENCES = [
+  {
+    id: "mouse",
+    name: "Mouse Tracking",
+    enable: "^[[?1000h",
+    disable: "^[[?1000l",
+    description: "Report mouse clicks as escape sequences",
+  },
+  {
+    id: "altscreen",
+    name: "Alternate Screen",
+    enable: "^[[?1049h",
+    disable: "^[[?1049l",
+    description: "Switch to a separate screen buffer",
+  },
+  {
+    id: "bracketed",
+    name: "Bracketed Paste",
+    enable: "^[[?2004h",
+    disable: "^[[?2004l",
+    description: "Wrap pasted text with special markers",
+  },
+] as const;
+
+export const DA1_CODES: Record<string, string> = {
+  "1": "132 columns",
+  "2": "Printer port",
+  "4": "Sixel graphics",
+  "6": "Selective erase",
+  "7": "Soft fonts (DRCS)",
+  "8": "User-defined keys",
+  "9": "National replacement sets",
+  "15": "Technical character set",
+  "18": "Windowing capability",
+  "21": "Horizontal scrolling",
+  "22": "ANSI color",
+  "28": "Rectangular editing",
+  "29": "ANSI text locator",
+};

--- a/src/app/how-terminals-work/page.test.tsx
+++ b/src/app/how-terminals-work/page.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { HOW_TERMINALS_WORK_INTRO, HOW_TERMINALS_WORK_TITLE } from "@/lib/how-terminals-work";
+
+import { HowTerminalsWorkGuide } from "./HowTerminalsWorkGuide";
+import HowTerminalsWorkPage from "./page";
+
+describe("How Terminals Work page", () => {
+  test("renders the essay title, intro, and every section heading", () => {
+    const html = renderToStaticMarkup(<HowTerminalsWorkPage />);
+    expect(html).toContain("<h1");
+    expect(html).toContain(HOW_TERMINALS_WORK_TITLE);
+    expect(html).toContain(HOW_TERMINALS_WORK_INTRO);
+
+    const guide = renderToStaticMarkup(<HowTerminalsWorkGuide />);
+    expect(guide).toContain("The Grid Model");
+    expect(guide).toContain("What's in a Cell?");
+    expect(guide).toContain("Escape Sequences");
+    expect(guide).toContain("Input Goes Both Ways");
+    expect(guide).toContain("Signals");
+    expect(guide).toContain("Raw vs Cooked Mode");
+    expect(guide).toContain("The Round Trip");
+    expect(guide).toContain("Building Complex TUIs");
+    expect(guide).toContain("The Alternate Screen Buffer");
+    expect(guide).toContain("Terminal Icons");
+    expect(guide).toContain("State Management");
+    expect(guide).toContain("Text Selection &amp; Cursor Positioning");
+    expect(guide).toContain("Capability Discovery");
+    expect(guide).toContain("Terminal Vocabulary");
+    expect(guide).toContain("Press any key");
+    expect(guide).toContain("^[[?1049h");
+  });
+});

--- a/src/app/how-terminals-work/page.test.tsx
+++ b/src/app/how-terminals-work/page.test.tsx
@@ -15,7 +15,7 @@ describe("How Terminals Work page", () => {
 
     const guide = renderToStaticMarkup(<HowTerminalsWorkGuide />);
     expect(guide).toContain("The Grid Model");
-    expect(guide).toContain("What's in a Cell?");
+    expect(guide).toContain("What&#x27;s in a Cell?");
     expect(guide).toContain("Escape Sequences");
     expect(guide).toContain("Input Goes Both Ways");
     expect(guide).toContain("Signals");

--- a/src/app/how-terminals-work/page.tsx
+++ b/src/app/how-terminals-work/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = createMetadata({
 export default function HowTerminalsWorkPage() {
   return (
     <div data-scrollable className="flex-1 overflow-y-auto">
-      <article className="mx-auto flex max-w-xl flex-1 flex-col gap-16 py-16 leading-[1.6]">
+      <article className="mx-auto flex max-w-3xl flex-1 flex-col gap-16 py-16 leading-[1.6]">
         <Section>
           <PageTitle>{HOW_TERMINALS_WORK_TITLE}</PageTitle>
           <p className="text-secondary text-pretty">{HOW_TERMINALS_WORK_INTRO}</p>

--- a/src/app/how-terminals-work/page.tsx
+++ b/src/app/how-terminals-work/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+
+import { Section } from "@/components/shared/ListComponents";
+import { PageTitle } from "@/components/Typography";
+import { HOW_TERMINALS_WORK_INTRO, HOW_TERMINALS_WORK_TITLE } from "@/lib/how-terminals-work";
+import { createMetadata } from "@/lib/metadata";
+
+import { HowTerminalsWorkGuide } from "./HowTerminalsWorkGuide";
+
+export const metadata: Metadata = createMetadata({
+  title: HOW_TERMINALS_WORK_TITLE,
+  description: HOW_TERMINALS_WORK_INTRO,
+  path: "/how-terminals-work",
+});
+
+export default function HowTerminalsWorkPage() {
+  return (
+    <div data-scrollable className="flex-1 overflow-y-auto">
+      <article className="mx-auto flex max-w-xl flex-1 flex-col gap-16 py-16 leading-[1.6]">
+        <Section>
+          <PageTitle>{HOW_TERMINALS_WORK_TITLE}</PageTitle>
+          <p className="text-secondary text-pretty">{HOW_TERMINALS_WORK_INTRO}</p>
+        </Section>
+        <HowTerminalsWorkGuide />
+      </article>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/ui/DemoButton.tsx
+++ b/src/app/how-terminals-work/ui/DemoButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button as UiButton } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+interface DemoButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "toggle";
+  size?: "sm" | "md";
+  active?: boolean;
+}
+
+export function DemoButton({
+  variant = "secondary",
+  size = "md",
+  active = false,
+  className = "",
+  children,
+  ...props
+}: DemoButtonProps) {
+  const mappedVariant =
+    variant === "primary" ? "default" : variant === "toggle" && active ? "secondary" : "outline";
+
+  return (
+    <UiButton
+      variant={mappedVariant}
+      size={size === "sm" ? "sm" : "default"}
+      className={cn(className)}
+      {...props}
+    >
+      {children}
+    </UiButton>
+  );
+}
+
+export { DemoButton as Button };

--- a/src/app/how-terminals-work/ui/FeatureBox.tsx
+++ b/src/app/how-terminals-work/ui/FeatureBox.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+interface FeatureBoxProps {
+  children: React.ReactNode;
+  className?: string;
+  number?: number | string;
+  title?: string;
+}
+
+export function FeatureBox({ children, className = "", number, title }: FeatureBoxProps) {
+  return (
+    <div className={cn("bg-tertiary space-y-2 p-4", className)}>
+      {(number !== undefined || title) && (
+        <div className="text-primary flex items-center gap-2 text-sm font-medium">
+          {number !== undefined && <span className="text-quaternary tabular-nums">{number}</span>}
+          {title && <span>{title}</span>}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/ui/FeatureBox.tsx
+++ b/src/app/how-terminals-work/ui/FeatureBox.tsx
@@ -9,7 +9,7 @@ interface FeatureBoxProps {
 
 export function FeatureBox({ children, className = "", number, title }: FeatureBoxProps) {
   return (
-    <div className={cn("bg-tertiary space-y-2 p-4", className)}>
+    <div className={cn("space-y-2", className)}>
       {(number !== undefined || title) && (
         <div className="text-primary flex items-center gap-2 text-sm font-medium">
           {number !== undefined && <span className="text-quaternary tabular-nums">{number}</span>}

--- a/src/app/how-terminals-work/ui/InfoPanel.tsx
+++ b/src/app/how-terminals-work/ui/InfoPanel.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+
+interface InfoPanelProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function InfoPanel({ children, className = "" }: InfoPanelProps) {
+  return (
+    <div className={cn("border-primary bg-tertiary border px-4 py-3 text-sm", className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/ui/InfoPanel.tsx
+++ b/src/app/how-terminals-work/ui/InfoPanel.tsx
@@ -6,9 +6,5 @@ interface InfoPanelProps {
 }
 
 export function InfoPanel({ children, className = "" }: InfoPanelProps) {
-  return (
-    <div className={cn("border-primary bg-tertiary border px-4 py-3 text-sm", className)}>
-      {children}
-    </div>
-  );
+  return <div className={cn("text-sm", className)}>{children}</div>;
 }

--- a/src/app/how-terminals-work/ui/NumberedStepNavigation.tsx
+++ b/src/app/how-terminals-work/ui/NumberedStepNavigation.tsx
@@ -23,7 +23,7 @@ export function NumberedStepNavigation({
           className={cn(
             "flex h-8 w-8 items-center justify-center border text-sm tabular-nums transition-colors",
             i === currentStep
-              ? "border-primary bg-tertiary text-primary"
+              ? "border-primary bg-primary/10 text-primary"
               : "border-primary text-quaternary hover:text-primary",
           )}
         >

--- a/src/app/how-terminals-work/ui/NumberedStepNavigation.tsx
+++ b/src/app/how-terminals-work/ui/NumberedStepNavigation.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface NumberedStepNavigationProps {
+  totalSteps: number;
+  currentStep: number;
+  onStepChange: (step: number) => void;
+}
+
+export function NumberedStepNavigation({
+  totalSteps,
+  currentStep,
+  onStepChange,
+}: NumberedStepNavigationProps) {
+  return (
+    <div className="flex items-center gap-2">
+      {Array.from({ length: totalSteps }, (_, i) => (
+        <button
+          key={i}
+          type="button"
+          onClick={() => onStepChange(i)}
+          className={cn(
+            "flex h-8 w-8 items-center justify-center border text-sm tabular-nums transition-colors",
+            i === currentStep
+              ? "border-primary bg-tertiary text-primary"
+              : "border-primary text-quaternary hover:text-primary",
+          )}
+        >
+          {i + 1}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/ui/StepDotsNavigation.tsx
+++ b/src/app/how-terminals-work/ui/StepDotsNavigation.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ChevronLeft } from "@/components/icons/ChevronLeft";
+import { ChevronRight } from "@/components/icons/ChevronRight";
+
+interface StepDotsNavigationProps<T extends string> {
+  steps: T[];
+  currentStep: T;
+  onStepChange: (step: T) => void;
+  showBorder?: boolean;
+}
+
+export function StepDotsNavigation<T extends string>({
+  steps,
+  currentStep,
+  onStepChange,
+}: StepDotsNavigationProps<T>) {
+  const currentStepIndex = steps.indexOf(currentStep);
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onStepChange(steps[Math.max(0, currentStepIndex - 1)]!)}
+        disabled={currentStepIndex === 0}
+        className="text-quaternary hover:text-primary p-1 disabled:cursor-not-allowed disabled:opacity-30"
+        aria-label="Previous"
+      >
+        <ChevronLeft size={16} />
+      </button>
+      <span className="text-quaternary min-w-[3ch] text-center text-xs tabular-nums">
+        {currentStepIndex + 1}/{steps.length}
+      </span>
+      <button
+        type="button"
+        onClick={() => onStepChange(steps[Math.min(steps.length - 1, currentStepIndex + 1)]!)}
+        disabled={currentStepIndex === steps.length - 1}
+        className="text-quaternary hover:text-primary p-1 disabled:cursor-not-allowed disabled:opacity-30"
+        aria-label="Next"
+      >
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/ui/SubsectionLabel.tsx
+++ b/src/app/how-terminals-work/ui/SubsectionLabel.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+
+interface SubsectionLabelProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SubsectionLabel({ children, className = "" }: SubsectionLabelProps) {
+  return (
+    <div className={cn("text-quaternary mb-2 text-xs tracking-wide uppercase", className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/app/how-terminals-work/ui/TerminalFrame.tsx
+++ b/src/app/how-terminals-work/ui/TerminalFrame.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+interface TerminalFrameProps {
+  children: React.ReactNode;
+  className?: string;
+  noPadding?: boolean;
+}
+
+export function TerminalFrame({ children, className = "", noPadding = false }: TerminalFrameProps) {
+  return (
+    <div className={cn("border-primary bg-secondary overflow-hidden border", className)}>
+      <div className={cn("font-mono text-sm", !noPadding && "p-4")}>{children}</div>
+    </div>
+  );
+}
+
+/** @deprecated Use TerminalFrame. Kept so ported demos can keep their original import name. */
+export const TerminalWindow = TerminalFrame;

--- a/src/app/how-terminals-work/ui/index.ts
+++ b/src/app/how-terminals-work/ui/index.ts
@@ -1,0 +1,7 @@
+export { Button, DemoButton } from "./DemoButton";
+export { FeatureBox } from "./FeatureBox";
+export { InfoPanel } from "./InfoPanel";
+export { NumberedStepNavigation } from "./NumberedStepNavigation";
+export { StepDotsNavigation } from "./StepDotsNavigation";
+export { SubsectionLabel } from "./SubsectionLabel";
+export { TerminalFrame, TerminalWindow } from "./TerminalFrame";

--- a/src/components/home/HomeHero.test.tsx
+++ b/src/components/home/HomeHero.test.tsx
@@ -23,5 +23,8 @@ describe("homepage content", () => {
     expect(projects).toContain('href="/computer"');
     expect(projects).toContain("How to Computer Better");
     expect(projects).not.toContain("notion.site/how-to-computer-better");
+    expect(projects).toContain('href="/how-terminals-work"');
+    expect(projects).toContain("How Terminals Work");
+    expect(projects).not.toContain("how-terminals-work.vercel.app");
   });
 });

--- a/src/components/home/ProjectsList.tsx
+++ b/src/components/home/ProjectsList.tsx
@@ -81,9 +81,9 @@ export const HOME_PROJECTS = [
   },
   {
     name: "How Terminals Work",
-    href: "https://how-terminals-work.vercel.app/",
+    href: "/how-terminals-work",
     description: "A visual guide to understand terminals",
-    external: true,
+    external: false,
   },
   {
     name: "HN CLI",

--- a/src/lib/activity-shared.ts
+++ b/src/lib/activity-shared.ts
@@ -342,6 +342,7 @@ const KNOWN_PATH_TITLES: Record<string, string> = {
   "/sites": "Sites",
   "/ama": "AMA",
   "/computer": "How to Computer Better",
+  "/how-terminals-work": "How Terminals Work",
   "/listening": "Listening",
   "/hn": "Hacker News",
   "/app-dissection": "App Dissection",

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1572,6 +1572,7 @@ describe("inferTitleFromPath", () => {
     expect(inferTitleFromPath("https://brianlovin.com/writing/foo")).toBe("foo");
     expect(inferTitleFromPath("https://brianlovin.com/writing")).toBe("Writing");
     expect(inferTitleFromPath("/computer")).toBe("How to Computer Better");
+    expect(inferTitleFromPath("/how-terminals-work")).toBe("How Terminals Work");
     expect(inferTitleFromPath("https://1password.com")).not.toBe("Home");
     expect(inferTitleFromPath("https://1password.com")).toBe("");
   });

--- a/src/lib/how-terminals-work.test.ts
+++ b/src/lib/how-terminals-work.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { HOME_PROJECTS } from "@/components/home/ProjectsList";
+import {
+  HOW_TERMINALS_WORK_INTRO,
+  HOW_TERMINALS_WORK_SECTIONS,
+  HOW_TERMINALS_WORK_TITLE,
+} from "@/lib/how-terminals-work";
+import { INDEXABLE_SECTIONS } from "@/lib/site-copy";
+
+describe("how terminals work copy", () => {
+  test("keeps the essay title and intro", () => {
+    expect(HOW_TERMINALS_WORK_TITLE).toBe("How Terminals Work");
+    expect(HOW_TERMINALS_WORK_INTRO).toBe("An interactive guide to understanding terminals");
+  });
+
+  test("lists all 14 numbered sections", () => {
+    expect(HOW_TERMINALS_WORK_SECTIONS).toHaveLength(14);
+    expect(HOW_TERMINALS_WORK_SECTIONS.map((section) => section.title)).toEqual([
+      "The Grid Model",
+      "What's in a Cell?",
+      "Escape Sequences",
+      "Input Goes Both Ways",
+      "Signals",
+      "Raw vs Cooked Mode",
+      "The Round Trip",
+      "Building Complex TUIs",
+      "The Alternate Screen Buffer",
+      "Terminal Icons",
+      "State Management",
+      "Text Selection & Cursor Positioning",
+      "Capability Discovery",
+      "Terminal Vocabulary",
+    ]);
+  });
+});
+
+describe("indexable section", () => {
+  test("includes /how-terminals-work in public section lists", () => {
+    expect(INDEXABLE_SECTIONS.some((section) => section.href === "/how-terminals-work")).toBe(true);
+  });
+});
+
+describe("homepage project", () => {
+  test("points How Terminals Work at the native /how-terminals-work route", () => {
+    const project = HOME_PROJECTS.find((item) => item.name === "How Terminals Work");
+    expect(project).toEqual({
+      name: "How Terminals Work",
+      href: "/how-terminals-work",
+      description: "A visual guide to understand terminals",
+      external: false,
+    });
+  });
+});

--- a/src/lib/how-terminals-work.ts
+++ b/src/lib/how-terminals-work.ts
@@ -1,0 +1,104 @@
+export const HOW_TERMINALS_WORK_TITLE = "How Terminals Work";
+export const HOW_TERMINALS_WORK_INTRO = "An interactive guide to understanding terminals";
+
+export const HOW_TERMINALS_WORK_SECTIONS = [
+  {
+    id: "grid",
+    number: 1,
+    title: "The Grid Model",
+    insight:
+      "A terminal is just a grid of same-sized cells—like a screen with huge pixels that can display the alphabet.",
+  },
+  {
+    id: "cell",
+    number: 2,
+    title: "What's in a Cell?",
+    insight: "Each cell holds one character plus styling info (color, bold, underline). That's it.",
+  },
+  {
+    id: "escape",
+    number: 3,
+    title: "Escape Sequences",
+    insight:
+      'Special character sequences control the terminal—move cursor, change colors, clear screen. That\'s why you sometimes see weird characters like "^[[31m".',
+  },
+  {
+    id: "input",
+    number: 4,
+    title: "Input Goes Both Ways",
+    insight:
+      "When you press a key, the terminal sends bytes to the program. Arrow keys and mouse clicks become escape sequences too.",
+  },
+  {
+    id: "signals",
+    number: 5,
+    title: "Signals",
+    insight:
+      "Ctrl+C doesn't type a character—it triggers a signal. Your terminal sends a byte (0x03), but the kernel's line discipline intercepts it and generates SIGINT before the program ever sees it.",
+  },
+  {
+    id: "input-modes",
+    number: 6,
+    title: "Raw vs Cooked Mode",
+    insight:
+      "In cooked mode, you type a full line and press Enter. In raw mode, every keystroke goes straight to the program. That's why vim responds instantly while your shell waits for Enter.",
+  },
+  {
+    id: "flow",
+    number: 7,
+    title: "The Round Trip",
+    insight:
+      "Every keystroke travels down through the terminal stack to the program, then output flows back up to render on screen.",
+  },
+  {
+    id: "advanced-tui",
+    number: 8,
+    title: "Building Complex TUIs",
+    insight:
+      "Advanced terminal apps like htop or vim divide the screen into regions—each with its own focus, content, and resize behavior. It's like building a GUI, but with characters instead of pixels.",
+  },
+  {
+    id: "alternate-screen",
+    number: 9,
+    title: "The Alternate Screen Buffer",
+    insight:
+      "When you open vim, your terminal history disappears. When you quit, it reappears. That's because terminals have two screens—the normal one (with your scrollback) and an alternate one apps use as a canvas.",
+  },
+  {
+    id: "icons",
+    number: 10,
+    title: "Terminal Icons",
+    insight:
+      "Those file icons in your terminal? They're just Unicode characters from special fonts called Nerd Fonts—thousands of icons mapped to the Private Use Area.",
+  },
+  {
+    id: "state",
+    number: 11,
+    title: "State Management",
+    insight:
+      "When you press Shift+Tab to cycle modes in Claude Code, the terminal doesn't remember anything—your app tracks state in memory and redraws the UI whenever it changes.",
+  },
+  {
+    id: "selection",
+    number: 12,
+    title: "Text Selection & Cursor Positioning",
+    insight:
+      "You can't click to move your cursor because the terminal handles text selection separately from the app's cursor. Option+Click works by simulating arrow keypresses—it's a hack, not native behavior.",
+  },
+  {
+    id: "capability-discovery",
+    number: 13,
+    title: "Capability Discovery",
+    insight:
+      "Before a program can use mouse tracking or 256 colors, it has to ask: what can this terminal do? The TERM variable and escape sequence queries let programs discover—and enable—terminal features.",
+  },
+  {
+    id: "vocabulary",
+    number: 14,
+    title: "Terminal Vocabulary",
+    insight:
+      "Terminal, shell, console, CLI—these words get thrown around interchangeably, but they mean different things. Understanding the distinction helps you know which tool to configure when something isn't working.",
+  },
+] as const;
+
+export type HowTerminalsWorkSection = (typeof HOW_TERMINALS_WORK_SECTIONS)[number];

--- a/src/lib/page-markdown.test.ts
+++ b/src/lib/page-markdown.test.ts
@@ -31,6 +31,15 @@ describe("renderPageMarkdown", () => {
     expect(result.cacheTags).toContain("notion:computer");
   });
 
+  test("how-terminals-work markdown includes the guide title and sections", async () => {
+    const result = await renderPageMarkdown("/how-terminals-work");
+    expect(result.status).toBe(200);
+    expect(result.body).toContain("# How Terminals Work");
+    expect(result.body).toContain("An interactive guide to understanding terminals");
+    expect(result.body).toContain("The Grid Model");
+    expect(result.body).toContain("Terminal Vocabulary");
+  });
+
   test("unknown paths return 404 markdown", async () => {
     const result = await renderPageMarkdown("/some-path-that-does-not-exist");
     expect(result.status).toBe(404);

--- a/src/lib/page-markdown.ts
+++ b/src/lib/page-markdown.ts
@@ -5,6 +5,11 @@ import { getDesignDetailsEpisodes } from "@/lib/design-details";
 import { getGoodWebsitesSource } from "@/lib/goodWebsites";
 import { getPostById, getRankedHNPosts } from "@/lib/hn";
 import {
+  HOW_TERMINALS_WORK_INTRO,
+  HOW_TERMINALS_WORK_SECTIONS,
+  HOW_TERMINALS_WORK_TITLE,
+} from "@/lib/how-terminals-work";
+import {
   getAmaItemContent,
   getAppDissectionDatabaseItems,
   getAppDissectionItemBySlug,
@@ -518,6 +523,25 @@ async function designDetailsMarkdown(id: string): Promise<MarkdownResult> {
   return md(200, body);
 }
 
+async function howTerminalsWorkMarkdown(): Promise<MarkdownResult> {
+  const body = [
+    `# ${HOW_TERMINALS_WORK_TITLE}`,
+    "",
+    HOW_TERMINALS_WORK_INTRO,
+    "",
+    "## Sections",
+    "",
+    ...HOW_TERMINALS_WORK_SECTIONS.flatMap((section) => [
+      `### ${section.number}. ${section.title}`,
+      "",
+      section.insight,
+      "",
+    ]),
+    "[Home](/)",
+  ].join("\n");
+  return md(200, body);
+}
+
 async function numbersMarkdown(): Promise<MarkdownResult> {
   const body = [
     `# Numbers`,
@@ -553,6 +577,7 @@ export async function renderPageMarkdown(pathname: string): Promise<MarkdownResu
   if (path === "/activity") return activityMarkdown();
   if (path === "/app-dissection") return appDissectionIndexMarkdown();
   if (path === "/design-details") return designDetailsIndexMarkdown();
+  if (path === "/how-terminals-work") return howTerminalsWorkMarkdown();
   if (path === "/numbers") return numbersMarkdown();
 
   const writing = path.match(/^\/writing\/([^/]+)$/);

--- a/src/lib/site-copy.test.ts
+++ b/src/lib/site-copy.test.ts
@@ -15,6 +15,7 @@ describe("llms.txt", () => {
     expect(body).toContain(SITE_HOST);
     expect(body).toContain("/writing");
     expect(body).toContain("/computer");
+    expect(body).toContain("/how-terminals-work");
     expect(body).toContain("/sitemap.xml");
     expect(body).toContain(SITE_REPO);
     expect(body).not.toContain("/contact");
@@ -31,6 +32,7 @@ describe("markdown 404", () => {
     expect(body).toContain("/llms.txt");
     expect(body).toContain("/writing");
     expect(body).toContain("/computer");
+    expect(body).toContain("/how-terminals-work");
     expect(body).not.toContain("/contact");
     expect(body).not.toContain("/privacy");
   });

--- a/src/lib/site-copy.ts
+++ b/src/lib/site-copy.ts
@@ -25,6 +25,11 @@ export const INDEXABLE_SECTIONS = [
     href: "/computer",
     note: "Tips for shortcuts, hotkeys, and workflows",
   },
+  {
+    title: "How Terminals Work",
+    href: "/how-terminals-work",
+    note: "An interactive guide to understanding terminals",
+  },
   { title: "Listening", href: "/listening", note: "Recent music from Spotify" },
   { title: "Activity", href: "/activity", note: "Public likes, visits, and other site events" },
   { title: "App Dissection", href: "/app-dissection", note: "Breakdowns of well-designed apps" },
@@ -66,7 +71,7 @@ export function markdownNotFoundBody(): string {
 export function llmsTxtBody(): string {
   return `# ${SITE_NAME}
 
-> Personal site of ${SITE_NAME} (${SITE_HOST} / ${SITE_PRODUCT}): writing, a tools stack, a sites collection, a Hacker News reader, listening history, an AMA, computer tips, and a public activity feed. Source: ${SITE_REPO}.
+> Personal site of ${SITE_NAME} (${SITE_HOST} / ${SITE_PRODUCT}): writing, a tools stack, a sites collection, a Hacker News reader, listening history, an AMA, computer tips, an interactive terminals guide, and a public activity feed. Source: ${SITE_REPO}.
 
 Prefer public HTML pages, the same URLs with \`Accept: text/markdown\`, RSS feeds, \`/llms.txt\`, and \`/sitemap.xml\`. There is no public API.
 

--- a/src/lib/sitemap-urls.test.ts
+++ b/src/lib/sitemap-urls.test.ts
@@ -11,6 +11,7 @@ describe("buildSitemapEntries", () => {
     expect(urls).toContain(`${SITE_CONFIG.url}/`);
     expect(urls).toContain(`${SITE_CONFIG.url}/writing`);
     expect(urls).toContain(`${SITE_CONFIG.url}/about`);
+    expect(urls).toContain(`${SITE_CONFIG.url}/how-terminals-work`);
     expect(urls).toContain(`${SITE_CONFIG.url}/computer`);
     expect(urls).toContain(`${SITE_CONFIG.url}/llms.txt`);
     expect(urls).not.toContain(`${SITE_CONFIG.url}/contact`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Port the standalone [how-terminals-work](https://how-terminals-work.vercel.app/) guide into briOS as a writing-style page.

## What
- New route at `/how-terminals-work` using Writing chrome (`PageTitle`, `Section`/`SectionHeading`)
- Essay column is `max-w-3xl` on this page only so two-column demos have room; two-col layouts stack until `lg`
- All 14 interactive demos from the source essay, restyled to briOS tokens
- Flattened demo chrome: no nested `bg-tertiary` dashboard boxes; FeatureBox/InfoPanel are unfilled
- Contrast fix: data packets, cursors, and play/query buttons use readable site tokens instead of `text-white` on `bg-tertiary`/`bg-primary`
- Cursor Sequences stack code above description so they wrap cleanly
- ANSI / escape / mouse / TERM logic preserved from the original pedagogy
- Homepage project now points at the native route (no external Vercel link)
- Added to sitemap, `llms.txt`, markdown negotiation, and activity path titles

Not added to the sidebar nav — this is a single essay, not a list-detail section.

## Verification
- `bun run lint`
- `bun test` for section copy, hrefs, ANSI parsing, mouse encoding, TERM capabilities
- Browser pass: §07 packets readable in light mode, Cursor Sequences wrap, two-column demos less cramped

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72c3988c-426d-4553-bfc9-c425f32ed2d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72c3988c-426d-4553-bfc9-c425f32ed2d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

