### PR TITLE
Ack illustrate-journal webhooks before Gemini/Sharp work

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -63,7 +63,7 @@ Webhook endpoints called by Notion database automations (button properties). All
 
 - `/api/webhooks/generate-short-id` — Generates a unique 7-char Short ID for writing posts
 - `/api/webhooks/optimize-writing-images` — Optimizes and uploads blog images to R2
-- `/api/webhooks/illustrate-journal` — Replaces Journal page photos in place with 4:3 rubber-stamp field-note posters
+- `/api/webhooks/illustrate-journal` — Acks immediately, then replaces Journal page photos in place with 4:3 rubber-stamp field-note posters
 - `/api/webhooks/process-stack-icon` — Optimizes existing stack page icons to R2
 - `/api/webhooks/update-site-icon` — Fetches and optimizes favicons for good websites
 
@@ -73,7 +73,7 @@ Webhook endpoints called by Notion database automations (button properties). All
 2. URL: `https://brianlovin.com/api/webhooks/illustrate-journal`
 3. Header: `x-webhook-secret` = `NOTION_WEBHOOK_VERIFICATION_SECRET`
 4. Body: the automation page payload, `{ "data": { "id": "{{id}}" } }`
-5. Each run walks image blocks (max 8), skips captions already marked `field-note`, and replaces the block URL with the poster. Videos are ignored. Do not keep originals.
+5. The route returns 200 immediately (`{ accepted: true, pageId }`) so Notion does not time out. Gemini + Sharp + R2 run after the response via Next.js `after()` (`maxDuration` 300). Each run walks image blocks (max 8), skips captions already marked `field-note`, and replaces the block URL with the poster. Videos are ignored. Do not keep originals.
 
 **Cache purge buttons** (same `CACHE_PURGE_SECRET` as `/api/purge-cache`):
 

--- a/src/app/api/webhooks/illustrate-journal/route.test.ts
+++ b/src/app/api/webhooks/illustrate-journal/route.test.ts
@@ -1,4 +1,29 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { NextResponse } from "next/server";
+
+const afterMock = mock(() => {});
+const generateStamp = mock(async () => {
+  throw new Error("generateStamp should not run before the webhook ack");
+});
+const composeFieldNotePoster = mock(async () => {
+  throw new Error("composeFieldNotePoster should not run before the webhook ack");
+});
+
+mock.module("next/server", () => ({
+  NextResponse,
+  after: afterMock,
+}));
+
+mock.module("./stamp", () => ({
+  generateStamp,
+  STAMP_MODEL: "test",
+  referencePhotoForStamp: mock(),
+}));
+
+mock.module("./compose", () => ({
+  composeFieldNotePoster,
+  preparePhotoBuffer: mock(async (buffer: Buffer) => buffer),
+}));
 
 import { POST } from "./route";
 
@@ -20,6 +45,9 @@ describe("POST /api/webhooks/illustrate-journal", () => {
 
   beforeEach(() => {
     process.env.NOTION_WEBHOOK_VERIFICATION_SECRET = TEST_SECRET;
+    afterMock.mockClear();
+    generateStamp.mockClear();
+    composeFieldNotePoster.mockClear();
   });
 
   afterEach(() => {
@@ -34,11 +62,13 @@ describe("POST /api/webhooks/illustrate-journal", () => {
     const res = await POST(webhookRequest({ data: { id: "page-1" } }));
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(afterMock).not.toHaveBeenCalled();
   });
 
   test("returns 401 for a mismatched webhook secret", async () => {
     const res = await POST(webhookRequest({ data: { id: "page-1" } }, "wrong-secret"));
     expect(res.status).toBe(401);
+    expect(afterMock).not.toHaveBeenCalled();
   });
 
   test("returns 400 when data.id is missing", async () => {
@@ -47,5 +77,16 @@ describe("POST /api/webhooks/illustrate-journal", () => {
     expect(await res.json()).toEqual({
       error: "Missing required field: data.id (pageId)",
     });
+    expect(afterMock).not.toHaveBeenCalled();
+  });
+
+  test("acks immediately and schedules illustrate work with after()", async () => {
+    const res = await POST(webhookRequest({ data: { id: "page-1" } }, TEST_SECRET));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accepted: true, pageId: "page-1" });
+    expect(afterMock).toHaveBeenCalledTimes(1);
+    expect(generateStamp).not.toHaveBeenCalled();
+    expect(composeFieldNotePoster).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/webhooks/illustrate-journal/route.ts
+++ b/src/app/api/webhooks/illustrate-journal/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 
 import { errorResponse, safeCompare } from "@/lib/api-utils";
 import { isFullPage, notion } from "@/lib/notion";
@@ -101,22 +101,8 @@ async function illustrateImageBlock(
   return { blockId: media.id, status: "processed", url: r2Url };
 }
 
-export async function POST(request: Request) {
+async function illustrateJournalPage(pageId: string): Promise<void> {
   try {
-    const webhookSecret = process.env.NOTION_WEBHOOK_VERIFICATION_SECRET;
-    const providedSecret = request.headers.get("x-webhook-secret");
-    if (!safeCompare(providedSecret, webhookSecret)) {
-      return errorResponse("Unauthorized", 401);
-    }
-
-    const body = await request.json();
-    const pageId = body.data?.id;
-
-    if (!pageId) {
-      console.error("Missing required field: data.id (pageId)", body);
-      return errorResponse("Missing required field: data.id (pageId)", 400);
-    }
-
     console.log(`\n🖼  Illustrating journal photos for page ${pageId}\n`);
 
     const page = await notion.pages.retrieve({ page_id: pageId });
@@ -158,17 +144,33 @@ export async function POST(request: Request) {
       }
     }
 
-    return NextResponse.json({
-      success: true,
-      processed,
-      skipped: skipped.length,
-      failed,
-      remaining,
+    console.log(
+      `✅ Journal illustrate complete: processed=${processed} skipped=${skipped.length} failed=${failed} remaining=${remaining}`,
       results,
-    });
+    );
   } catch (error) {
     console.error("Error illustrating journal images", error);
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    return errorResponse(`Failed to illustrate journal images: ${errorMessage}`, 500, error);
   }
+}
+
+export async function POST(request: Request) {
+  const webhookSecret = process.env.NOTION_WEBHOOK_VERIFICATION_SECRET;
+  const providedSecret = request.headers.get("x-webhook-secret");
+  if (!safeCompare(providedSecret, webhookSecret)) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const pageId = body.data?.id;
+
+  if (!pageId) {
+    console.error("Missing required field: data.id (pageId)", body);
+    return errorResponse("Missing required field: data.id (pageId)", 400);
+  }
+
+  after(() => {
+    void illustrateJournalPage(pageId);
+  });
+
+  return NextResponse.json({ accepted: true, pageId });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Notion’s button toast times out because `POST /api/webhooks/illustrate-journal` waited for Gemini + Sharp + R2. The handler now verifies `x-webhook-secret` and `data.id`, then returns `200 { accepted: true, pageId }` immediately.

The existing illustrate pipeline (stamp generation, Sharp compose, R2 upload, in-place Notion replace) runs after the response via Next.js `after()`. `maxDuration` stays 300. Per-image processed/skipped/failed logs are unchanged; page-level failures are logged instead of being dropped.

Poster look and the stamp/composite path are untouched.

## Tests

Route tests still cover 401/400. A new test asserts a valid request acks with `{ accepted: true, pageId }` and that `after()` is scheduled without calling `generateStamp` or `composeFieldNotePoster`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6deace2a-bf13-4668-b18a-a2427716342f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6deace2a-bf13-4668-b18a-a2427716342f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

