### PR TITLE
Shorten /computer intro copy

### DIFF
--- a/src/lib/computer.test.ts
+++ b/src/lib/computer.test.ts
@@ -27,9 +27,7 @@ function tip(overrides: Partial<ComputerTip> & Pick<ComputerTip, "id" | "title">
 describe("computer copy and links", () => {
   test("keeps the catalog title and intro", () => {
     expect(COMPUTER_TITLE).toBe("How to Computer Better");
-    expect(COMPUTER_INTRO).toBe(
-      "This is a living list of tips to use computers better: shortcuts, hotkeys, utility apps, helpful workflows, and so on.",
-    );
+    expect(COMPUTER_INTRO).toBe("A living list of tips to use your computer better.");
   });
 
   test("reads tip lists from either API envelope", () => {

--- a/src/lib/computer.ts
+++ b/src/lib/computer.ts
@@ -12,8 +12,7 @@ import { buildSlug, extractShortIdFromSlug } from "@/lib/short-id";
 
 export const COMPUTER_TITLE = "How to Computer Better";
 
-export const COMPUTER_INTRO =
-  "This is a living list of tips to use computers better: shortcuts, hotkeys, utility apps, helpful workflows, and so on.";
+export const COMPUTER_INTRO = "A living list of tips to use your computer better.";
 
 export type ComputerTip = NotionComputerItem;
 

--- a/src/lib/page-markdown.test.ts
+++ b/src/lib/page-markdown.test.ts
@@ -25,9 +25,7 @@ describe("renderPageMarkdown", () => {
     const result = await renderPageMarkdown("/computer");
     expect(result.status).toBe(200);
     expect(result.body).toContain("# How to Computer Better");
-    expect(result.body).toContain(
-      "This is a living list of tips to use computers better: shortcuts, hotkeys, utility apps, helpful workflows, and so on.",
-    );
+    expect(result.body).toContain("A living list of tips to use your computer better.");
     expect(result.cacheTags).toContain("notion:computer");
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `/computer` catalog intro to a shorter sentence.

**Before:** `This is a living list of tips to use computers better: shortcuts, hotkeys, utility apps, helpful workflows, and so on.`

**After:** `A living list of tips to use your computer better.`

The `COMPUTER_INTRO` constant in `src/lib/computer.ts` is the single source for this copy (catalog page, metadata, markdown). Tests that asserted the old string were updated (`computer.test.ts`, `page-markdown.test.ts`). `ComputerCatalog.test.tsx` already reads `COMPUTER_INTRO`, so it did not need a hardcoded string change.

No other UI changes.

Verified:
- `bun run lint`
- `bun test` for computer catalog, copy, layout, and markdown
- Live `GET /computer` (200) shows the new sentence in the page body, meta description, and markdown negotiation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8536328-b1a9-48a4-82ff-c03e93d2af95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8536328-b1a9-48a4-82ff-c03e93d2af95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

