### PR TITLE
Skip individual /api/likes GETs inside BatchLikesContext

### DIFF
--- a/src/lib/hooks/useLikes.test.ts
+++ b/src/lib/hooks/useLikes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { individualLikesKey } from "@/lib/hooks/useLikes";
+
+describe("individualLikesKey", () => {
+  test("does not register an individual GET when BatchLikesContext is present", () => {
+    expect(individualLikesKey("page-1", true)).toBeNull();
+  });
+
+  test("uses the individual likes key when there is no batch provider", () => {
+    expect(individualLikesKey("page-1", false)).toBe("/api/likes/page-1");
+  });
+
+  test("does not register a key without a page id", () => {
+    expect(individualLikesKey("", false)).toBeNull();
+    expect(individualLikesKey("", true)).toBeNull();
+  });
+});

--- a/src/lib/hooks/useLikes.ts
+++ b/src/lib/hooks/useLikes.ts
@@ -33,6 +33,11 @@ type BatchLikesContextType = {
 
 export const BatchLikesContext = createContext<BatchLikesContextType | null>(null);
 
+/** Individual GET key. Null inside BatchLikesContext so SWR does not request `/api/likes/:id`. */
+export function individualLikesKey(pageId: string, inBatch: boolean): string | null {
+  return pageId && !inBatch ? `/api/likes/${pageId}` : null;
+}
+
 function persistViewerLike(pageId: string, data: LikeData) {
   if (!isViewerLikeData(data) || !Number.isFinite(data.count) || !Number.isFinite(data.userLikes)) {
     return;
@@ -56,19 +61,19 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
   );
   const storedHint = storedViewerHint(stored, pageId);
 
-  const { data, error } = useSWR<LikeData>(
-    pageId ? `/api/likes/${pageId}` : null,
-    inBatch ? null : fetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      revalidateIfStale: false,
-    },
-  );
+  // Null fetcher does not disable the request: SWR does `fn || config.fetcher`,
+  // and the app-wide SWRConfig supplies `fetcher`. Disable with a null key.
+  const { data, error } = useSWR<LikeData>(individualLikesKey(pageId, inBatch), fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+  });
 
   const { count, userLikes, viewerKnown } = resolveLikeState(
     countOnly,
-    batchContext?.viewer?.[pageId] ?? storedHint,
+    // This-tab store is written on like; prefer it over a stale batch snapshot
+    // so list pages still update after POST without a per-id GET.
+    storedHint ?? batchContext?.viewer?.[pageId],
     data,
   );
 
@@ -82,52 +87,66 @@ export function useLikes(pageId: string, target: LikeActivityTarget = {}) {
     if (!payload) return;
 
     const optimisticData = optimisticAddLike(count, userLikes);
+    const rollbackViewer = storedHint ?? batchContext?.viewer?.[pageId];
+    if (inBatch) persistViewerLike(pageId, optimisticData);
 
-    await mutate(
-      `/api/likes/${pageId}`,
-      async () => {
-        const res = await fetch(`/api/likes/${pageId}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        });
-        if (!res.ok) {
-          throw new Error("Failed to like");
-        }
-        const next = (await res.json()) as LikeData;
-        persistViewerLike(pageId, next);
-        return next;
-      },
-      {
-        optimisticData,
-        rollbackOnError: true,
-        revalidate: false,
-      },
-    );
+    try {
+      await mutate(
+        `/api/likes/${pageId}`,
+        async () => {
+          const res = await fetch(`/api/likes/${pageId}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+          if (!res.ok) {
+            throw new Error("Failed to like");
+          }
+          const next = (await res.json()) as LikeData;
+          persistViewerLike(pageId, next);
+          return next;
+        },
+        {
+          optimisticData,
+          rollbackOnError: true,
+          revalidate: false,
+        },
+      );
+    } catch (error) {
+      if (inBatch && rollbackViewer) persistViewerLike(pageId, rollbackViewer);
+      throw error;
+    }
   };
 
   const removeLike = async () => {
     if (userLikes <= 0) return;
 
     const optimisticData = optimisticRemoveLike(count, userLikes);
+    const rollbackViewer = storedHint ?? batchContext?.viewer?.[pageId];
+    if (inBatch) persistViewerLike(pageId, optimisticData);
 
-    await mutate(
-      `/api/likes/${pageId}`,
-      async () => {
-        const res = await fetch(`/api/likes/${pageId}`, { method: "DELETE" });
-        if (!res.ok) {
-          throw new Error("Failed to remove like");
-        }
-        const next = (await res.json()) as LikeData;
-        persistViewerLike(pageId, next);
-        return next;
-      },
-      {
-        optimisticData,
-        rollbackOnError: true,
-        revalidate: false,
-      },
-    );
+    try {
+      await mutate(
+        `/api/likes/${pageId}`,
+        async () => {
+          const res = await fetch(`/api/likes/${pageId}`, { method: "DELETE" });
+          if (!res.ok) {
+            throw new Error("Failed to remove like");
+          }
+          const next = (await res.json()) as LikeData;
+          persistViewerLike(pageId, next);
+          return next;
+        },
+        {
+          optimisticData,
+          rollbackOnError: true,
+          revalidate: false,
+        },
+      );
+    } catch (error) {
+      if (inBatch && rollbackViewer) persistViewerLike(pageId, rollbackViewer);
+      throw error;
+    }
   };
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes BRIOS-Y (N+1 `GET /api/likes/:id` on `/sites`, 717 events).

## Root cause

`useLikes` always registered the SWR key `/api/likes/${pageId}` and passed `inBatch ? null : fetcher`. SWR does not treat a null fetcher as “do not fetch”: `withArgs` resolves `fn || config.fetcher`, and the app-wide `SWRConfig` supplies `fetcher`. Every `LikeButton` and every gallery `useLikes(item.id)` on `/sites` still issued an individual GET even though `GoodWebsitesPageClient` already wraps the list in `BatchLikesProvider` (`GET /api/likes/batch?ids=...`).

Gallery cards call `useLikes` twice (item hook + `LikeButton`), so the per-card GET was duplicated.

## Fix

- When `BatchLikesContext` is present, pass a **null SWR key** so SWR does not request `/api/likes/:id`.
- Keep the individual GET only when there is no batch provider.
- Do not change like POST/DELETE HTTP or the batch endpoint.
- Prefer the this-tab viewer store over a stale batch snapshot so list pages still update after like without a per-id GET.

BRIOS-Z (`/api/til/*` on `/til`) is a separate per-entry content fetch, not this SWR-key bug. Left alone.

## Tests

`individualLikesKey` asserts: batch context → no `/api/likes/${id}` key; no batch provider → individual key.

Headless Chrome on `/sites` after the fix: only `GET /api/likes/batch` (React Strict Mode remount). Zero individual `/api/likes/:id` GETs.

Manual check: `/sites` like on Benji Taylor went 41 → 42 and the heart filled. `/stack` like buttons still render.

[Sites likes before click](https://cursor.com/agents/bc-23b104e0-ab51-41e1-baff-df5aadc76abd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsites_likes_before_click.webp)
[Sites likes after click](https://cursor.com/agents/bc-23b104e0-ab51-41e1-baff-df5aadc76abd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsites_likes_after_click.webp)
[sites_like_click_still_works.mp4](https://cursor.com/agents/bc-23b104e0-ab51-41e1-baff-df5aadc76abd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsites_like_click_still_works.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23b104e0-ab51-41e1-baff-df5aadc76abd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23b104e0-ab51-41e1-baff-df5aadc76abd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

