### PR TITLE
Hide /how-terminals-work from site discovery

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -134,7 +134,7 @@ export default function About() {
 
             <Section>
               <SectionHeading>Projects</SectionHeading>
-              <ProjectsList exclude={["How Terminals Work"]} />
+              <ProjectsList />
             </Section>
 
             <Section>

--- a/src/components/home/HomeHero.test.tsx
+++ b/src/components/home/HomeHero.test.tsx
@@ -23,8 +23,7 @@ describe("homepage content", () => {
     expect(projects).toContain('href="/computer"');
     expect(projects).toContain("How to Computer Better");
     expect(projects).not.toContain("notion.site/how-to-computer-better");
-    expect(projects).toContain('href="/how-terminals-work"');
-    expect(projects).toContain("How Terminals Work");
-    expect(projects).not.toContain("how-terminals-work.vercel.app");
+    expect(projects).not.toContain('href="/how-terminals-work"');
+    expect(projects).not.toContain("How Terminals Work");
   });
 });

--- a/src/components/home/ProjectsList.tsx
+++ b/src/components/home/ProjectsList.tsx
@@ -80,12 +80,6 @@ export const HOME_PROJECTS = [
     external: true,
   },
   {
-    name: "How Terminals Work",
-    href: "/how-terminals-work",
-    description: "A visual guide to understand terminals",
-    external: false,
-  },
-  {
     name: "HN CLI",
     href: "https://github.com/brianlovin/hn-cli",
     description: "Hacker News in your terminal",

--- a/src/lib/how-terminals-work.test.ts
+++ b/src/lib/how-terminals-work.test.ts
@@ -37,9 +37,8 @@ describe("how terminals work copy", () => {
 
 describe("indexable section", () => {
   test("omits /how-terminals-work from public section lists", () => {
-    expect(INDEXABLE_SECTIONS.some((section) => section.href === "/how-terminals-work")).toBe(
-      false,
-    );
+    const hrefs: string[] = INDEXABLE_SECTIONS.map((section) => section.href);
+    expect(hrefs).not.toContain("/how-terminals-work");
   });
 });
 

--- a/src/lib/how-terminals-work.test.ts
+++ b/src/lib/how-terminals-work.test.ts
@@ -36,19 +36,16 @@ describe("how terminals work copy", () => {
 });
 
 describe("indexable section", () => {
-  test("includes /how-terminals-work in public section lists", () => {
-    expect(INDEXABLE_SECTIONS.some((section) => section.href === "/how-terminals-work")).toBe(true);
+  test("omits /how-terminals-work from public section lists", () => {
+    expect(INDEXABLE_SECTIONS.some((section) => section.href === "/how-terminals-work")).toBe(
+      false,
+    );
   });
 });
 
 describe("homepage project", () => {
-  test("points How Terminals Work at the native /how-terminals-work route", () => {
-    const project = HOME_PROJECTS.find((item) => item.name === "How Terminals Work");
-    expect(project).toEqual({
-      name: "How Terminals Work",
-      href: "/how-terminals-work",
-      description: "A visual guide to understand terminals",
-      external: false,
-    });
+  test("omits How Terminals Work from the homepage projects list", () => {
+    expect(HOME_PROJECTS.find((item) => item.name === "How Terminals Work")).toBeUndefined();
+    expect(HOME_PROJECTS.some((item) => item.href === "/how-terminals-work")).toBe(false);
   });
 });

--- a/src/lib/page-markdown.test.ts
+++ b/src/lib/page-markdown.test.ts
@@ -10,6 +10,8 @@ describe("renderPageMarkdown", () => {
     expect(result.body).toContain(`# ${SITE_NAME}`);
     expect(result.body).toContain("## Writing");
     expect(result.body).toContain("/writing");
+    expect(result.body).not.toContain("/how-terminals-work");
+    expect(result.body).not.toContain("How Terminals Work");
     expect(result.cacheTags).toContain("notion:writing");
   });
 

--- a/src/lib/site-copy.test.ts
+++ b/src/lib/site-copy.test.ts
@@ -15,7 +15,8 @@ describe("llms.txt", () => {
     expect(body).toContain(SITE_HOST);
     expect(body).toContain("/writing");
     expect(body).toContain("/computer");
-    expect(body).toContain("/how-terminals-work");
+    expect(body).not.toContain("/how-terminals-work");
+    expect(body).not.toContain("interactive terminals guide");
     expect(body).toContain("/sitemap.xml");
     expect(body).toContain(SITE_REPO);
     expect(body).not.toContain("/contact");
@@ -32,7 +33,7 @@ describe("markdown 404", () => {
     expect(body).toContain("/llms.txt");
     expect(body).toContain("/writing");
     expect(body).toContain("/computer");
-    expect(body).toContain("/how-terminals-work");
+    expect(body).not.toContain("/how-terminals-work");
     expect(body).not.toContain("/contact");
     expect(body).not.toContain("/privacy");
   });

--- a/src/lib/site-copy.ts
+++ b/src/lib/site-copy.ts
@@ -25,11 +25,6 @@ export const INDEXABLE_SECTIONS = [
     href: "/computer",
     note: "Tips for shortcuts, hotkeys, and workflows",
   },
-  {
-    title: "How Terminals Work",
-    href: "/how-terminals-work",
-    note: "An interactive guide to understanding terminals",
-  },
   { title: "Listening", href: "/listening", note: "Recent music from Spotify" },
   { title: "Activity", href: "/activity", note: "Public likes, visits, and other site events" },
   { title: "App Dissection", href: "/app-dissection", note: "Breakdowns of well-designed apps" },
@@ -71,7 +66,7 @@ export function markdownNotFoundBody(): string {
 export function llmsTxtBody(): string {
   return `# ${SITE_NAME}
 
-> Personal site of ${SITE_NAME} (${SITE_HOST} / ${SITE_PRODUCT}): writing, a tools stack, a sites collection, a Hacker News reader, listening history, an AMA, computer tips, an interactive terminals guide, and a public activity feed. Source: ${SITE_REPO}.
+> Personal site of ${SITE_NAME} (${SITE_HOST} / ${SITE_PRODUCT}): writing, a tools stack, a sites collection, a Hacker News reader, listening history, an AMA, computer tips, and a public activity feed. Source: ${SITE_REPO}.
 
 Prefer public HTML pages, the same URLs with \`Accept: text/markdown\`, RSS feeds, \`/llms.txt\`, and \`/sitemap.xml\`. There is no public API.
 

--- a/src/lib/sitemap-urls.test.ts
+++ b/src/lib/sitemap-urls.test.ts
@@ -11,7 +11,7 @@ describe("buildSitemapEntries", () => {
     expect(urls).toContain(`${SITE_CONFIG.url}/`);
     expect(urls).toContain(`${SITE_CONFIG.url}/writing`);
     expect(urls).toContain(`${SITE_CONFIG.url}/about`);
-    expect(urls).toContain(`${SITE_CONFIG.url}/how-terminals-work`);
+    expect(urls).not.toContain(`${SITE_CONFIG.url}/how-terminals-work`);
     expect(urls).toContain(`${SITE_CONFIG.url}/computer`);
     expect(urls).toContain(`${SITE_CONFIG.url}/llms.txt`);
     expect(urls).not.toContain(`${SITE_CONFIG.url}/contact`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Keep `/how-terminals-work` live for direct visits (and markdown negotiation), but stop advertising it while the essay is polished.

## Changes
- Remove the How Terminals Work entry from homepage `HOME_PROJECTS`
- Drop the route from `INDEXABLE_SECTIONS` so sitemap, `llms.txt`, homepage markdown, and markdown 404 lists no longer mention it
- Leave site nav as-is (there was no HTW nav entry; HN CLI’s Terminal icon stays)
- Invert discovery/href tests to assert the route is absent from visitor-facing lists

## Kept
- The `/how-terminals-work` page, demos, and page-level markdown
- Activity title inference for the path

## Verification
[Homepage projects without How Terminals Work](https://cursor.com/agents/bc-fd39ef3e-585b-4c86-91d1-6061abcf5068/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_projects_no_htw.webp)
[Nav sidebar without How Terminals Work](https://cursor.com/agents/bc-fd39ef3e-585b-4c86-91d1-6061abcf5068/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnav_sidebar_no_htw.webp)
[Command palette search for How Terminals has no results](https://cursor.com/agents/bc-fd39ef3e-585b-4c86-91d1-6061abcf5068/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcommand_palette_how_terminals.webp)
[Direct /how-terminals-work URL still loads](https://cursor.com/agents/bc-fd39ef3e-585b-4c86-91d1-6061abcf5068/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdirect_url_how_terminals_work.webp)
[hide_how_terminals_work_discovery.mp4](https://cursor.com/agents/bc-fd39ef3e-585b-4c86-91d1-6061abcf5068/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhide_how_terminals_work_discovery.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd39ef3e-585b-4c86-91d1-6061abcf5068?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd39ef3e-585b-4c86-91d1-6061abcf5068&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

