### PR TITLE
Paginate Good websites Notion queries past the first 100 rows

### DIFF
--- a/src/lib/notion/queries.test.ts
+++ b/src/lib/notion/queries.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+import * as cache from "./cache";
+import { notion } from "./client";
+import { getGoodWebsitesDatabaseItems, getGoodWebsitesDatabaseItemsForRss } from "./queries";
+import type { PageResponse } from "./types";
+
+function richTextItem(content: string) {
+  return {
+    type: "text" as const,
+    text: { content, link: null },
+    annotations: {
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: "default" as const,
+    },
+    plain_text: content,
+    href: null,
+  };
+}
+
+function goodWebsitePage({
+  id,
+  name,
+  url,
+  createdTime = "2024-01-01T00:00:00.000Z",
+}: {
+  id: string;
+  name: string;
+  url?: string;
+  createdTime?: string;
+}): PageResponse {
+  return {
+    object: "page",
+    id,
+    created_time: createdTime,
+    icon: null,
+    properties: {
+      Name: { id: "title", type: "title", title: [richTextItem(name)] },
+      URL: { id: "url", type: "url", url: url ?? null },
+      "Created time": {
+        id: "created",
+        type: "created_time",
+        created_time: createdTime,
+      },
+    },
+  } as PageResponse;
+}
+
+function queryPage(
+  results: PageResponse[],
+  { hasMore = false, nextCursor = null }: { hasMore?: boolean; nextCursor?: string | null } = {},
+) {
+  return {
+    object: "list" as const,
+    results,
+    has_more: hasMore,
+    next_cursor: nextCursor,
+  };
+}
+
+function stubGoodWebsitesFetch() {
+  process.env.NOTION_GOOD_WEBSITES_DATABASE_ID = "db-good-websites";
+  spyOn(cache, "cachedNotionQuery").mockImplementation(async (_key, fetcher) => fetcher());
+  spyOn(notion.databases, "retrieve").mockResolvedValue({
+    data_sources: [{ id: "ds-good-websites" }],
+  } as never);
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("getGoodWebsitesDatabaseItems", () => {
+  test("follows start_cursor until has_more is false and keeps Name sort", async () => {
+    stubGoodWebsitesFetch();
+    const query = spyOn(notion.dataSources, "query").mockImplementation(async (args) => {
+      if (!args.start_cursor) {
+        return queryPage(
+          [goodWebsitePage({ id: "1", name: "Linear", url: "https://linear.app" })],
+          {
+            hasMore: true,
+            nextCursor: "cursor-page-2",
+          },
+        ) as never;
+      }
+
+      expect(args.start_cursor).toBe("cursor-page-2");
+      return queryPage([
+        goodWebsitePage({ id: "2", name: "SF Compute", url: "https://sfcompute.com" }),
+      ]) as never;
+    });
+
+    const items = await getGoodWebsitesDatabaseItems();
+
+    expect(items.map((item) => ({ id: item.id, name: item.name, url: item.url }))).toEqual([
+      { id: "1", name: "Linear", url: "https://linear.app" },
+      { id: "2", name: "SF Compute", url: "https://sfcompute.com" },
+    ]);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0]?.[0]).toEqual({
+      data_source_id: "ds-good-websites",
+      page_size: 100,
+      sorts: [{ property: "Name", direction: "ascending" }],
+    });
+    expect(query.mock.calls[1]?.[0]).toEqual({
+      data_source_id: "ds-good-websites",
+      page_size: 100,
+      start_cursor: "cursor-page-2",
+      sorts: [{ property: "Name", direction: "ascending" }],
+    });
+  });
+
+  test("returns a single page when Notion is already exhausted", async () => {
+    stubGoodWebsitesFetch();
+    const query = spyOn(notion.dataSources, "query").mockResolvedValue(
+      queryPage([goodWebsitePage({ id: "1", name: "Linear", url: "https://linear.app" })]) as never,
+    );
+
+    const items = await getGoodWebsitesDatabaseItems();
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.name).toBe("Linear");
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0]?.[0]).not.toHaveProperty("start_cursor");
+  });
+
+  test("drops partial rows while still concatenating later pages", async () => {
+    stubGoodWebsitesFetch();
+    spyOn(notion.dataSources, "query").mockImplementation(async (args) => {
+      if (!args.start_cursor) {
+        return queryPage(
+          [
+            { object: "page", id: "partial" } as PageResponse,
+            goodWebsitePage({ id: "1", name: "A" }),
+          ],
+          { hasMore: true, nextCursor: "next" },
+        ) as never;
+      }
+
+      return queryPage([goodWebsitePage({ id: "2", name: "SF Computer" })]) as never;
+    });
+
+    const items = await getGoodWebsitesDatabaseItems();
+
+    expect(items.map((item) => item.id)).toEqual(["1", "2"]);
+  });
+});
+
+describe("getGoodWebsitesDatabaseItemsForRss", () => {
+  test("aggregates every page and keeps Created time descending sort", async () => {
+    stubGoodWebsitesFetch();
+    const query = spyOn(notion.dataSources, "query").mockImplementation(async (args) => {
+      if (!args.start_cursor) {
+        return queryPage(
+          [
+            goodWebsitePage({
+              id: "new",
+              name: "Newer site",
+              url: "https://new.example",
+              createdTime: "2026-01-02T00:00:00.000Z",
+            }),
+          ],
+          { hasMore: true, nextCursor: "rss-page-2" },
+        ) as never;
+      }
+
+      expect(args.start_cursor).toBe("rss-page-2");
+      return queryPage([
+        goodWebsitePage({
+          id: "old",
+          name: "Older site",
+          url: "https://old.example",
+          createdTime: "2025-01-01T00:00:00.000Z",
+        }),
+      ]) as never;
+    });
+
+    const items = await getGoodWebsitesDatabaseItemsForRss();
+
+    expect(
+      items.map((item) => ({
+        id: item.id,
+        name: item.name,
+        url: item.url,
+        createdTime: item.createdTime,
+      })),
+    ).toEqual([
+      {
+        id: "new",
+        name: "Newer site",
+        url: "https://new.example",
+        createdTime: "2026-01-02T00:00:00.000Z",
+      },
+      {
+        id: "old",
+        name: "Older site",
+        url: "https://old.example",
+        createdTime: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0]?.[0]).toMatchObject({
+      data_source_id: "ds-good-websites",
+      page_size: 100,
+      sorts: [{ property: "Created time", direction: "descending" }],
+    });
+    expect(query.mock.calls[1]?.[0]).toMatchObject({
+      start_cursor: "rss-page-2",
+      page_size: 100,
+    });
+  });
+});

--- a/src/lib/notion/queries.ts
+++ b/src/lib/notion/queries.ts
@@ -47,6 +47,29 @@ import {
   richTextPlainText,
 } from "./types";
 
+type DataSourceQueryArgs = Parameters<typeof notion.dataSources.query>[0];
+type DataSourceQueryResults = Awaited<ReturnType<typeof notion.dataSources.query>>["results"];
+
+async function queryAllDataSourcePages(
+  args: Omit<DataSourceQueryArgs, "start_cursor" | "page_size">,
+): Promise<DataSourceQueryResults> {
+  const results: DataSourceQueryResults = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await notion.dataSources.query({
+      ...args,
+      page_size: 100,
+      ...(cursor ? { start_cursor: cursor } : {}),
+    });
+
+    results.push(...response.results);
+    cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+  } while (cursor);
+
+  return results;
+}
+
 export async function getDataSourceId(databaseId: string): Promise<string> {
   return cachedNotionQuery(
     `notion:datasource:${databaseId}`,
@@ -344,7 +367,7 @@ export async function getGoodWebsitesDatabaseItems(): Promise<GoodWebsiteItem[]>
     async () => {
       const databaseId = process.env.NOTION_GOOD_WEBSITES_DATABASE_ID || "";
       const dataSourceId = await getDataSourceId(databaseId);
-      const response = await notion.dataSources.query({
+      const results = await queryAllDataSourcePages({
         data_source_id: dataSourceId,
         sorts: [
           {
@@ -354,7 +377,7 @@ export async function getGoodWebsitesDatabaseItems(): Promise<GoodWebsiteItem[]>
         ],
       });
 
-      return response.results
+      return results
         .map(mapGoodWebsiteItem)
         .filter((item): item is GoodWebsiteItem => item !== null);
     },
@@ -368,7 +391,7 @@ export async function getGoodWebsitesDatabaseItemsForRss(): Promise<GoodWebsiteI
     async () => {
       const databaseId = process.env.NOTION_GOOD_WEBSITES_DATABASE_ID || "";
       const dataSourceId = await getDataSourceId(databaseId);
-      const response = await notion.dataSources.query({
+      const results = await queryAllDataSourcePages({
         data_source_id: dataSourceId,
         sorts: [
           {
@@ -378,7 +401,7 @@ export async function getGoodWebsitesDatabaseItemsForRss(): Promise<GoodWebsiteI
         ],
       });
 
-      return response.results
+      return results
         .map(mapGoodWebsiteItemWithDate)
         .filter((item): item is GoodWebsiteItemWithDate => item !== null);
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`getGoodWebsitesDatabaseItems` and `getGoodWebsitesDatabaseItemsForRss` each called `notion.dataSources.query` once. Notion defaults to ~100 results per page. With 168 Good websites rows sorted by Name, anything past that first page (for example SF Computer / SF Compute) never reached `/api/sites` or `/sites`, even after `purge-cache?type=sites`.

## Change

Both list fetchers now loop with `page_size: 100` and `start_cursor` until `has_more` is false, matching the existing computer-tips pagination. Sorts, mappers, and filters are unchanged:

- `/sites` and `/api/sites` still sort by Name ascending
- RSS still sorts by Created time descending
- Partial pages are still dropped by the existing mappers

## Tests

`src/lib/notion/queries.test.ts` mocks a `has_more` first page plus a final page and asserts both functions concatenate every mapped row, pass `start_cursor` on the follow-up call, and keep their original sorts.

Live check against the Good websites database (not committed): a single Notion page still returns 100 rows and omits SF Computer. After pagination, both list and RSS return **168** rows, including `SF Computer` (`https://sfcompute.com/`) and `SF Compute (Old)` (`https://old.sfcompute.com/`). Local `/api/sites` and `/sites` also include those rows.

## Notes

Do not merge from this PR unless you intend to. After deploy, `purge-cache?type=sites` is still needed so cached lists pick up the full set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63483ef4-895a-455e-a414-98a383eaae71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63483ef4-895a-455e-a414-98a383eaae71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

