### PR TITLE
Expire Notion cache tags immediately on purge

### DIFF
--- a/src/lib/notion/cache.ts
+++ b/src/lib/notion/cache.ts
@@ -67,7 +67,7 @@ interface CachedNotionQueryOptions {
 /**
  * Derive a coarse cache tag from a key like `notion:writing:content:v2:<id>`.
  * Returns the first two segments so a whole content type can be invalidated
- * at once via `revalidateTag("notion:writing", "max")`.
+ * at once via `revalidateTag("notion:writing", { expire: 0 })`.
  */
 function deriveTag(key: string): string {
   return key.split(":").slice(0, 2).join(":");

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -99,7 +99,7 @@ describe("purgeContentType", () => {
     await expect(purgeContentType("writing")).resolves.toBe(4);
     expect(invalidate).toHaveBeenCalledTimes(1);
     expect(invalidate).toHaveBeenCalledWith("notion:writing:*");
-    expect(revalidateTag).toHaveBeenCalledWith("notion:writing", "max");
+    expect(revalidateTag).toHaveBeenCalledWith("notion:writing", { expire: 0 });
     expect(revalidatePath).toHaveBeenCalledTimes(3);
     expect(revalidatePath).toHaveBeenCalledWith("/writing");
     expect(revalidatePath).toHaveBeenCalledWith("/api/writing");
@@ -111,7 +111,7 @@ describe("purgeContentType", () => {
 
     await expect(purgeContentType("sites")).resolves.toBe(2);
     expect(invalidate).toHaveBeenCalledWith("notion:good-websites:*");
-    expect(revalidateTag).toHaveBeenCalledWith("notion:good-websites", "max");
+    expect(revalidateTag).toHaveBeenCalledWith("notion:good-websites", { expire: 0 });
     expect(revalidatePath).toHaveBeenCalledTimes(2);
     expect(revalidatePath).toHaveBeenCalledWith("/sites");
     expect(revalidatePath).toHaveBeenCalledWith("/api/sites");
@@ -122,10 +122,25 @@ describe("purgeContentType", () => {
 
     await expect(purgeContentType("stack")).resolves.toBe(1);
     expect(invalidate).toHaveBeenCalledWith("notion:stack:*");
-    expect(revalidateTag).toHaveBeenCalledWith("notion:stack", "max");
+    expect(revalidateTag).toHaveBeenCalledWith("notion:stack", { expire: 0 });
     expect(revalidatePath).toHaveBeenCalledTimes(2);
     expect(revalidatePath).toHaveBeenCalledWith("/stack");
     expect(revalidatePath).toHaveBeenCalledWith("/api/stacks");
+  });
+
+  test("expires every content-type tag immediately instead of SWR max", async () => {
+    spyOn(cache, "invalidateNotionCache").mockResolvedValue(1);
+    spyOn(hnCache, "clearHnCache").mockResolvedValue(1);
+
+    for (const type of PURGEABLE_CONTENT_TYPES) {
+      revalidateTag.mockClear();
+      await purgeContentType(type);
+      expect(revalidateTag).toHaveBeenCalled();
+      for (const call of revalidateTag.mock.calls) {
+        expect(call[1]).toEqual({ expire: 0 });
+        expect(call[1]).not.toBe("max");
+      }
+    }
   });
 
   test("clears HN Redis and Next tags/paths without touching Notion Redis", async () => {
@@ -136,9 +151,9 @@ describe("purgeContentType", () => {
     expect(clearHn).toHaveBeenCalledTimes(1);
     expect(invalidate).not.toHaveBeenCalled();
     expect(revalidateTag).toHaveBeenCalledTimes(3);
-    expect(revalidateTag).toHaveBeenCalledWith("hn:post-ids", "max");
-    expect(revalidateTag).toHaveBeenCalledWith("hn:post", "max");
-    expect(revalidateTag).toHaveBeenCalledWith("hn:ranked", "max");
+    expect(revalidateTag).toHaveBeenCalledWith("hn:post-ids", { expire: 0 });
+    expect(revalidateTag).toHaveBeenCalledWith("hn:post", { expire: 0 });
+    expect(revalidateTag).toHaveBeenCalledWith("hn:ranked", { expire: 0 });
     expect(revalidatePath).toHaveBeenCalledTimes(2);
     expect(revalidatePath).toHaveBeenCalledWith("/hn");
     expect(revalidatePath).toHaveBeenCalledWith("/hn/[id]", "page");

--- a/src/lib/notion/purge.test.ts
+++ b/src/lib/notion/purge.test.ts
@@ -136,9 +136,8 @@ describe("purgeContentType", () => {
       revalidateTag.mockClear();
       await purgeContentType(type);
       expect(revalidateTag).toHaveBeenCalled();
-      for (const call of revalidateTag.mock.calls) {
-        expect(call[1]).toEqual({ expire: 0 });
-        expect(call[1]).not.toBe("max");
+      for (const tag of PURGE_CONFIG[type].tags) {
+        expect(revalidateTag).toHaveBeenCalledWith(tag, { expire: 0 });
       }
     }
   });

--- a/src/lib/notion/purge.ts
+++ b/src/lib/notion/purge.ts
@@ -98,11 +98,13 @@ export async function purgeContentType(type: PurgeableContentType): Promise<numb
     }
   }
 
-  // Next 16 requires a cacheLife profile as the second arg; "max" gives
-  // stale-while-revalidate behavior (serve existing cached data while
-  // regenerating in the background).
+  // Next 16 `revalidateTag(tag, "max")` is stale-while-revalidate: the next
+  // hit can serve the existing use-cache entry (e.g. the days-long sites list)
+  // while a background regen reshuffles that same stale array without Notion.
+  // Route Handlers cannot use `updateTag`. `{ expire: 0 }` expires the tag
+  // immediately so the next GET is a blocking cache miss / fresh refetch.
   for (const tag of config.tags) {
-    revalidateTag(tag, "max");
+    revalidateTag(tag, { expire: 0 });
   }
 
   for (const path of config.paths) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After renaming a Good websites Notion row (for example `SF Computer` → `SF Compute`), a successful `GET`/`POST /api/purge-cache?type=sites` still left `/api/sites` returning the old name. Notion itself showed the new name. Redis delete count was sometimes `purged.sites=1`, sometimes `0`. Extra purges did not help.

## Cause

`purgeContentType` deleted Redis keys, then called `revalidateTag(tag, "max")`. In Next 16, `"max"` is stale-while-revalidate: the next `/api/sites` hit serves the existing `"use cache"` list (`cacheLife("days")` + `cacheTag("notion:good-websites")`) and a background regen can reshuffle that same stale array without calling Notion.

Official Next 16 docs: Route Handler / webhook invalidation that must drop data immediately should use `revalidateTag(tag, { expire: 0 })`. `updateTag` cannot be used in Route Handlers.

## Change

- Shared helper now expires tags immediately: `revalidateTag(tag, { expire: 0 })`.
- Applies to every type that uses `purgeContentType` (`writing`, `til`, `ama`, `computer`, `stack`, `sites`, `hn`).
- Shuffle cadence and `/sites` visuals are unchanged.
- Tests assert `revalidateTag` is called with `{ expire: 0 }`, not `"max"`.

## How to verify

1. Rename any Good websites `Name` in Notion.
2. Hit `/api/purge-cache?type=sites`.
3. `GET /api/sites` should show the new name (cache miss / blocking revalidate), not the pre-purge name.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8f96224-bd5a-4be1-98ca-69e7b2e563c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8f96224-bd5a-4be1-98ca-69e7b2e563c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

